### PR TITLE
feat: add MDR transformations (mdr)

### DIFF
--- a/safeguards/mdr/mdr/confirmedLicensePurchased.py
+++ b/safeguards/mdr/mdr/confirmedLicensePurchased.py
@@ -1,0 +1,147 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: MDR (mdr)  |  Category: MDR
+Evaluates: Whether a valid MDR licence has been purchased and is active.
+           Reads the 'licensePurchased' field from the getMDRStatus response.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "mdr",
+                "category": "MDR"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        license_purchased = data.get("licensePurchased", False)
+        service_active = data.get("serviceActive", False)
+        status = data.get("status", "unknown")
+
+        is_licensed = bool(license_purchased)
+
+        return {
+            "confirmedLicensePurchased": is_licensed,
+            "licensePurchasedFlag": is_licensed,
+            "serviceActive": bool(service_active),
+            "serviceStatus": str(status)
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("A valid MDR licence is confirmed purchased and active")
+            pass_reasons.append("licensePurchasedFlag: " + str(extra_fields.get("licensePurchasedFlag", False)))
+        else:
+            fail_reasons.append("No active MDR licence is confirmed in the vendor response")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Purchase a valid MDR licence through your vendor portal and ensure it is "
+                "activated for your organisation before proceeding"
+            )
+
+        additional_findings.append("serviceStatus: " + str(extra_fields.get("serviceStatus", "unknown")))
+        additional_findings.append("serviceActive: " + str(extra_fields.get("serviceActive", False)))
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "licensePurchasedFlag": extra_fields.get("licensePurchasedFlag"),
+                "serviceActive": extra_fields.get("serviceActive"),
+                "serviceStatus": extra_fields.get("serviceStatus")
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/mdr/mdr/isMDRConfigured.py
+++ b/safeguards/mdr/mdr/isMDRConfigured.py
@@ -1,0 +1,155 @@
+"""
+Transformation: isMDRConfigured
+Vendor: MDR (mdr)  |  Category: MDR
+Evaluates: Whether the MDR service has been fully configured in the vendor portal --
+           authorised contacts set, threat response mode selected, integrations active.
+           Reads the 'configured' field from the getMDRStatus response.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isMDRConfigured",
+                "vendor": "mdr",
+                "category": "MDR"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        configured = data.get("configured", False)
+        enabled = data.get("enabled", False)
+        service_active = data.get("serviceActive", False)
+        status = data.get("status", "unknown")
+
+        is_configured = bool(configured)
+
+        return {
+            "isMDRConfigured": is_configured,
+            "configuredFlag": is_configured,
+            "enabledFlag": bool(enabled),
+            "serviceActive": bool(service_active),
+            "serviceStatus": str(status)
+        }
+    except Exception as e:
+        return {"isMDRConfigured": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isMDRConfigured"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                "MDR service is fully configured with authorised contacts and threat response mode"
+            )
+            pass_reasons.append("configuredFlag: " + str(extra_fields.get("configuredFlag", False)))
+        else:
+            fail_reasons.append(
+                "MDR service is not fully configured in the vendor portal"
+            )
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Complete MDR configuration: set authorised contacts, select a threat response "
+                "mode, and activate all required integrations in the vendor portal"
+            )
+
+        additional_findings.append("serviceStatus: " + str(extra_fields.get("serviceStatus", "unknown")))
+        additional_findings.append("enabledFlag: " + str(extra_fields.get("enabledFlag", False)))
+        additional_findings.append("serviceActive: " + str(extra_fields.get("serviceActive", False)))
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "configuredFlag": extra_fields.get("configuredFlag"),
+                "enabledFlag": extra_fields.get("enabledFlag"),
+                "serviceStatus": extra_fields.get("serviceStatus")
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/mdr/mdr/isMDREnabled.py
+++ b/safeguards/mdr/mdr/isMDREnabled.py
@@ -1,0 +1,147 @@
+"""
+Transformation: isMDREnabled
+Vendor: MDR (mdr)  |  Category: MDR
+Evaluates: Whether the MDR service is actively enabled, cross-referencing
+           the 'enabled' and 'serviceActive' fields from the getMDRStatus response.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isMDREnabled",
+                "vendor": "mdr",
+                "category": "MDR"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        enabled = data.get("enabled", False)
+        service_active = data.get("serviceActive", False)
+        status = data.get("status", "unknown")
+
+        is_enabled = bool(enabled) and bool(service_active)
+
+        return {
+            "isMDREnabled": is_enabled,
+            "enabledFlag": bool(enabled),
+            "serviceActive": bool(service_active),
+            "serviceStatus": str(status)
+        }
+    except Exception as e:
+        return {"isMDREnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isMDREnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("MDR service is confirmed active and enabled")
+            pass_reasons.append("enabledFlag: " + str(extra_fields.get("enabledFlag", False)))
+            pass_reasons.append("serviceActive: " + str(extra_fields.get("serviceActive", False)))
+        else:
+            if not eval_result.get("enabledFlag", False):
+                fail_reasons.append("MDR service is not marked as enabled in the vendor response")
+            if not eval_result.get("serviceActive", False):
+                fail_reasons.append("MDR service is not reported as active (serviceActive=False)")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable the MDR service in your vendor portal and confirm serviceActive status")
+
+        additional_findings.append("serviceStatus: " + str(extra_fields.get("serviceStatus", "unknown")))
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "enabledFlag": extra_fields.get("enabledFlag"),
+                "serviceActive": extra_fields.get("serviceActive"),
+                "serviceStatus": extra_fields.get("serviceStatus")
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/mdr/mdr/isSSOEnabled.py
+++ b/safeguards/mdr/mdr/isSSOEnabled.py
@@ -1,0 +1,143 @@
+"""
+Transformation: isSSOEnabled
+Vendor: MDR (mdr)  |  Category: MDR
+Evaluates: Whether Single Sign-On is enabled for access to the MDR vendor portal.
+           Reads the 'ssoEnabled' field from the getMDRStatus response.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isSSOEnabled",
+                "vendor": "mdr",
+                "category": "MDR"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        sso_enabled = data.get("ssoEnabled", False)
+        service_status = data.get("status", "unknown")
+
+        is_sso = bool(sso_enabled)
+
+        return {
+            "isSSOEnabled": is_sso,
+            "ssoEnabledFlag": is_sso,
+            "serviceStatus": str(service_status)
+        }
+    except Exception as e:
+        return {"isSSOEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSSOEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Single Sign-On is confirmed enabled for MDR portal access")
+            pass_reasons.append("ssoEnabledFlag: " + str(extra_fields.get("ssoEnabledFlag", False)))
+        else:
+            fail_reasons.append("Single Sign-On is not enabled for access to the MDR vendor portal")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Enable SSO for your MDR vendor portal to centralise access control and "
+                "reduce credential sprawl"
+            )
+
+        additional_findings.append("serviceStatus: " + str(extra_fields.get("serviceStatus", "unknown")))
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "ssoEnabledFlag": extra_fields.get("ssoEnabledFlag"),
+                "serviceStatus": extra_fields.get("serviceStatus")
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/mdr/mdr/requiredCoveragePercentage.py
+++ b/safeguards/mdr/mdr/requiredCoveragePercentage.py
@@ -1,0 +1,199 @@
+"""
+Transformation: requiredCoveragePercentage
+Vendor: MDR (mdr)  |  Category: MDR
+Evaluates: The percentage of organisational endpoints currently enrolled under MDR
+           monitoring. Derives actual coverage from the getMDREndpoints 'items' array
+           and 'total'/'size' pagination fields, then validates against the attested
+           coveragePercentage and a minimum required threshold of 80%.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "requiredCoveragePercentage",
+                "vendor": "mdr",
+                "category": "MDR"
+            }
+        }
+    }
+
+
+def safe_round(value, decimals):
+    multiplier = 1
+    for i in range(decimals):
+        multiplier = multiplier * 10
+    rounded = int(value * multiplier + 0.5) / multiplier
+    return rounded
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        total_pages = data.get("total", 0)
+        page_size = data.get("size", 0)
+        attested_coverage = data.get("coveragePercentage", 0)
+
+        if not isinstance(items, list):
+            items = []
+
+        enrolled_count = len(items)
+
+        total_endpoints = 0
+        if total_pages and page_size:
+            total_endpoints = total_pages * page_size
+        elif enrolled_count > 0:
+            total_endpoints = enrolled_count
+
+        coverage_percentage = 0.0
+        if total_endpoints > 0:
+            raw = (enrolled_count / total_endpoints) * 100.0
+            coverage_percentage = safe_round(raw, 2)
+            if coverage_percentage > 100.0:
+                coverage_percentage = 100.0
+        elif attested_coverage > 0:
+            coverage_percentage = float(attested_coverage)
+
+        required_threshold = 80.0
+        meets_threshold = coverage_percentage >= required_threshold
+
+        return {
+            "requiredCoveragePercentage": meets_threshold,
+            "coveragePercentage": coverage_percentage,
+            "enrolledEndpoints": enrolled_count,
+            "totalEndpoints": total_endpoints,
+            "attestedCoveragePercentage": float(attested_coverage),
+            "requiredThreshold": required_threshold
+        }
+    except Exception as e:
+        return {"requiredCoveragePercentage": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "requiredCoveragePercentage"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        coverage = extra_fields.get("coveragePercentage", 0.0)
+        threshold = extra_fields.get("requiredThreshold", 80.0)
+        enrolled = extra_fields.get("enrolledEndpoints", 0)
+        total = extra_fields.get("totalEndpoints", 0)
+
+        if result_value:
+            pass_reasons.append(
+                "MDR endpoint coverage of " + str(coverage) + "% meets the required threshold of " +
+                str(threshold) + "%"
+            )
+            pass_reasons.append(
+                "Enrolled endpoints: " + str(enrolled) + " of " + str(total)
+            )
+        else:
+            fail_reasons.append(
+                "MDR endpoint coverage of " + str(coverage) + "% is below the required threshold of " +
+                str(threshold) + "%"
+            )
+            fail_reasons.append(
+                "Enrolled endpoints: " + str(enrolled) + " of " + str(total)
+            )
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Enrol additional endpoints under MDR monitoring to reach at least " +
+                str(threshold) + "% coverage of the total endpoint estate"
+            )
+
+        additional_findings.append(
+            "attestedCoveragePercentage: " + str(extra_fields.get("attestedCoveragePercentage", 0.0))
+        )
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "enrolledEndpoints": enrolled,
+                "totalEndpoints": total,
+                "coveragePercentage": coverage,
+                "requiredThreshold": threshold
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Five transformation scripts for Sophos MDR service validation covering enablement, configuration, licensing, SSO, and endpoint coverage. The scripts follow the standard extract_input → evaluate → transform contract correctly and output valid schema v1.0 responses. However, **field name assumptions are not validated against actual Sophos API response schemas**, and the endpoint coverage calculation makes untested assumptions about pagination field semantics.

**Context:** This is part of the Spektrum integration onboarding pipeline for Sophos MDR. All scripts are structurally sound but require field-level verification before production use.

**Script count:** 5 transformations

## What each transformation does

### `isMDREnabled.py`
Evaluates whether the MDR service is actively enabled by checking the `enabled` and `serviceActive` boolean flags from the health status response.

- **Consumes:** `getMDRStatus` (endpoint: `{$baseURL}/common/v1/health`) — UNVERIFIED endpoint
- **Pass criteria:** `enabled AND serviceActive` both true
- **Key edge cases handled:**
  - Missing `enabled` field defaults to false
  - Missing `serviceActive` field defaults to false
  - Both fields coerced to boolean; non-boolean values treated as truthy/falsy
  - `status` field captured for additional context
  - No handling for API error responses (stat: FAIL)

### `isMDRConfigured.py`
Evaluates whether MDR has been fully configured in the vendor portal, including authorized contacts, threat response mode selection, and active integrations.

- **Consumes:** `getMDRStatus` (endpoint: `{$baseURL}/common/v1/health`) — UNVERIFIED endpoint
- **Pass criteria:** `configured` flag is true
- **Key edge cases handled:**
  - Missing `configured` field defaults to false
  - Also captures `enabled` and `serviceActive` for cross-validation context
  - Service status included in additionalFindings
  - No handling for API error responses

