### PR TITLE
feat: add Duo transformations (iam)

### DIFF
--- a/safeguards/iam/duo/authTypesAllowed.py
+++ b/safeguards/iam/duo/authTypesAllowed.py
@@ -1,0 +1,132 @@
+"""
+Transformation: authTypesAllowed
+Vendor: Duo  |  Category: IAM
+Evaluates: Inspects Duo account settings to determine which authentication factor types are
+permitted. Evaluates push_enabled, sms_enabled, voice_enabled, mobile_otp_enabled,
+hard_token_enabled, and u2f_enabled from the /admin/v1/settings response.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "authTypesAllowed", "vendor": "Duo", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        settings = {}
+        if isinstance(data, dict):
+            settings = data.get("settings", data)
+        if not isinstance(settings, dict):
+            settings = {}
+
+        push_enabled = bool(settings.get("push_enabled", False))
+        sms_enabled = bool(settings.get("sms_enabled", False))
+        voice_enabled = bool(settings.get("voice_enabled", False))
+        mobile_otp_enabled = bool(settings.get("mobile_otp_enabled", False))
+        hard_token_enabled = bool(settings.get("hard_token_enabled", False))
+        u2f_enabled = bool(settings.get("u2f_enabled", False))
+
+        allowed_types = []
+        if push_enabled:
+            allowed_types.append("push")
+        if sms_enabled:
+            allowed_types.append("sms")
+        if voice_enabled:
+            allowed_types.append("voice")
+        if mobile_otp_enabled:
+            allowed_types.append("mobile_otp")
+        if hard_token_enabled:
+            allowed_types.append("hard_token")
+        if u2f_enabled:
+            allowed_types.append("u2f")
+
+        has_auth_types = len(allowed_types) > 0
+
+        return {
+            "authTypesAllowed": allowed_types,
+            "hasAuthTypesConfigured": has_auth_types,
+            "pushEnabled": push_enabled,
+            "smsEnabled": sms_enabled,
+            "voiceEnabled": voice_enabled,
+            "mobileOtpEnabled": mobile_otp_enabled,
+            "hardTokenEnabled": hard_token_enabled,
+            "u2fEnabled": u2f_enabled,
+            "authTypeCount": len(allowed_types)
+        }
+    except Exception as e:
+        return {"authTypesAllowed": [], "hasAuthTypesConfigured": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "authTypesAllowed"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: [], "hasAuthTypesConfigured": False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        allowed_types = eval_result.get(criteriaKey, [])
+        has_auth_types = eval_result.get("hasAuthTypesConfigured", False)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if has_auth_types:
+            pass_reasons.append(str(len(allowed_types)) + " authentication type(s) configured: " + ", ".join(allowed_types))
+        else:
+            fail_reasons.append("No authentication factor types are enabled in Duo account settings")
+            recommendations.append("Enable at least one strong authentication factor type such as push, hard_token, or u2f in Duo account settings")
+        return create_response(
+            result=eval_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"authTypeCount": eval_result.get("authTypeCount", 0), "authTypesAllowed": allowed_types}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: [], "hasAuthTypesConfigured": False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
+++ b/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
@@ -1,0 +1,153 @@
+"""
+Transformation: confirmPasswordPolicyEnforced
+Vendor: Duo  |  Category: IAM
+Evaluates: Validates that a password policy is enforced within Duo account settings.
+Inspects minimum_password_length, password_requires_upper_alpha, password_requires_lower_alpha,
+password_requires_numeric, and password_requires_special_char to confirm a strong password
+policy is active.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmPasswordPolicyEnforced", "vendor": "Duo", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        settings = {}
+        if isinstance(data, dict):
+            settings = data.get("settings", data)
+        if not isinstance(settings, dict):
+            settings = {}
+
+        min_length_raw = settings.get("minimum_password_length", 0)
+        try:
+            min_length = int(min_length_raw)
+        except Exception:
+            min_length = 0
+
+        requires_upper = bool(settings.get("password_requires_upper_alpha", False))
+        requires_lower = bool(settings.get("password_requires_lower_alpha", False))
+        requires_numeric = bool(settings.get("password_requires_numeric", False))
+        requires_special = bool(settings.get("password_requires_special_char", False))
+
+        length_ok = min_length >= 8
+
+        complexity_count = 0
+        if requires_upper:
+            complexity_count = complexity_count + 1
+        if requires_lower:
+            complexity_count = complexity_count + 1
+        if requires_numeric:
+            complexity_count = complexity_count + 1
+        if requires_special:
+            complexity_count = complexity_count + 1
+
+        policy_enforced = length_ok and complexity_count >= 3
+
+        return {
+            "confirmPasswordPolicyEnforced": policy_enforced,
+            "minimumPasswordLength": min_length,
+            "passwordLengthMeetsRequirement": length_ok,
+            "requiresUpperAlpha": requires_upper,
+            "requiresLowerAlpha": requires_lower,
+            "requiresNumeric": requires_numeric,
+            "requiresSpecialChar": requires_special,
+            "complexityRulesMet": complexity_count,
+            "complexityRulesTotal": 4
+        }
+    except Exception as e:
+        return {"confirmPasswordPolicyEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmPasswordPolicyEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append("Password policy enforced: minimum length of " + str(eval_result.get("minimumPasswordLength", 0)) + " characters")
+            pass_reasons.append(str(eval_result.get("complexityRulesMet", 0)) + " of 4 complexity rules are active")
+        else:
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            if not eval_result.get("passwordLengthMeetsRequirement", False):
+                fail_reasons.append("Minimum password length is " + str(eval_result.get("minimumPasswordLength", 0)) + ", which is below the required 8 characters")
+                recommendations.append("Set minimum_password_length to at least 8 in Duo account settings")
+            complexity_met = eval_result.get("complexityRulesMet", 0)
+            if complexity_met < 3:
+                fail_reasons.append("Only " + str(complexity_met) + " of 4 complexity rules active; at least 3 required")
+                if not eval_result.get("requiresUpperAlpha", False):
+                    recommendations.append("Enable password_requires_upper_alpha in Duo account settings")
+                if not eval_result.get("requiresLowerAlpha", False):
+                    recommendations.append("Enable password_requires_lower_alpha in Duo account settings")
+                if not eval_result.get("requiresNumeric", False):
+                    recommendations.append("Enable password_requires_numeric in Duo account settings")
+                if not eval_result.get("requiresSpecialChar", False):
+                    recommendations.append("Enable password_requires_special_char in Duo account settings")
+        return create_response(
+            result=eval_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={
+                "minimumPasswordLength": eval_result.get("minimumPasswordLength", 0),
+                "complexityRulesMet": eval_result.get("complexityRulesMet", 0),
+                "complexityRulesTotal": 4
+            }
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/isAuditLoggingEnabled.py
+++ b/safeguards/iam/duo/isAuditLoggingEnabled.py
@@ -1,0 +1,132 @@
+"""
+Transformation: isAuditLoggingEnabled
+Vendor: Duo  |  Category: IAM
+Evaluates: Validates that audit logging is enabled and capturing both authentication events
+(via /admin/v2/logs/authentication) and administrator action events (via /admin/v1/logs/administrator).
+Checks that log entries are present and that the stat field returns OK.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAuditLoggingEnabled", "vendor": "Duo", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"isAuditLoggingEnabled": False, "error": "Unexpected data format"}
+
+        authlogs = data.get("authlogs", [])
+        adminlogs = data.get("adminlogs", [])
+        stat = data.get("stat", "")
+
+        if not isinstance(authlogs, list):
+            authlogs = []
+        if not isinstance(adminlogs, list):
+            adminlogs = []
+
+        auth_logs_present = len(authlogs) > 0
+        admin_logs_present = len(adminlogs) > 0
+        stat_ok = str(stat).upper() == "OK"
+
+        is_enabled = auth_logs_present and admin_logs_present and stat_ok
+
+        return {
+            "isAuditLoggingEnabled": is_enabled,
+            "authLogsPresent": auth_logs_present,
+            "adminLogsPresent": admin_logs_present,
+            "authLogCount": len(authlogs),
+            "adminLogCount": len(adminlogs),
+            "statOk": stat_ok,
+            "stat": stat
+        }
+    except Exception as e:
+        return {"isAuditLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAuditLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append("Audit logging is enabled for both authentication and administrator events")
+            pass_reasons.append("Authentication log entries found: " + str(eval_result.get("authLogCount", 0)))
+            pass_reasons.append("Administrator log entries found: " + str(eval_result.get("adminLogCount", 0)))
+        else:
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            if not eval_result.get("statOk", False):
+                fail_reasons.append("Duo API did not return a successful stat: " + str(eval_result.get("stat", "")))
+            if not eval_result.get("authLogsPresent", False):
+                fail_reasons.append("No authentication log entries found")
+                recommendations.append("Ensure authentication logging is active and generating events in Duo")
+            if not eval_result.get("adminLogsPresent", False):
+                fail_reasons.append("No administrator log entries found")
+                recommendations.append("Ensure administrator action logging is active and generating events in Duo")
+        return create_response(
+            result=eval_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={
+                "authLogCount": eval_result.get("authLogCount", 0),
+                "adminLogCount": eval_result.get("adminLogCount", 0),
+                "statOk": eval_result.get("statOk", False)
+            }
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Adds 3 **Duo** (iam) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Duo API responses against Spektrum safeguard criteria to determine whether the organization's Duo configuration meets security posture requirements.

**Context:** Duo is being onboarded as a new iam vendor integration. These scripts cover the `safeguards/iam/duo` namespace.

## What each transformation does

### `authTypesAllowed.py` (Validated)
Inspects Duo account settings to determine which authentication factor types are

- **API fields consumed:** `settings`, `push_enabled`, `sms_enabled`, `voice_enabled`, `mobile_otp_enabled`, `hard_token_enabled`, `u2f_enabled`
- Graceful fallback on missing keys and empty responses

### `isAuditLoggingEnabled.py` (Validated)
Validates that audit logging is enabled and capturing both authentication events

- **API fields consumed:** `authlogs`, `adminlogs`, `stat`
- **Pass criteria:** `auth_logs_present and admin_logs_present and stat_ok`
- Graceful fallback on missing keys and empty responses

### `confirmPasswordPolicyEnforced.py` (Validated)
Validates that a password policy is enforced within Duo account settings.

- **API fields consumed:** `settings`, `minimum_password_length`, `password_requires_upper_alpha`, `password_requires_lower_alpha`, `password_requires_numeric`, `password_requires_special_char`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline