### PR TITLE
feat: add Halcyon transformations (epp)

### DIFF
--- a/safeguards/epp/halcyon/isEPPEnabled.py
+++ b/safeguards/epp/halcyon/isEPPEnabled.py
@@ -1,0 +1,171 @@
+"""
+Transformation: isEPPEnabled
+Vendor: Halcyon  |  Category: epp
+Evaluates: Checks whether the Halcyon EPP agent is enabled and actively protecting endpoints.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPEnabled", "vendor": "Halcyon", "category": "epp"}
+        }
+    }
+
+
+def extract_bool_flag(data, primary_keys, fallback_status_values):
+    """
+    Attempts to read a boolean flag from a dict.
+    Tries primary_keys first (exact bool/int), then looks for a 'status' string
+    matched against fallback_status_values.
+    Returns (found: bool, value: bool).
+    """
+    for key in primary_keys:
+        if key in data:
+            raw = data[key]
+            if isinstance(raw, bool):
+                return True, raw
+            if isinstance(raw, int):
+                return True, raw != 0
+            if isinstance(raw, str):
+                return True, raw.lower() in fallback_status_values
+    status_val = data.get("status", "")
+    if isinstance(status_val, str) and status_val != "":
+        return True, status_val.lower() in fallback_status_values
+    return False, False
+
+
+def evaluate(data):
+    """
+    Determines whether the Halcyon EPP agent is enabled.
+    The workflow merges getEPPEnabledStatus, getEPPDeploymentStatus, and
+    getEPPConfigurationStatus, so the input may contain keys from all three.
+    Passes when the EPP enabled flag is explicitly true.
+    """
+    try:
+        positive_strings = ["enabled", "true", "active", "on", "yes", "1"]
+
+        inner = data
+        if isinstance(data.get("data"), dict):
+            inner = data["data"]
+
+        primary_keys = [
+            "isEPPEnabled",
+            "eppEnabled",
+            "epp_enabled",
+            "enabled",
+            "result",
+            "passed",
+            "pass",
+            "value",
+        ]
+
+        found, flag_value = extract_bool_flag(inner, primary_keys, positive_strings)
+
+        if not found:
+            found, flag_value = extract_bool_flag(data, primary_keys, positive_strings)
+
+        if not found:
+            return {
+                "isEPPEnabled": False,
+                "error": "Could not determine EPP enabled status from API response",
+            }
+
+        # Collect supplementary fields present in the merged workflow response
+        additional = {}
+        for sup_key in ["isEPPDeployed", "isEPPConfigured", "deploymentStatus", "configurationStatus"]:
+            if sup_key in inner:
+                additional[sup_key] = inner[sup_key]
+            elif sup_key in data:
+                additional[sup_key] = data[sup_key]
+
+        result = {"isEPPEnabled": flag_value}
+        for k in additional:
+            result[k] = additional[k]
+        return result
+    except Exception as e:
+        return {"isEPPEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"],
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append(
+                "Halcyon EPP agent is enabled and actively protecting endpoints."
+            )
+            for k, v in extra_fields.items():
+                additional_findings.append(k + ": " + str(v))
+        else:
+            fail_reasons.append("Halcyon EPP agent is not enabled.")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Enable the Halcyon EPP agent across all managed endpoints via the Halcyon console "
+                "to ensure active endpoint protection is in place."
+            )
+            for k, v in extra_fields.items():
+                additional_findings.append(k + ": " + str(v))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value},
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)],
+        )

--- a/safeguards/epp/halcyon/isEPPLoggingEnabled.py
+++ b/safeguards/epp/halcyon/isEPPLoggingEnabled.py
@@ -1,0 +1,150 @@
+"""
+Transformation: isEPPLoggingEnabled
+Vendor: Halcyon  |  Category: epp
+Evaluates: Checks whether EPP event logging is enabled for audit, monitoring, and compliance purposes.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPLoggingEnabled", "vendor": "Halcyon", "category": "epp"}
+        }
+    }
+
+
+def extract_bool_flag(data, primary_keys, fallback_status_values):
+    """
+    Attempts to read a boolean flag from a dict.
+    Tries primary_keys first (exact bool/int), then looks for a 'status' string
+    matched against fallback_status_values.
+    Returns (found: bool, value: bool).
+    """
+    for key in primary_keys:
+        if key in data:
+            raw = data[key]
+            if isinstance(raw, bool):
+                return True, raw
+            if isinstance(raw, int):
+                return True, raw != 0
+            if isinstance(raw, str):
+                return True, raw.lower() in fallback_status_values
+    status_val = data.get("status", "")
+    if isinstance(status_val, str) and status_val != "":
+        return True, status_val.lower() in fallback_status_values
+    return False, False
+
+
+def evaluate(data):
+    """
+    Determines whether EPP logging is enabled.
+    Accepts several common field shapes returned by the Halcyon API.
+    """
+    try:
+        positive_strings = ["enabled", "true", "active", "on", "yes", "1"]
+
+        inner = data
+        if isinstance(data.get("data"), dict):
+            inner = data["data"]
+
+        primary_keys = [
+            "isEPPLoggingEnabled",
+            "loggingEnabled",
+            "logging_enabled",
+            "enabled",
+            "result",
+            "passed",
+            "pass",
+            "value",
+        ]
+
+        found, flag_value = extract_bool_flag(inner, primary_keys, positive_strings)
+
+        if not found:
+            found, flag_value = extract_bool_flag(data, primary_keys, positive_strings)
+
+        if not found:
+            return {
+                "isEPPLoggingEnabled": False,
+                "error": "Could not determine EPP logging status from API response",
+            }
+
+        return {"isEPPLoggingEnabled": flag_value}
+    except Exception as e:
+        return {"isEPPLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"],
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append("EPP event logging is enabled -- audit and compliance requirements are met.")
+        else:
+            fail_reasons.append("EPP event logging is not enabled.")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Enable EPP logging in the Halcyon console to ensure endpoint events are "
+                "captured for audit, monitoring, and compliance purposes."
+            )
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value},
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)],
+        )