### `confirmedLicensePurchased.py`
Confirms a valid MDR license has been purchased and is currently active.

- **Consumes:** `getMDRStatus` (endpoint: `{$baseURL}/common/v1/health`) — UNVERIFIED endpoint
- **Pass criteria:** `licensePurchased` flag is true
- **Key edge cases handled:**
  - Missing `licensePurchased` field defaults to false
  - Captures `serviceActive` for context (license presence doesn't guarantee service is running)
  - Status field tracked
  - No handling for expired license dates or license validation depth

### `isSSOEnabled.py`
Checks whether Single Sign-On is enabled for MDR vendor portal access, reducing credential sprawl and centralizing access control.

- **Consumes:** `getMDRStatus` (endpoint: `{$baseURL}/common/v1/health`) — UNVERIFIED endpoint
- **Pass criteria:** `ssoEnabled` field is true
- **Key edge cases handled:**
  - Missing `ssoEnabled` defaults to false
  - Treats any falsy value (false, null, 0, empty string) as disabled
  - No distinction between SSO configured but disabled vs. SSO not available
  - Service status tracked

### `requiredCoveragePercentage.py`
Calculates the percentage of organizational endpoints enrolled under MDR monitoring by comparing enrolled endpoint count against total endpoint estate. Validates coverage meets or exceeds an 80% minimum threshold.

- **Consumes:** `getMDREndpoints` (endpoint: `{$baseURL}/endpoint/v1/endpoints`) — VERIFIED endpoint
- **Pass criteria:** `(enrolledCount / totalEndpoints) * 100 >= 80%`
- **Key edge cases handled:**
  - If `items` array is not a list, treats as empty (0 enrolled endpoints)
  - Total endpoints calculated as `total * size` (assumes pages.total is page count and pages.size is page size) — ASSUMPTION NOT VERIFIED
  - If total cannot be calculated and enrolled > 0, uses enrolled count as total
  - If enrolled is 0 and total is 0, defaults to attested coveragePercentage from requirements
  - Coverage capped at 100% if calculation exceeds it
  - Rounds to 2 decimal places
  - No pagination handling (only processes first page of results)
  - Recommendation suggests enrolling additional endpoints to reach 80%

## Architecture notes

All five scripts follow the standard Spektrum transformation contract: extract_input (unwraps nested response wrappers) → evaluate (applies business logic, returns dict with criteriaKey + computed fields) → transform (orchestrates evaluation, formats passReasons/failReasons/recommendations/additionalFindings, returns response schema v1.0).

Response schema is consistent across all scripts:
- `transformedResponse`: result dict with criteriaKey boolean + extra fields
- `additionalInfo.dataCollection`: status + api_errors array
- `additionalInfo.evaluation`: passReasons, failReasons, recommendations, additionalFindings
- `additionalInfo.metadata`: evaluatedAt (ISO 8601 UTC), schemaVersion (1.0), transformationId, vendor, category

All scripts use RestrictedPython-safe patterns (no exec/eval, stdlib only, datetime imports allowed).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation (syntax + RestrictedPython constraints)
- [ ] Verify `evaluate()` returns correct boolean for:
  - [ ] `isMDREnabled`: enabled=true, serviceActive=true → true; enabled=false → false; serviceActive=false → false
  - [ ] `isMDRConfigured`: configured=true → true; configured=false → false; missing field → false
  - [ ] `confirmedLicensePurchased`: licensePurchased=true → true; false → false
  - [ ] `isSSOEnabled`: ssoEnabled=true → true; false → false
  - [ ] `requiredCoveragePercentage`: items=[...] (10 items), total=100, size=1 → (10/100)*100=10% → false (below 80%); items=[...] (80 items), total=100, size=1 → true
- [ ] Confirm field names in `data.get("...")` calls match Sophos API response schema:
  - [ ] For `/common/v1/health`: enabled, serviceActive, status, configured, licensePurchased, ssoEnabled, coveragePercentage
  - [ ] For `/endpoint/v1/endpoints`: items (array), pages.total, pages.size
- [ ] Test edge cases:
  - [ ] Missing fields → appropriate defaults (false for booleans, empty list for items)
  - [ ] API error response (stat: FAIL) → scripts handle missing data gracefully
  - [ ] Empty items array → coverage calculation returns 0% or uses attested value
  - [ ] Non-list items value → treated as empty
- [ ] Spot-check schema v1.0 compliance:
  - [ ] Timestamp format: ISO 8601 with Z suffix
  - [ ] schemaVersion field present
  - [ ] All required evaluation fields present (passReasons, failReasons, etc.)
- [ ] Pagination validation for `requiredCoveragePercentage`:
  - [ ] If `pages.nextKey` is present, script should iterate (CURRENTLY NOT IMPLEMENTED — flag for future enhancement)

**Field accuracy risk:** HIGH — The actual Sophos MDR API response schema has not been confirmed. Recommend obtaining live API response samples before production deployment.