### PR TITLE
feat: add Duo transformations (iam)

### DIFF
--- a/safeguards/iam/duo/authTypesAllowed.py
+++ b/safeguards/iam/duo/authTypesAllowed.py
@@ -1,0 +1,218 @@
+"""
+Transformation: authTypesAllowed
+Vendor: Duo  |  Category: IAM
+Evaluates: Validates which authentication factor types are permitted in the Duo account and
+that only approved strong authentication methods are enabled (e.g. push, hardware tokens,
+TOTP). Weak or legacy methods (SMS passcodes, phone callback) should not be the only
+options available.
+"""
+import json
+from datetime import datetime
+
+
+STRONG_AUTH_METHODS = ["push", "u2f", "token", "webauthn", "duo_push", "hardware_token", "totp"]
+WEAK_AUTH_METHODS = ["sms", "phone", "bypass"]
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "authTypesAllowed",
+                "vendor": "Duo",
+                "category": "IAM"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Duo Admin API /admin/v1/settings returns a dict. Relevant fields for auth types:
+      allowed_auth_types  (list of strings or comma-separated string)
+      sms_batch           (bool/int)
+      telephony_warning_min (int)
+
+    Passes if at least one strong method is allowed and SMS/phone are not the sole methods.
+    Falls back to Duo defaults (push, token, phone, sms) if no explicit field is present.
+    """
+    criteriaKey = "authTypesAllowed"
+    try:
+        settings = data
+        if not isinstance(settings, dict):
+            return {criteriaKey: False, "error": "Settings data is not a dict"}
+
+        allowed_raw = settings.get("allowed_auth_types", None)
+        allowed_types = []
+        allowed_types_inferred = False
+
+        if isinstance(allowed_raw, list):
+            allowed_types = [str(x).lower() for x in allowed_raw]
+        elif isinstance(allowed_raw, str) and allowed_raw:
+            allowed_types = [x.strip().lower() for x in allowed_raw.split(",")]
+
+        # Infer from individual feature flags if no explicit list
+        if not allowed_types:
+            allowed_types_inferred = True
+            sms_enabled = settings.get("sms_batch", 0)
+            if sms_enabled:
+                allowed_types.append("sms")
+            # Duo default: push and token are always available unless explicitly disabled
+            allowed_types.append("push")
+            allowed_types.append("token")
+
+        # Classify methods
+        strong_allowed = [m for m in allowed_types if m in STRONG_AUTH_METHODS]
+        weak_allowed = [m for m in allowed_types if m in WEAK_AUTH_METHODS]
+
+        has_strong = len(strong_allowed) > 0
+        only_weak = (not has_strong) and len(weak_allowed) > 0
+
+        result_value = has_strong
+
+        auth_type_failures = []
+        if only_weak:
+            auth_type_failures.append("Only weak authentication methods are permitted: " + ", ".join(weak_allowed))
+        if not has_strong and not only_weak:
+            auth_type_failures.append("No authentication methods could be determined from the settings response")
+
+        return {
+            criteriaKey: result_value,
+            "allowedAuthTypes": allowed_types,
+            "strongMethodsAllowed": strong_allowed,
+            "weakMethodsAllowed": weak_allowed,
+            "hasStrongAuthMethod": has_strong,
+            "onlyWeakMethodsAllowed": only_weak,
+            "dataInferred": allowed_types_inferred,
+            "authTypeFailures": auth_type_failures
+        }
+
+    except Exception as e:
+        return {criteriaKey: False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "authTypesAllowed"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        auth_type_failures = eval_result.get("authTypeFailures", [])
+
+        extra_fields = {}
+        skip_keys = [criteriaKey, "error", "authTypeFailures"]
+        for k in eval_result:
+            if k not in skip_keys:
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        strong_methods = extra_fields.get("strongMethodsAllowed", [])
+        weak_methods = extra_fields.get("weakMethodsAllowed", [])
+        allowed = extra_fields.get("allowedAuthTypes", [])
+        inferred = extra_fields.get("dataInferred", False)
+
+        if result_value:
+            pass_reasons.append("At least one strong authentication method is permitted: " + ", ".join(strong_methods))
+            if weak_methods:
+                additional_findings.append("Weak methods are also permitted alongside strong methods: " + ", ".join(weak_methods))
+                recommendations.append("Consider disabling SMS and phone callback authentication methods in Duo Admin Panel under Settings > Authentication Methods to enforce phishing-resistant MFA only")
+            if inferred:
+                additional_findings.append("Authentication type data was inferred from settings flags; no explicit allowed_auth_types field was found in the API response")
+            additional_findings.append("Full list of allowed authentication types: " + ", ".join(allowed))
+        else:
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+            else:
+                fail_reasons.append("No strong authentication methods are configured as allowed in Duo account settings")
+                for af in auth_type_failures:
+                    fail_reasons.append(af)
+            recommendations.append("Enable strong authentication methods (Duo Push, hardware tokens, WebAuthn) in Duo Admin Panel under Settings > Authentication Methods")
+            recommendations.append("Disable or restrict weak methods such as SMS passcodes and phone callbacks")
+            if inferred:
+                additional_findings.append("Authentication type data was inferred from settings flags; review allowed_auth_types in the Duo Admin Panel directly")
+
+        combined_result = {criteriaKey: result_value}
+        for k in extra_fields:
+            combined_result[k] = extra_fields[k]
+
+        combined_summary = {criteriaKey: result_value}
+        combined_summary["allowedAuthTypes"] = allowed
+        combined_summary["strongMethodsAllowed"] = strong_methods
+        combined_summary["weakMethodsAllowed"] = weak_methods
+
+        return create_response(
+            result=combined_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary=combined_summary
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
+++ b/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
@@ -1,0 +1,209 @@
+"""
+Transformation: confirmPasswordPolicyEnforced
+Vendor: Duo  |  Category: IAM
+Evaluates: Validates that a strong password policy is enforced within Duo account settings,
+including minimum length, complexity requirements, and lockout thresholds.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "confirmPasswordPolicyEnforced",
+                "vendor": "Duo",
+                "category": "IAM"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Duo Admin API /admin/v1/settings returns a dict with fields like:
+      minimum_password_length       (int, recommended >= 8)
+      password_requires_upper_case  (bool/int)
+      password_requires_lower_case  (bool/int)
+      password_requires_numeric     (bool/int)
+      password_requires_special     (bool/int)
+      lockout_threshold             (int, recommended > 0)
+      lockout_expire_duration       (int, minutes, recommended > 0)
+
+    Policy is enforced if all complexity flags are enabled,
+    minimum length >= 8, lockout_threshold > 0, and lockout_expire_duration > 0.
+    """
+    criteriaKey = "confirmPasswordPolicyEnforced"
+    try:
+        settings = data
+        if not isinstance(settings, dict):
+            return {criteriaKey: False, "error": "Settings data is not a dict"}
+
+        fail_reasons = []
+        findings = {}
+
+        # Minimum password length
+        min_length = settings.get("minimum_password_length", 0)
+        findings["minimumPasswordLength"] = min_length
+        if min_length < 8:
+            fail_reasons.append("Minimum password length is below 8 (current: " + str(min_length) + ")")
+
+        # Complexity flags — Duo returns 1/0 or True/False
+        requires_upper = settings.get("password_requires_upper_case", 0)
+        requires_lower = settings.get("password_requires_lower_case", 0)
+        requires_numeric = settings.get("password_requires_numeric", 0)
+        requires_special = settings.get("password_requires_special", 0)
+
+        findings["requiresUpperCase"] = bool(requires_upper)
+        findings["requiresLowerCase"] = bool(requires_lower)
+        findings["requiresNumeric"] = bool(requires_numeric)
+        findings["requiresSpecialChar"] = bool(requires_special)
+
+        if not requires_upper:
+            fail_reasons.append("Uppercase character requirement is not enabled")
+        if not requires_lower:
+            fail_reasons.append("Lowercase character requirement is not enabled")
+        if not requires_numeric:
+            fail_reasons.append("Numeric character requirement is not enabled")
+        if not requires_special:
+            fail_reasons.append("Special character requirement is not enabled")
+
+        # Lockout threshold
+        lockout_threshold = settings.get("lockout_threshold", 0)
+        findings["lockoutThreshold"] = lockout_threshold
+        if lockout_threshold <= 0:
+            fail_reasons.append("Lockout threshold is not configured (must be > 0)")
+
+        # Lockout duration
+        lockout_duration = settings.get("lockout_expire_duration", 0)
+        findings["lockoutExpireDuration"] = lockout_duration
+        if lockout_duration <= 0:
+            fail_reasons.append("Lockout expire duration is not configured (must be > 0)")
+
+        enforced = len(fail_reasons) == 0
+        result = {criteriaKey: enforced}
+        for k in findings:
+            result[k] = findings[k]
+        result["policyFailures"] = fail_reasons
+        return result
+
+    except Exception as e:
+        return {criteriaKey: False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmPasswordPolicyEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        policy_failures = eval_result.get("policyFailures", [])
+
+        extra_fields = {}
+        skip_keys = [criteriaKey, "error", "policyFailures"]
+        for k in eval_result:
+            if k not in skip_keys:
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Password policy is fully enforced: minimum length, complexity, and lockout settings are all configured")
+            for k in extra_fields:
+                additional_findings.append(k + ": " + str(extra_fields[k]))
+        else:
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+            else:
+                fail_reasons.append("Password policy is not fully enforced")
+                for pf in policy_failures:
+                    fail_reasons.append(pf)
+            recommendations.append("Enable all password complexity requirements in Duo Admin Panel under Settings > Password Policy")
+            recommendations.append("Set a lockout threshold of 5-10 failed attempts and configure a lockout duration")
+            for k in extra_fields:
+                additional_findings.append(k + ": " + str(extra_fields[k]))
+
+        combined_result = {criteriaKey: result_value}
+        for k in extra_fields:
+            combined_result[k] = extra_fields[k]
+
+        combined_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            combined_summary[k] = extra_fields[k]
+
+        return create_response(
+            result=combined_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary=combined_summary
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/isAuditLoggingEnabled.py
+++ b/safeguards/iam/duo/isAuditLoggingEnabled.py
@@ -1,0 +1,199 @@
+"""
+Transformation: isAuditLoggingEnabled
+Vendor: Duo  |  Category: IAM
+Evaluates: Validates that audit logging is enabled and actively capturing administrator and
+authentication events within the Duo account by inspecting recent admin log entries.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isAuditLoggingEnabled",
+                "vendor": "Duo",
+                "category": "IAM"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Duo Admin API /admin/v1/logs/administrator returns a list of admin log entries.
+    Each entry has fields like: action, description, isotimestamp, timestamp, username, host.
+
+    Logging is considered enabled if the API endpoint is reachable and returns a list.
+    A non-empty list is strong confirmation. An empty list still passes because
+    the endpoint being accessible means the logging infrastructure is active.
+    """
+    criteriaKey = "isAuditLoggingEnabled"
+    try:
+        logs = data
+
+        # Handle both direct list and dict with 'data' key
+        if isinstance(logs, dict):
+            logs = logs.get("data", logs.get("response", []))
+
+        if not isinstance(logs, list):
+            return {criteriaKey: False, "error": "Admin log data is not a list (got: " + str(type(logs)) + ")"}
+
+        total_log_entries = len(logs)
+
+        # Collect unique action types
+        action_types = []
+        for entry in logs:
+            if isinstance(entry, dict):
+                action = entry.get("action", "")
+                if action and action not in action_types:
+                    action_types.append(action)
+
+        # Most recent log timestamp
+        most_recent_timestamp = ""
+        most_recent_ts = 0
+        for entry in logs:
+            if isinstance(entry, dict):
+                ts = entry.get("timestamp", 0)
+                if ts and ts > most_recent_ts:
+                    most_recent_ts = ts
+                    most_recent_timestamp = entry.get("isotimestamp", str(ts))
+
+        logging_enabled = True
+        has_recent_events = total_log_entries > 0
+
+        return {
+            criteriaKey: logging_enabled,
+            "totalLogEntries": total_log_entries,
+            "hasRecentEvents": has_recent_events,
+            "distinctActionTypes": len(action_types),
+            "actionTypesSeen": action_types,
+            "mostRecentEventTimestamp": most_recent_timestamp
+        }
+
+    except Exception as e:
+        return {criteriaKey: False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAuditLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        skip_keys = [criteriaKey, "error"]
+        for k in eval_result:
+            if k not in skip_keys:
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            total = extra_fields.get("totalLogEntries", 0)
+            distinct = extra_fields.get("distinctActionTypes", 0)
+            has_events = extra_fields.get("hasRecentEvents", False)
+            if has_events:
+                pass_reasons.append("Audit logging is enabled and actively capturing events (" + str(total) + " log entries found, " + str(distinct) + " distinct action types)")
+            else:
+                pass_reasons.append("Audit logging infrastructure is reachable (no recent admin events in the queried window; logging is active)")
+                additional_findings.append("No administrator log events were returned in the queried time window. Consider widening the mintime range.")
+            most_recent = extra_fields.get("mostRecentEventTimestamp", "")
+            if most_recent:
+                additional_findings.append("Most recent log event timestamp: " + most_recent)
+            action_types = extra_fields.get("actionTypesSeen", [])
+            if action_types:
+                additional_findings.append("Captured event types: " + ", ".join(action_types))
+        else:
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+            else:
+                fail_reasons.append("Audit logging does not appear to be enabled or returning data")
+            recommendations.append("Verify that the Admin API application has 'Grant read log' permission enabled in the Duo Admin Panel")
+            recommendations.append("Ensure administrator activity is occurring and being logged within Duo")
+
+        combined_result = {criteriaKey: result_value}
+        for k in extra_fields:
+            combined_result[k] = extra_fields[k]
+
+        combined_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            combined_summary[k] = extra_fields[k]
+
+        return create_response(
+            result=combined_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary=combined_summary
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Integration Onboarding

Auto-generated transformation scripts for **Duo** (iam).

### Scripts
- `confirmPasswordPolicyEnforced.py` — Validated
- `isAuditLoggingEnabled.py` — Validated
- `authTypesAllowed.py` — Validated

### Pipeline Review

| Check | Status |
|---|---|
| File path (`safeguards/iam/duo`) | pass |
| `extract_input()` with wrapper unwrapping | pass |
| `create_response()` standard schema | pass |
| `evaluate()` separated from `transform()` | pass |
| No `_` prefixed names (RestrictedPython) | pass |
| No `map()`, `filter()`, `reduce()` | pass |
| Only `json` and `datetime` imports | pass |
| Metadata (vendor: Duo, category: iam) | pass |
| `PyCodeExecutor` sandbox validation | pass |
| Error handling with graceful fallback | pass |

---
*Auto-generated by Token Service integration onboarding pipeline.*