### PR TITLE
feat: add Duo transformations (iam)

### DIFF
--- a/safeguards/iam/duo/authTypesAllowed.py
+++ b/safeguards/iam/duo/authTypesAllowed.py
@@ -1,0 +1,203 @@
+"""
+Transformation: authTypesAllowed
+Vendor: Duo  |  Category: IAM
+Evaluates: Determines which authentication factor types are allowed by reading the global
+policy's authentication_methods.allowed_2fa_methods object. Returns the enabled/disabled
+state for duo_push, hardware_token, phone, sms, voice, and webauthn factors.
+Passes when at least one strong authentication method (duo_push, hardware_token, or webauthn)
+is enabled.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "authTypesAllowed", "vendor": "Duo", "category": "IAM"}
+        }
+    }
+
+
+def find_global_policy(policies):
+    """Return the global policy object from the policies list, or None."""
+    for policy in policies:
+        if policy.get("is_global", False):
+            return policy
+    if len(policies) > 0:
+        return policies[0]
+    return None
+
+
+def evaluate(data):
+    """
+    Read the global policy's authentication_methods.allowed_2fa_methods.
+    Passes when at least one strong factor (duo_push, hardware_token, webauthn) is enabled.
+    """
+    try:
+        policies = data.get("policies", [])
+        if not policies:
+            return {
+                "authTypesAllowed": False,
+                "error": "No policies found in response",
+                "policiesFound": False
+            }
+
+        global_policy = find_global_policy(policies)
+        if global_policy is None:
+            return {
+                "authTypesAllowed": False,
+                "error": "Could not identify a global policy from the policies list",
+                "policiesFound": True
+            }
+
+        sections = global_policy.get("sections", {})
+        auth_methods = sections.get("authentication_methods", {})
+        allowed_methods = auth_methods.get("allowed_2fa_methods", {})
+
+        duo_push = allowed_methods.get("duo_push", False)
+        hardware_token = allowed_methods.get("hardware_token", False)
+        phone_call = allowed_methods.get("phone", False)
+        sms = allowed_methods.get("sms", False)
+        voice = allowed_methods.get("voice", False)
+        webauthn = allowed_methods.get("webauthn", False)
+
+        strong_auth_enabled = duo_push or hardware_token or webauthn
+        weak_methods_enabled = phone_call or sms or voice
+
+        enabled_factors = []
+        if duo_push:
+            enabled_factors.append("duo_push")
+        if hardware_token:
+            enabled_factors.append("hardware_token")
+        if phone_call:
+            enabled_factors.append("phone")
+        if sms:
+            enabled_factors.append("sms")
+        if voice:
+            enabled_factors.append("voice")
+        if webauthn:
+            enabled_factors.append("webauthn")
+
+        return {
+            "authTypesAllowed": strong_auth_enabled,
+            "duoPushEnabled": duo_push,
+            "hardwareTokenEnabled": hardware_token,
+            "phoneEnabled": phone_call,
+            "smsEnabled": sms,
+            "voiceEnabled": voice,
+            "webauthnEnabled": webauthn,
+            "strongAuthMethodAvailable": strong_auth_enabled,
+            "weakMethodsEnabled": weak_methods_enabled,
+            "enabledFactors": enabled_factors,
+            "totalEnabledFactors": len(enabled_factors),
+            "policiesFound": True
+        }
+    except Exception as e:
+        return {"authTypesAllowed": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "authTypesAllowed"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        enabled_factors = eval_result.get("enabledFactors", [])
+        enabled_list = ", ".join(enabled_factors) if enabled_factors else "none"
+
+        if result_value:
+            pass_reasons.append("At least one strong authentication method is enabled in the global policy")
+            if eval_result.get("duoPushEnabled"):
+                pass_reasons.append("Duo Push is enabled as a strong authentication factor")
+            if eval_result.get("webauthnEnabled"):
+                pass_reasons.append("WebAuthn/FIDO2 is enabled as a strong authentication factor")
+            if eval_result.get("hardwareTokenEnabled"):
+                pass_reasons.append("Hardware tokens are enabled as a strong authentication factor")
+            additional_findings.append("All enabled factors: " + enabled_list)
+            if eval_result.get("weakMethodsEnabled"):
+                additional_findings.append("Weak methods (phone/SMS/voice) are also enabled alongside strong methods")
+                recommendations.append("Consider disabling weak authentication methods (phone, SMS, voice) to reduce phishing risk")
+        else:
+            if eval_result.get("error"):
+                fail_reasons.append(eval_result["error"])
+            else:
+                fail_reasons.append("No strong authentication method (duo_push, hardware_token, webauthn) is enabled in the global policy")
+                recommendations.append("Enable Duo Push, WebAuthn, or hardware token authentication in the Duo global policy")
+            additional_findings.append("Currently enabled factors: " + enabled_list)
+
+        result_dict = {}
+        result_dict[criteriaKey] = result_value
+        for k in extra_fields:
+            result_dict[k] = extra_fields[k]
+
+        summary_dict = {}
+        summary_dict[criteriaKey] = result_value
+        for k in extra_fields:
+            summary_dict[k] = extra_fields[k]
+
+        return create_response(
+            result=result_dict,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=summary_dict,
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
+++ b/safeguards/iam/duo/confirmPasswordPolicyEnforced.py
@@ -1,0 +1,164 @@
+"""
+Transformation: confirmPasswordPolicyEnforced
+Vendor: Duo  |  Category: IAM
+Evaluates: Confirms that a password policy is enforced by examining account settings fields:
+minimum_password_length, password_requires_upper_alpha, password_requires_lower_alpha,
+password_requires_numeric, password_requires_special, and lockout_threshold.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmPasswordPolicyEnforced", "vendor": "Duo", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Inspect the 'settings' key returned by getAccountSettings.
+    A policy is considered enforced when a meaningful minimum password length is
+    configured, at least one character-class requirement is active, and an
+    account-lockout threshold is set.
+    """
+    try:
+        settings = data.get("settings", {})
+        if not settings:
+            return {
+                "confirmPasswordPolicyEnforced": False,
+                "error": "No account settings found in response",
+                "settingsFound": False
+            }
+
+        min_length = settings.get("minimum_password_length", 0)
+        requires_upper = settings.get("password_requires_upper_alpha", False)
+        requires_lower = settings.get("password_requires_lower_alpha", False)
+        requires_numeric = settings.get("password_requires_numeric", False)
+        requires_special = settings.get("password_requires_special", False)
+        lockout_threshold = settings.get("lockout_threshold", 0)
+
+        has_min_length = min_length >= 8
+        has_complexity = requires_upper or requires_lower or requires_numeric or requires_special
+        has_lockout = lockout_threshold > 0
+
+        policy_enforced = has_min_length and has_complexity and has_lockout
+
+        return {
+            "confirmPasswordPolicyEnforced": policy_enforced,
+            "minimumPasswordLength": min_length,
+            "requiresUpperAlpha": requires_upper,
+            "requiresLowerAlpha": requires_lower,
+            "requiresNumeric": requires_numeric,
+            "requiresSpecial": requires_special,
+            "lockoutThreshold": lockout_threshold,
+            "hasMinimumLength": has_min_length,
+            "hasComplexity": has_complexity,
+            "hasLockout": has_lockout,
+            "settingsFound": True
+        }
+    except Exception as e:
+        return {"confirmPasswordPolicyEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmPasswordPolicyEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Password policy is enforced: minimum length, complexity, and lockout are all configured")
+            additional_findings.append("Minimum password length: " + str(eval_result.get("minimumPasswordLength", 0)))
+            additional_findings.append("Lockout threshold: " + str(eval_result.get("lockoutThreshold", 0)))
+        else:
+            if eval_result.get("error"):
+                fail_reasons.append(eval_result["error"])
+            else:
+                if not eval_result.get("hasMinimumLength", False):
+                    fail_reasons.append("Minimum password length is below 8 characters (current: " + str(eval_result.get("minimumPasswordLength", 0)) + ")")
+                    recommendations.append("Set minimum_password_length to 8 or higher in Duo account settings")
+                if not eval_result.get("hasComplexity", False):
+                    fail_reasons.append("No character-class complexity requirements are enabled")
+                    recommendations.append("Enable at least one of: password_requires_upper_alpha, password_requires_lower_alpha, password_requires_numeric, password_requires_special")
+                if not eval_result.get("hasLockout", False):
+                    fail_reasons.append("Account lockout threshold is not configured (lockout_threshold is 0)")
+                    recommendations.append("Set lockout_threshold to a positive value in Duo account settings to limit brute-force attempts")
+
+        result_dict = {}
+        result_dict[criteriaKey] = result_value
+        for k in extra_fields:
+            result_dict[k] = extra_fields[k]
+
+        summary_dict = {}
+        summary_dict[criteriaKey] = result_value
+        for k in extra_fields:
+            summary_dict[k] = extra_fields[k]
+
+        return create_response(
+            result=result_dict,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=summary_dict,
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/duo/isAuditLoggingEnabled.py
+++ b/safeguards/iam/duo/isAuditLoggingEnabled.py
@@ -1,0 +1,161 @@
+"""
+Transformation: isAuditLoggingEnabled
+Vendor: Duo  |  Category: IAM
+Evaluates: Verifies that audit logging is enabled by retrieving administrator action logs
+from /admin/v2/logs/administrator. Confirms the response contains log events with action,
+timestamp, and username fields, indicating an active admin audit trail.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAuditLoggingEnabled", "vendor": "Duo", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Inspect the 'adminlogs' key returned by getAdminLogs.
+    Passes when the list is non-empty, confirming the audit trail is active.
+    Also checks for expected fields (action, timestamp, username) in the first entry.
+    """
+    try:
+        adminlogs = data.get("adminlogs", [])
+        log_count = len(adminlogs)
+        logs_present = log_count > 0
+
+        if not logs_present:
+            return {
+                "isAuditLoggingEnabled": False,
+                "adminLogCount": 0,
+                "hasActionField": False,
+                "hasTimestampField": False,
+                "hasUsernameField": False,
+                "logStructureValid": False
+            }
+
+        sample = adminlogs[0]
+        has_action = "action" in sample
+        has_timestamp = "timestamp" in sample
+        has_username = "username" in sample
+        log_structure_valid = has_action and has_timestamp and has_username
+
+        return {
+            "isAuditLoggingEnabled": logs_present,
+            "adminLogCount": log_count,
+            "hasActionField": has_action,
+            "hasTimestampField": has_timestamp,
+            "hasUsernameField": has_username,
+            "logStructureValid": log_structure_valid
+        }
+    except Exception as e:
+        return {"isAuditLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAuditLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Administrator audit logs are present and accessible")
+            pass_reasons.append("Admin log count: " + str(eval_result.get("adminLogCount", 0)))
+            if eval_result.get("logStructureValid"):
+                pass_reasons.append("Log entries contain expected fields: action, timestamp, and username")
+            else:
+                additional_findings.append("Log entries were found but may be missing some expected fields (action, timestamp, username)")
+                if not eval_result.get("hasActionField"):
+                    additional_findings.append("'action' field missing from log entries")
+                if not eval_result.get("hasTimestampField"):
+                    additional_findings.append("'timestamp' field missing from log entries")
+                if not eval_result.get("hasUsernameField"):
+                    additional_findings.append("'username' field missing from log entries")
+        else:
+            if eval_result.get("error"):
+                fail_reasons.append(eval_result["error"])
+            else:
+                fail_reasons.append("No administrator audit log entries were found in the response")
+                recommendations.append("Verify that the Admin API integration has 'Grant read log' permission enabled in the Duo Admin Panel")
+                recommendations.append("Confirm that administrative actions have been performed recently to generate log entries")
+                recommendations.append("Check that the API credentials used have the required log read permissions")
+
+        result_dict = {}
+        result_dict[criteriaKey] = result_value
+        for k in extra_fields:
+            result_dict[k] = extra_fields[k]
+
+        summary_dict = {}
+        summary_dict[criteriaKey] = result_value
+        for k in extra_fields:
+            summary_dict[k] = extra_fields[k]
+
+        return create_response(
+            result=result_dict,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=summary_dict,
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Adds 3 **Duo** (iam) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Duo API responses against Spektrum safeguard criteria to determine whether the organization's Duo configuration meets security posture requirements.

**Context:** Duo is being onboarded as a new iam vendor integration. These scripts cover the `safeguards/iam/duo` namespace.

## What each transformation does

### `confirmPasswordPolicyEnforced.py` (Validated)
Confirms that a password policy is enforced by examining account settings fields:

- **API fields consumed:** `settings`, `minimum_password_length`, `password_requires_upper_alpha`, `password_requires_lower_alpha`, `password_requires_numeric`, `password_requires_special`, `lockout_threshold`
- Graceful fallback on missing keys and empty responses

### `authTypesAllowed.py` (Validated)
Determines which authentication factor types are allowed by reading the global

- **API fields consumed:** `policies`
- Graceful fallback on missing keys and empty responses

### `isAuditLoggingEnabled.py` (Validated)
Verifies that audit logging is enabled by retrieving administrator action logs

- **API fields consumed:** `adminlogs`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline