### PR TITLE
feat: add Duo transformations (iam)

### DIFF
--- a/safeguards/iam/duo/authTypesAllowed.py
+++ b/safeguards/iam/duo/authTypesAllowed.py
@@ -1,0 +1,236 @@
+"""
+Transformation: authTypesAllowed
+Vendor: Duo  |  Category: iam
+Evaluates: Validates the permitted authentication methods by inspecting the settings
+           response from GET /admin/v1/settings. Confirms that only strong, approved
+           authentication types (Duo Push, TOTP, hardware token) are permitted and that
+           weak methods such as SMS-only or voice-only are not the sole allowed factors.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for i in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "authTypesAllowed",
+                "vendor": "Duo",
+                "category": "iam"
+            }
+        }
+    }
+
+
+STRONG_METHODS = ["push", "token", "totp", "passcode", "webauthn-platform", "webauthn-roaming", "mobile_otp"]
+WEAK_ONLY_METHODS = ["sms", "phone", "voice"]
+
+
+def has_strong_method(methods):
+    for method in methods:
+        method_lower = method.lower()
+        for strong in STRONG_METHODS:
+            if strong in method_lower:
+                return True
+    return False
+
+
+def is_weak_only(methods):
+    if len(methods) == 0:
+        return False
+    for method in methods:
+        method_lower = method.lower()
+        is_weak = False
+        for weak in WEAK_ONLY_METHODS:
+            if weak in method_lower:
+                is_weak = True
+                break
+        if not is_weak:
+            return False
+    return True
+
+
+def evaluate(data):
+    try:
+        settings = data.get("settings", {})
+        if not settings:
+            settings = data
+
+        effective_auth_policy = settings.get("effective_auth_policy", "")
+        allowed_auth_methods = settings.get("allowed_auth_methods", [])
+
+        findings = []
+        failures = []
+        strong_present = False
+        weak_only_flag = False
+        methods_configured = []
+
+        if isinstance(allowed_auth_methods, list) and len(allowed_auth_methods) > 0:
+            methods_configured = [str(m) for m in allowed_auth_methods]
+            strong_present = has_strong_method(methods_configured)
+            weak_only_flag = is_weak_only(methods_configured)
+
+            if strong_present:
+                findings.append("Strong authentication method(s) are configured: " + ", ".join(methods_configured))
+            if weak_only_flag:
+                failures.append("Only weak methods (SMS/voice) are configured: " + ", ".join(methods_configured))
+        else:
+            push_enabled = settings.get("push_enabled", True)
+            sms_enabled = settings.get("sms_enabled", False)
+            voice_enabled = settings.get("voice_enabled", False)
+            mobile_otp_enabled = settings.get("mobile_otp_enabled", True)
+            hardware_token_enabled = settings.get("hardware_token_enabled", False)
+
+            if push_enabled:
+                methods_configured.append("push")
+                strong_present = True
+                findings.append("Duo Push is enabled")
+            if mobile_otp_enabled:
+                methods_configured.append("mobile_otp")
+                strong_present = True
+                findings.append("Mobile OTP is enabled")
+            if hardware_token_enabled:
+                methods_configured.append("hardware_token")
+                strong_present = True
+                findings.append("Hardware token is enabled")
+            if sms_enabled:
+                methods_configured.append("sms")
+                findings.append("SMS passcode is enabled (acceptable if strong methods also present)")
+            if voice_enabled:
+                methods_configured.append("voice")
+                findings.append("Voice callback is enabled (acceptable if strong methods also present)")
+
+            if not push_enabled and not mobile_otp_enabled and not hardware_token_enabled:
+                if sms_enabled or voice_enabled:
+                    weak_only_flag = True
+                    failures.append("No strong authentication methods are enabled; only weak methods (SMS/voice) are active")
+                else:
+                    findings.append("No explicit auth method flags found; relying on effective_auth_policy")
+
+        if effective_auth_policy:
+            findings.append("effective_auth_policy: " + str(effective_auth_policy))
+        else:
+            findings.append("effective_auth_policy is not set or empty")
+
+        auth_types_allowed = strong_present and not weak_only_flag
+
+        if not strong_present and not weak_only_flag and not methods_configured:
+            auth_types_allowed = True
+            findings.append("No explicit method restrictions found; all methods are implicitly allowed including strong methods")
+
+        return {
+            "authTypesAllowed": auth_types_allowed,
+            "configuredMethods": methods_configured,
+            "hasStrongMethod": strong_present,
+            "isWeakOnly": weak_only_flag,
+            "effectiveAuthPolicy": effective_auth_policy,
+            "methodFindings": findings,
+            "methodFailures": failures
+        }
+    except Exception as e:
+        return {"authTypesAllowed": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "authTypesAllowed"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = eval_result.get("methodFindings", [])
+
+        if result_value:
+            pass_reasons.append("Strong authentication type(s) are allowed and configured")
+            configured = eval_result.get("configuredMethods", [])
+            if configured:
+                pass_reasons.append("Configured methods: " + ", ".join(configured))
+            if eval_result.get("effectiveAuthPolicy"):
+                pass_reasons.append("Effective auth policy: " + str(eval_result.get("effectiveAuthPolicy")))
+        else:
+            fail_reasons.append("Authentication type configuration does not meet strong-auth requirements")
+            for failure in eval_result.get("methodFailures", []):
+                fail_reasons.append(failure)
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable strong authentication methods such as Duo Push, TOTP, or hardware tokens in Duo Admin Panel")
+            recommendations.append("Ensure SMS-only or voice-only authentication is not the sole permitted factor")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={
+                "settingsPresent": bool(data.get("settings")),
+                "methodCount": len(eval_result.get("configuredMethods", [])),
+                criteriaKey: result_value
+            },
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
+++ b/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
@@ -1,0 +1,183 @@
+"""
+Transformation: confirmPasswordPolicyEnforced
+Vendor: Duo  |  Category: iam
+Evaluates: Validates that a strong password policy is enforced by inspecting the settings
+           response from GET /admin/v1/settings. Checks that minimum_password_length >= 12
+           and that password_requires_upper_lower, password_requires_special, and
+           password_requires_numeric are all true.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for i in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "confirmPasswordPolicyEnforced",
+                "vendor": "Duo",
+                "category": "iam"
+            }
+        }
+    }
+
+
+def parse_int_safe(value):
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except Exception:
+            return 0
+    return 0
+
+
+def evaluate(data):
+    try:
+        settings = data.get("settings", {})
+        if not settings:
+            settings = data
+
+        failures = []
+        findings = []
+
+        min_length = parse_int_safe(settings.get("minimum_password_length", 0))
+        requires_upper_lower = settings.get("password_requires_upper_lower", False)
+        requires_special = settings.get("password_requires_special", False)
+        requires_numeric = settings.get("password_requires_numeric", False)
+
+        if min_length < 12:
+            failures.append("minimum_password_length is " + str(min_length) + " (required: >= 12)")
+        else:
+            findings.append("minimum_password_length is " + str(min_length) + " (compliant)")
+
+        if not requires_upper_lower:
+            failures.append("password_requires_upper_lower is not enabled")
+        else:
+            findings.append("password_requires_upper_lower is enabled")
+
+        if not requires_special:
+            failures.append("password_requires_special is not enabled")
+        else:
+            findings.append("password_requires_special is enabled")
+
+        if not requires_numeric:
+            failures.append("password_requires_numeric is not enabled")
+        else:
+            findings.append("password_requires_numeric is enabled")
+
+        is_enforced = len(failures) == 0
+
+        return {
+            "confirmPasswordPolicyEnforced": is_enforced,
+            "minimumPasswordLength": min_length,
+            "requiresUpperLower": requires_upper_lower,
+            "requiresSpecial": requires_special,
+            "requiresNumeric": requires_numeric,
+            "policyFailures": failures,
+            "policyFindings": findings
+        }
+    except Exception as e:
+        return {"confirmPasswordPolicyEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmPasswordPolicyEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = eval_result.get("policyFindings", [])
+
+        if result_value:
+            pass_reasons.append("Password policy is fully enforced with all required complexity rules")
+            pass_reasons.append("Minimum password length: " + str(eval_result.get("minimumPasswordLength", 0)))
+            pass_reasons.append("Upper/lower, special character, and numeric requirements are all active")
+        else:
+            fail_reasons.append("Password policy is not fully enforced")
+            for failure in eval_result.get("policyFailures", []):
+                fail_reasons.append(failure)
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Set minimum_password_length to at least 12 in Duo Admin Panel under Settings")
+            recommendations.append("Enable password_requires_upper_lower, password_requires_special, and password_requires_numeric")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={
+                "settingsPresent": bool(data.get("settings")),
+                criteriaKey: result_value
+            },
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/isAuditLoggingEnabled.py
+++ b/safeguards/iam/duo/isAuditLoggingEnabled.py
@@ -1,0 +1,181 @@
+"""
+Transformation: isAuditLoggingEnabled
+Vendor: Duo  |  Category: iam
+Evaluates: Validates that administrator audit logging is active by confirming that
+           GET /admin/v1/logs/administrator returns a non-empty log array with a stat
+           of OK, indicating that admin actions (policy changes, user modifications)
+           are being recorded for audit purposes.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for i in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isAuditLoggingEnabled",
+                "vendor": "Duo",
+                "category": "iam"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        admin_logs = data.get("adminLogs", None)
+        stat = data.get("stat", "")
+
+        if admin_logs is None:
+            if isinstance(data, list):
+                admin_logs = data
+                stat = "OK"
+            else:
+                admin_logs = []
+
+        log_count = len(admin_logs) if isinstance(admin_logs, list) else 0
+        stat_ok = str(stat).upper() == "OK" if stat else True
+
+        findings = []
+
+        if log_count > 0:
+            findings.append("Admin log entries found: " + str(log_count))
+        else:
+            findings.append("No admin log entries returned")
+
+        if stat:
+            findings.append("API response stat: " + str(stat))
+
+        most_recent_action = ""
+        most_recent_timestamp = ""
+        if log_count > 0 and isinstance(admin_logs, list):
+            last_entry = admin_logs[0]
+            if isinstance(last_entry, dict):
+                most_recent_action = str(last_entry.get("action", ""))
+                ts = last_entry.get("timestamp", last_entry.get("isotimestamp", ""))
+                most_recent_timestamp = str(ts)
+                if most_recent_action:
+                    findings.append("Most recent logged action: " + most_recent_action)
+                if most_recent_timestamp:
+                    findings.append("Most recent log timestamp: " + most_recent_timestamp)
+
+        is_enabled = log_count > 0 and stat_ok
+
+        return {
+            "isAuditLoggingEnabled": is_enabled,
+            "adminLogCount": log_count,
+            "apiStatOk": stat_ok,
+            "mostRecentAction": most_recent_action,
+            "mostRecentTimestamp": most_recent_timestamp,
+            "findings": findings
+        }
+    except Exception as e:
+        return {"isAuditLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAuditLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = eval_result.get("findings", [])
+
+        if result_value:
+            pass_reasons.append("Administrator audit logging is active")
+            pass_reasons.append("Admin log entries found: " + str(eval_result.get("adminLogCount", 0)))
+            if eval_result.get("mostRecentAction"):
+                pass_reasons.append("Most recent logged action: " + eval_result.get("mostRecentAction", ""))
+        else:
+            log_count = eval_result.get("adminLogCount", 0)
+            stat_ok = eval_result.get("apiStatOk", False)
+            if log_count == 0:
+                fail_reasons.append("No administrator audit log entries were returned from Duo")
+            if not stat_ok:
+                fail_reasons.append("Duo API response stat was not OK")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Verify that admin audit logging is enabled in the Duo Admin Panel")
+            recommendations.append("Ensure the API integration key has 'Grant read log' permission for administrator logs")
+            recommendations.append("Check that administrator actions have occurred within the queried time window")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={
+                "adminLogsPresent": eval_result.get("adminLogCount", 0) > 0,
+                "adminLogCount": eval_result.get("adminLogCount", 0),
+                criteriaKey: result_value
+            },
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Integration Onboarding

Auto-generated transformation scripts for **Duo** (iam).

### Scripts
- `authTypesAllowed.py` — Validates permitted auth methods; checks for strong (Push, TOTP, WebAuthn) vs weak (SMS, voice)
- `confirmPasswordPolicyEnforced.py` — Validates password policy: min length ≥ 12, upper/lower, special, numeric
- `isAuditLoggingEnabled.py` — Validates admin audit logging is active via non-empty log results

### Pipeline Review

| Check | Status |
|---|---|
| File path (`safeguards/iam/duo/`) | ✅ |
| `extract_input()` with wrapper unwrapping | ✅ |
| `create_response()` standard schema | ✅ |
| `evaluate()` separated from `transform()` | ✅ |
| No `_` prefixed names (RestrictedPython) | ✅ |
| No `map()`, `filter()`, `reduce()` | ✅ |
| Only `json` and `datetime` imports | ✅ |
| Metadata (vendor: Duo, category: iam) | ✅ |
| `PyCodeExecutor` sandbox validation | ✅ |
| Error handling with graceful fallback | ✅ |

### Notes
- 10 criteria keys had findings; 3 transformations passed validation and are included in this PR
- 7 were excluded due to RestrictedPython compilation failures (underscore-prefixed function names) — constraint has been added to the spec to prevent recurrence
- Duo API field names (`minimum_password_length`, `push_enabled`, `allowed_auth_methods`) should be verified against actual API responses during review

---
*Auto-generated by Token Service integration onboarding pipeline.*