--- a/safeguards/epp/halcyon/requiredCoveragePercentage.py
+++ b/safeguards/epp/halcyon/requiredCoveragePercentage.py
@@ -1,0 +1,188 @@
+"""
+Transformation: requiredCoveragePercentage
+Vendor: Halcyon  |  Category: epp
+Evaluates: Checks the required coverage percentage for EPP agent deployment across all managed endpoints.
+           Passes when the reported coverage percentage meets or exceeds the required threshold (default 95%).
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "requiredCoveragePercentage", "vendor": "Halcyon", "category": "epp"}
+        }
+    }
+
+
+def safe_float(val, default):
+    if val is None:
+        return default
+    try:
+        return float(val)
+    except Exception:
+        return default
+
+
+def evaluate(data):
+    """
+    Extracts the EPP coverage percentage from the API response.
+    Looks for known field names in order of specificity.
+    Passes when the actual coverage meets or exceeds the required threshold (95%).
+    """
+    try:
+        REQUIRED_THRESHOLD = 95.0
+
+        candidate_keys = [
+            "requiredCoveragePercentage",
+            "coveragePercentage",
+            "percentage",
+            "coverage",
+            "value",
+            "score",
+        ]
+
+        raw_value = None
+        for key in candidate_keys:
+            if key in data:
+                raw_value = data[key]
+                break
+
+        # Some endpoints return a nested "data" dict -- unwrap one level if needed
+        if raw_value is None and isinstance(data.get("data"), dict):
+            nested = data["data"]
+            for key in candidate_keys:
+                if key in nested:
+                    raw_value = nested[key]
+                    break
+
+        # Determine whether this is a straight boolean result vs a numeric percentage
+        result_value = data.get("result", None)
+        passed_bool = data.get("passed", data.get("pass", None))
+
+        # If a numeric percentage is present, evaluate against threshold
+        if raw_value is not None:
+            score = safe_float(raw_value, -1.0)
+            if score < 0:
+                passes = False
+                actual_percentage = 0.0
+            else:
+                actual_percentage = score
+                passes = actual_percentage >= REQUIRED_THRESHOLD
+            return {
+                "requiredCoveragePercentage": passes,
+                "scoreInPercentage": actual_percentage,
+                "requiredThreshold": REQUIRED_THRESHOLD,
+            }
+
+        # No numeric value found -- fall back to boolean indicators
+        if result_value is not None:
+            passes = bool(result_value)
+            return {
+                "requiredCoveragePercentage": passes,
+                "scoreInPercentage": 100.0 if passes else 0.0,
+                "requiredThreshold": REQUIRED_THRESHOLD,
+            }
+
+        if passed_bool is not None:
+            passes = bool(passed_bool)
+            return {
+                "requiredCoveragePercentage": passes,
+                "scoreInPercentage": 100.0 if passes else 0.0,
+                "requiredThreshold": REQUIRED_THRESHOLD,
+            }
+
+        # Completely unknown shape -- return False with 0
+        return {
+            "requiredCoveragePercentage": False,
+            "scoreInPercentage": 0.0,
+            "requiredThreshold": REQUIRED_THRESHOLD,
+            "error": "Could not locate a coverage percentage value in the API response",
+        }
+    except Exception as e:
+        return {"requiredCoveragePercentage": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "requiredCoveragePercentage"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"],
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        score = eval_result.get("scoreInPercentage", 0.0)
+        threshold = eval_result.get("requiredThreshold", 95.0)
+        if result_value:
+            pass_reasons.append(
+                "EPP agent coverage meets the required threshold: "
+                + str(score) + "% >= " + str(threshold) + "%"
+            )
+        else:
+            fail_reasons.append(
+                "EPP agent coverage does not meet the required threshold: "
+                + str(score) + "% < " + str(threshold) + "%"
+            )
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Deploy the Halcyon EPP agent to all unprotected endpoints to reach "
+                + str(threshold) + "% coverage."
+            )
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "scoreInPercentage": score},
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)],
+        )


### PR DESCRIPTION
## Summary

Three transformation scripts validate Halcyon EPP deployment, enablement, and compliance controls. These scripts support the Halcyon anti-ransomware platform integration, checking whether the agent is deployed across a sufficient percentage of endpoints (95%+ coverage), whether logging is enabled for audit, and whether the EPP service is actively enabled and protecting. **Total: 3 scripts.**

**Context:** These transformations enable Spektrum to assess EPP posture across organizations using Halcyon for endpoint protection and ransomware resilience.

## What each transformation does

### `requiredCoveragePercentage.py`
Validates that the Halcyon EPP agent is deployed across a required percentage of managed endpoints (default: 95% coverage).

- **Consumes:** `getRequiredCoveragePercentage` API method (note: method not yet defined in integration config)
- **Pass criteria:** `scoreInPercentage >= 95.0` AND coverage field is present and parseable as a number. Falls back to boolean evaluation if percentage unavailable.
- **Key edge cases handled:**
  - Wrapping layer detection and unwrapping (api_response, response, result, apiResponse, Output)
  - Multiple fallback field names (requiredCoveragePercentage, coveragePercentage, percentage, coverage, value, score)
  - Nested data dict unwrapping (checks data.data)
  - Boolean fallback when no percentage found (uses result, passed, pass fields)
  - Non-numeric values safely converted with -1.0 sentinel (returns fail)
  - Empty/missing data returns 0% coverage (fail)
  - Note: No explicit handling of API error status (stat: FAIL) — assumes all responses are valid attempts

### `isEPPLoggingEnabled.py`
Checks whether EPP event logging is enabled on the Halcyon platform for audit, monitoring, and compliance purposes.

- **Consumes:** `getEPPLoggingStatus` API method (note: method not yet defined in integration config)
- **Pass criteria:** Field value evaluates to true. Accepts boolean true, integer != 0, or case-insensitive string match against [enabled, true, active, on, yes, 1].
- **Key edge cases handled:**
  - Wrapping detection and unwrapping (same layers as above)
  - Primary key lookup (isEPPLoggingEnabled, loggingEnabled, logging_enabled, enabled, result, passed, pass, value)
  - Fallback to status field string evaluation
  - Nested data dict unwrapping
  - Returns False if no recognizable field found (with descriptive error message)
  - Note: No explicit handling of API error status — assumes valid responses
  - Helper function extract_bool_flag() factored for reusability

### `isEPPEnabled.py`
Determines whether the Halcyon EPP agent is enabled and actively protecting endpoints. Designed to work with merged workflow response (consolidates getEPPEnabledStatus, getEPPDeploymentStatus, getEPPConfigurationStatus).

- **Consumes:** `getEPPEnabledStatus` API method (also expects merge input containing isEPPDeployed, isEPPConfigured, deploymentStatus, configurationStatus fields)
- **Pass criteria:** Field value evaluates to true using the same boolean logic as isEPPLoggingEnabled.
- **Key edge cases handled:**
  - Wrapping detection and unwrapping (same layers)
  - Primary key lookup with fallback to status field
  - Nested data dict unwrapping
  - Capture and preserve supplementary fields from merged workflow (isEPPDeployed, isEPPConfigured, deploymentStatus, configurationStatus) for observability
  - Returns False if no recognizable field found
  - Additional findings surface supplementary fields via string concatenation (could be more structured)
  - Note: No explicit handling of API error status — assumes valid responses

## Architecture notes

All three scripts follow the standard Spektrum transformation contract: `extract_input` unwraps response wrappers and validates input format, `evaluate` determines the boolean pass/fail condition and extracts metadata, `transform` orchestrates the full pipeline and returns a structured response matching schema version 1.0. Response shape includes `transformedResponse` (criteria result + extra fields) and `additionalInfo` (dataCollection, validation, transformation, evaluation, metadata). All scripts are RestrictedPython-safe with no disallowed imports or operations.

## Test plan

- [x] All three scripts validated by PyCodeExecutor sandbox (reported: success)
- [ ] Verify each script's evaluate() returns correct boolean result for:
  - Valid coverage percentage (e.g., 98.5 >= 95 → True)
  - Coverage below threshold (e.g., 85 < 95 → False)
  - Missing percentage field (fallback to result/passed/pass → True/False)
  - Empty response data (→ False with error message)
  - Non-numeric percentage value (→ False with -1.0 sentinel)
- [ ] Verify each script's evaluate() handles boolean enabled flag for:
  - Boolean true/false
  - Integer 1/0
  - String "enabled"/"disabled" (case-insensitive)
  - Missing field (→ False with error message)
- [ ] Confirm field names in data.get("...") calls match Halcyon API response schema:
  - Validate against actual API endpoint responses once integration config methods are finalized
  - Check whether Halcyon returns percentages as floats, strings, or integers
  - Verify whether nested data dict unwrapping is necessary (may be defensive only)
- [ ] Spot-check create_response() output structure:
  - transformedResponse includes criteriaKey, extra_fields (e.g., scoreInPercentage, supplementary fields)
  - additionalInfo.evaluation includes passReasons, failReasons, recommendations, additionalFindings
  - metadata.schemaVersion is 1.0, transformationId matches script name
- [ ] Verify merge workflow pattern in isEPPEnabled:
  - Input contains fields from all three merged methods
  - Supplementary fields (isEPPDeployed, isEPPConfigured) correctly extracted and included in result
- [ ] Add API error handling:
  - If Halcyon returns stat: FAIL or error status, scripts should fail gracefully (currently no explicit check)
  - Consider adding optional error_status field detection in evaluate()

Generated by Spektrum integration onboarding pipeline