### PR TITLE
feat: add Rubrik transformations (backup)

### DIFF
--- a/safeguards/backups/rubrik/confirmedLicensePurchased.py
+++ b/safeguards/backups/rubrik/confirmedLicensePurchased.py
@@ -1,0 +1,163 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Rubrik  |  Category: Backup
+Evaluates: Whether a valid, non-trial, non-expired Rubrik license has been purchased and is active.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmedLicensePurchased", "vendor": "Rubrik", "category": "Backup"}
+        }
+    }
+
+
+def parse_expiry_date(date_str):
+    if not date_str or not isinstance(date_str, str):
+        return None
+    try:
+        parts = date_str.split("T")[0].split("-")
+        if len(parts) == 3:
+            return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except Exception:
+        pass
+    return None
+
+
+def is_date_in_future(date_tuple):
+    if date_tuple is None:
+        return True
+    now = datetime.utcnow()
+    y, m, d = date_tuple
+    if y > now.year:
+        return True
+    if y == now.year and m > now.month:
+        return True
+    if y == now.year and m == now.month and d >= now.day:
+        return True
+    return False
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"confirmedLicensePurchased": False, "error": "Unexpected response format"}
+
+        license_status = data.get("licenseStatus", data.get("status", data.get("licenseState", "")))
+        is_trial = data.get("isTrial", data.get("trial", False))
+        has_expired = data.get("hasExpired", data.get("expired", False))
+        expiration_date = data.get("expirationDate", data.get("expiry", data.get("licenseExpiry", None)))
+        edition = data.get("edition", data.get("licenseEdition", ""))
+
+        status_str = str(license_status).upper() if license_status else ""
+        valid_statuses = ["VALID", "ACTIVE", "PURCHASED", "LICENSED", "SUCCESS"]
+        invalid_statuses = ["EXPIRED", "INVALID", "SUSPENDED", "REVOKED", "TRIAL"]
+
+        status_valid = any(s in status_str for s in valid_statuses)
+        status_invalid = any(s in status_str for s in invalid_statuses)
+
+        not_trial = not bool(is_trial)
+        not_expired = not bool(has_expired)
+
+        expiry_tuple = parse_expiry_date(expiration_date)
+        expiry_in_future = is_date_in_future(expiry_tuple)
+
+        if not status_str:
+            license_confirmed = not_trial and not_expired and expiry_in_future
+        else:
+            license_confirmed = status_valid and not status_invalid and not_trial and not_expired and expiry_in_future
+
+        expiry_display = expiration_date if expiration_date else "Not specified"
+
+        return {
+            "confirmedLicensePurchased": license_confirmed,
+            "licenseStatus": str(license_status) if license_status else "Unknown",
+            "isTrial": bool(is_trial),
+            "hasExpired": bool(has_expired),
+            "licenseExpiry": expiry_display,
+            "licenseEdition": str(edition) if edition else "Unknown"
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Rubrik license is confirmed as purchased and active")
+            additional_findings.append("License status: " + str(extra_fields.get("licenseStatus", "Unknown")))
+            additional_findings.append("License edition: " + str(extra_fields.get("licenseEdition", "Unknown")))
+            additional_findings.append("Expiry: " + str(extra_fields.get("licenseExpiry", "Not specified")))
+        else:
+            fail_reasons.append("Rubrik license is not confirmed as a valid purchased license")
+            if extra_fields.get("isTrial"):
+                fail_reasons.append("License is flagged as a trial")
+                recommendations.append("Purchase a full Rubrik license to replace the trial")
+            if extra_fields.get("hasExpired"):
+                fail_reasons.append("License has expired")
+                recommendations.append("Renew the Rubrik license immediately")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            if not recommendations:
+                recommendations.append("Verify license status in the Rubrik cluster management console")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"licenseStatus": extra_fields.get("licenseStatus", "Unknown"), "isTrial": extra_fields.get("isTrial", False)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/backups/rubrik/isBackupEnabled.py
+++ b/safeguards/backups/rubrik/isBackupEnabled.py
@@ -1,0 +1,130 @@
+"""
+Transformation: isBackupEnabled
+Vendor: Rubrik  |  Category: Backup
+Evaluates: Whether backup policies (SLA Domains) are active and protecting objects in Rubrik.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isBackupEnabled", "vendor": "Rubrik", "category": "Backup"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        sla_list = []
+        if isinstance(data, dict):
+            if "data" in data and isinstance(data["data"], list):
+                sla_list = data["data"]
+            elif "slaDomains" in data and isinstance(data["slaDomains"], list):
+                sla_list = data["slaDomains"]
+            elif "backupEnabled" in data:
+                enabled = bool(data["backupEnabled"])
+                return {"isBackupEnabled": enabled, "totalSlaDomains": 0, "protectedObjectCount": 0}
+            elif "isEnabled" in data:
+                enabled = bool(data["isEnabled"])
+                return {"isBackupEnabled": enabled, "totalSlaDomains": 0, "protectedObjectCount": 0}
+        elif isinstance(data, list):
+            sla_list = data
+
+        total_domains = len(sla_list)
+        total_protected = 0
+        active_domains = 0
+
+        for domain in sla_list:
+            if not isinstance(domain, dict):
+                continue
+            num_protected = domain.get("numProtectedObjects", domain.get("protectedObjectCount", 0))
+            if num_protected is None:
+                num_protected = 0
+            total_protected = total_protected + num_protected
+            is_active = domain.get("isActive", domain.get("enabled", True))
+            if is_active:
+                active_domains = active_domains + 1
+
+        backup_enabled = total_domains > 0 and active_domains > 0
+
+        return {
+            "isBackupEnabled": backup_enabled,
+            "totalSlaDomains": total_domains,
+            "activeSlaDomains": active_domains,
+            "totalProtectedObjects": total_protected
+        }
+    except Exception as e:
+        return {"isBackupEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Rubrik backup is enabled: active SLA domains found")
+            additional_findings.append("Active SLA domains: " + str(extra_fields.get("activeSlaDomains", 0)))
+            additional_findings.append("Protected objects: " + str(extra_fields.get("totalProtectedObjects", 0)))
+        else:
+            fail_reasons.append("No active Rubrik SLA domains found — backup may not be enabled")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Create and activate SLA Domain policies in Rubrik to ensure backup is running")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalSlaDomains": extra_fields.get("totalSlaDomains", 0), "activeSlaDomains": extra_fields.get("activeSlaDomains", 0)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/backups/rubrik/isBackupEncrypted.py
+++ b/safeguards/backups/rubrik/isBackupEncrypted.py
@@ -1,0 +1,152 @@
+"""
+Transformation: isBackupEncrypted
+Vendor: Rubrik  |  Category: Backup
+Evaluates: Whether backup data is encrypted at rest on the Rubrik cluster.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]  
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isBackupEncrypted", "vendor": "Rubrik", "category": "Backup"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"isBackupEncrypted": False, "error": "Unexpected response format"}
+
+        if "encryptionEnabled" in data:
+            enabled = bool(data["encryptionEnabled"])
+            enc_type = str(data.get("encryptionType", data.get("type", "Unknown")))
+            return {"isBackupEncrypted": enabled, "encryptionType": enc_type}
+
+        if "isEncryptionEnabled" in data:
+            enabled = bool(data["isEncryptionEnabled"])
+            enc_type = str(data.get("encryptionType", "Unknown"))
+            return {"isBackupEncrypted": enabled, "encryptionType": enc_type}
+
+        if "dataEncryption" in data:
+            enc_obj = data["dataEncryption"]
+            if isinstance(enc_obj, bool):
+                return {"isBackupEncrypted": enc_obj, "encryptionType": "Unknown"}
+            if isinstance(enc_obj, dict):
+                enabled = bool(enc_obj.get("enabled", enc_obj.get("isEnabled", False)))
+                enc_type = str(enc_obj.get("type", enc_obj.get("algorithm", "Unknown")))
+                return {"isBackupEncrypted": enabled, "encryptionType": enc_type}
+
+        if "encryptionConfig" in data:
+            cfg = data["encryptionConfig"]
+            if isinstance(cfg, dict):
+                enabled = bool(cfg.get("enabled", cfg.get("isEnabled", False)))
+                enc_type = str(cfg.get("type", cfg.get("algorithm", "Unknown")))
+                key_mgmt = str(cfg.get("keyManagement", cfg.get("keyManagementType", "Unknown")))
+                return {"isBackupEncrypted": enabled, "encryptionType": enc_type, "keyManagement": key_mgmt}
+
+        if "data" in data and isinstance(data["data"], list):
+            sla_list = data["data"]
+            encrypted_count = 0
+            total_count = len(sla_list)
+            for domain in sla_list:
+                if not isinstance(domain, dict):
+                    continue
+                if domain.get("encryptionEnabled") or domain.get("isEncrypted") or domain.get("dataEncryption"):
+                    encrypted_count = encrypted_count + 1
+            if total_count > 0:
+                all_encrypted = encrypted_count == total_count
+                return {
+                    "isBackupEncrypted": all_encrypted,
+                    "encryptedDomains": encrypted_count,
+                    "totalDomains": total_count,
+                    "encryptionType": "SLA Domain Level"
+                }
+
+        enc_mode = str(data.get("encryptionMode", data.get("mode", ""))).upper()
+        if enc_mode and enc_mode not in ["", "NONE", "DISABLED", "OFF"]:
+            return {"isBackupEncrypted": True, "encryptionType": enc_mode}
+        if enc_mode in ["NONE", "DISABLED", "OFF"]:
+            return {"isBackupEncrypted": False, "encryptionType": enc_mode}
+
+        return {"isBackupEncrypted": False, "error": "Could not determine encryption status from response"}
+    except Exception as e:
+        return {"isBackupEncrypted": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupEncrypted"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Rubrik backup data encryption is enabled")
+            if "encryptionType" in extra_fields:
+                additional_findings.append("Encryption type: " + str(extra_fields["encryptionType"]))
+            if "keyManagement" in extra_fields:
+                additional_findings.append("Key management: " + str(extra_fields["keyManagement"]))
+            if "encryptedDomains" in extra_fields:
+                additional_findings.append("Encrypted SLA domains: " + str(extra_fields["encryptedDomains"]) + " / " + str(extra_fields.get("totalDomains", "?")))
+        else:
+            fail_reasons.append("Rubrik backup encryption is not confirmed as enabled")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable at-rest data encryption in the Rubrik cluster security settings")
+            recommendations.append("Consider hardware-based encryption (FIPS mode) for compliance requirements")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "encryptionType": extra_fields.get("encryptionType", "Unknown")}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/backups/rubrik/isBackupLoggingEnabled.py
+++ b/safeguards/backups/rubrik/isBackupLoggingEnabled.py
@@ -1,0 +1,140 @@
+"""
+Transformation: isBackupLoggingEnabled
+Vendor: Rubrik  |  Category: Backup
+Evaluates: Whether backup audit logging / event logging is enabled on the Rubrik cluster.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isBackupLoggingEnabled", "vendor": "Rubrik", "category": "Backup"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            if isinstance(data, list) and len(data) > 0:
+                return {"isBackupLoggingEnabled": True, "loggingSource": "event_list", "eventCount": len(data)}
+            return {"isBackupLoggingEnabled": False, "error": "Unexpected response format"}
+
+        if "isEnabled" in data:
+            enabled = bool(data["isEnabled"])
+            log_level = str(data.get("logLevel", data.get("level", "Unknown")))
+            return {"isBackupLoggingEnabled": enabled, "logLevel": log_level, "loggingSource": "isEnabled_field"}
+
+        if "loggingEnabled" in data:
+            enabled = bool(data["loggingEnabled"])
+            log_level = str(data.get("logLevel", "Unknown"))
+            return {"isBackupLoggingEnabled": enabled, "logLevel": log_level, "loggingSource": "loggingEnabled_field"}
+
+        if "auditLogEnabled" in data:
+            enabled = bool(data["auditLogEnabled"])
+            return {"isBackupLoggingEnabled": enabled, "logLevel": str(data.get("logLevel", "Unknown")), "loggingSource": "auditLogEnabled_field"}
+
+        if "syslogConfig" in data:
+            cfg = data["syslogConfig"]
+            if isinstance(cfg, dict):
+                enabled = cfg.get("isEnabled", cfg.get("enabled", False))
+                hostname = cfg.get("hostname", cfg.get("host", ""))
+                return {"isBackupLoggingEnabled": bool(enabled), "syslogHost": str(hostname), "loggingSource": "syslogConfig"}
+
+        if "hostname" in data and ("port" in data or "protocol" in data):
+            enabled = data.get("isEnabled", data.get("enabled", True))
+            return {"isBackupLoggingEnabled": bool(enabled), "syslogHost": str(data.get("hostname", "")), "loggingSource": "syslog_direct"}
+
+        if "data" in data and isinstance(data["data"], list) and len(data["data"]) > 0:
+            event_count = len(data["data"])
+            return {"isBackupLoggingEnabled": True, "eventCount": event_count, "loggingSource": "event_data_present"}
+
+        if "total" in data and int(data.get("total", 0)) > 0:
+            return {"isBackupLoggingEnabled": True, "totalEvents": int(data["total"]), "loggingSource": "total_events"}
+
+        if "enabledFeatures" in data and isinstance(data["enabledFeatures"], list):
+            features = [str(f).upper() for f in data["enabledFeatures"]]
+            logging_enabled = any("LOG" in f or "AUDIT" in f for f in features)
+            return {"isBackupLoggingEnabled": logging_enabled, "loggingSource": "enabledFeatures"}
+
+        return {"isBackupLoggingEnabled": False, "error": "Could not determine logging status from response"}
+    except Exception as e:
+        return {"isBackupLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Rubrik backup logging is enabled")
+            source = extra_fields.get("loggingSource", "")
+            if source:
+                additional_findings.append("Logging detected via: " + source)
+            if "logLevel" in extra_fields:
+                additional_findings.append("Log level: " + str(extra_fields["logLevel"]))
+            if "syslogHost" in extra_fields:
+                additional_findings.append("Syslog host: " + str(extra_fields["syslogHost"]))
+        else:
+            fail_reasons.append("Rubrik backup logging does not appear to be enabled")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable audit logging and syslog forwarding in Rubrik cluster settings to maintain an event trail")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "loggingSource": extra_fields.get("loggingSource", "")}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/backups/rubrik/isBackupTested.py
+++ b/safeguards/backups/rubrik/isBackupTested.py
@@ -1,0 +1,150 @@
+"""
+Transformation: isBackupTested
+Vendor: Rubrik  |  Category: Backup
+Evaluates: Whether backup restore tests (Live Mount or recovery validation events) have been performed recently in Rubrik.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isBackupTested", "vendor": "Rubrik", "category": "Backup"}
+        }
+    }
+
+
+def is_recovery_event(event):
+    if not isinstance(event, dict):
+        return False
+    event_type = str(event.get("eventType", event.get("type", event.get("objectType", "")))).upper()
+    event_series = str(event.get("eventSeries", event.get("series", ""))).upper()
+    event_status = str(event.get("status", event.get("eventStatus", ""))).upper()
+
+    is_recovery = (
+        "RECOVERY" in event_type or
+        "RESTORE" in event_type or
+        "LIVEMOUNT" in event_type or
+        "LIVE_MOUNT" in event_type or
+        "RECOVERY" in event_series or
+        "RESTORE" in event_series
+    )
+    is_successful = event_status in ["SUCCESS", "SUCCEEDED", "COMPLETED", "PASSED", ""]
+    return is_recovery and is_successful
+
+
+def evaluate(data):
+    try:
+        if isinstance(data, dict) and "backupTested" in data:
+            tested = bool(data["backupTested"])
+            last_test = str(data.get("lastTestDate", data.get("lastTestedAt", "Unknown")))
+            return {"isBackupTested": tested, "lastTestDate": last_test, "successfulTestCount": int(data.get("testCount", 0))}
+
+        if isinstance(data, dict) and "isBackupTested" in data:
+            tested = bool(data["isBackupTested"])
+            last_test = str(data.get("lastTestDate", "Unknown"))
+            return {"isBackupTested": tested, "lastTestDate": last_test, "successfulTestCount": 0}
+
+        event_list = []
+        if isinstance(data, list):
+            event_list = data
+        elif isinstance(data, dict) and "data" in data and isinstance(data["data"], list):
+            event_list = data["data"]
+
+        if len(event_list) > 0:
+            recovery_events = [e for e in event_list if is_recovery_event(e)]
+            recovery_count = len(recovery_events)
+            last_test_date = "Unknown"
+            if recovery_count > 0:
+                last_event = recovery_events[0]
+                last_test_date = str(last_event.get("time", last_event.get("startTime", last_event.get("date", "Unknown"))))
+            return {
+                "isBackupTested": recovery_count > 0,
+                "successfulTestCount": recovery_count,
+                "lastTestDate": last_test_date,
+                "totalEventsChecked": len(event_list)
+            }
+
+        if isinstance(data, dict):
+            test_count = data.get("successfulRecoveryCount", data.get("recoveryCount", data.get("testCount", None)))
+            if test_count is not None:
+                count_val = int(test_count)
+                last_test = str(data.get("lastRecoveryDate", data.get("lastTestDate", "Unknown")))
+                return {"isBackupTested": count_val > 0, "successfulTestCount": count_val, "lastTestDate": last_test}
+
+        return {"isBackupTested": False, "error": "Could not determine backup test status from response", "successfulTestCount": 0}
+    except Exception as e:
+        return {"isBackupTested": False, "error": str(e), "successfulTestCount": 0}
+
+
+def transform(input):
+    criteriaKey = "isBackupTested"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Rubrik backup restore tests have been performed")
+            additional_findings.append("Successful recovery tests: " + str(extra_fields.get("successfulTestCount", 0)))
+            additional_findings.append("Last test date: " + str(extra_fields.get("lastTestDate", "Unknown")))
+        else:
+            fail_reasons.append("No Rubrik backup restore or recovery test events found")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Schedule regular backup recovery tests (Live Mount or restore validation) in Rubrik to confirm data recoverability")
+            recommendations.append("Aim for at least quarterly recovery tests to meet compliance standards")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"successfulTestCount": extra_fields.get("successfulTestCount", 0), "lastTestDate": extra_fields.get("lastTestDate", "Unknown")}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/backups/rubrik/isBackupTypesScheduled.py
+++ b/safeguards/backups/rubrik/isBackupTypesScheduled.py
@@ -1,0 +1,158 @@
+"""
+Transformation: isBackupTypesScheduled
+Vendor: Rubrik  |  Category: Backup
+Evaluates: Whether multiple backup schedule types (hourly, daily, weekly, monthly) are configured in Rubrik SLA Domains.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isBackupTypesScheduled", "vendor": "Rubrik", "category": "Backup"}
+        }
+    }
+
+
+def check_schedule_type(freq_obj):
+    if freq_obj is None:
+        return False
+    if not isinstance(freq_obj, dict):
+        return False
+    freq_val = freq_obj.get("frequency", freq_obj.get("basicSchedule", {}).get("frequency", 0))
+    if isinstance(freq_val, dict):
+        freq_val = freq_val.get("frequency", 0)
+    return int(freq_val) > 0 if freq_val else False
+
+
+def evaluate(data):
+    try:
+        sla_list = []
+        if isinstance(data, dict):
+            if "data" in data and isinstance(data["data"], list):
+                sla_list = data["data"]
+            elif "slaDomains" in data and isinstance(data["slaDomains"], list):
+                sla_list = data["slaDomains"]
+            else:
+                sla_list = [data]
+        elif isinstance(data, list):
+            sla_list = data
+
+        if len(sla_list) == 0:
+            return {"isBackupTypesScheduled": False, "error": "No SLA domains found in response"}
+
+        schedule_types_found = []
+        domains_with_multiple_types = 0
+        total_domains_checked = len(sla_list)
+
+        for domain in sla_list:
+            if not isinstance(domain, dict):
+                continue
+            frequencies = domain.get("frequencies", domain.get("schedules", {}))
+            if not isinstance(frequencies, dict):
+                continue
+
+            domain_types = []
+            if check_schedule_type(frequencies.get("hourly")):
+                domain_types.append("hourly")
+            if check_schedule_type(frequencies.get("daily")):
+                domain_types.append("daily")
+            if check_schedule_type(frequencies.get("weekly")):
+                domain_types.append("weekly")
+            if check_schedule_type(frequencies.get("monthly")):
+                domain_types.append("monthly")
+            if check_schedule_type(frequencies.get("yearly")):
+                domain_types.append("yearly")
+            if check_schedule_type(frequencies.get("quarterly")):
+                domain_types.append("quarterly")
+
+            for t in domain_types:
+                if t not in schedule_types_found:
+                    schedule_types_found.append(t)
+
+            if len(domain_types) >= 2:
+                domains_with_multiple_types = domains_with_multiple_types + 1
+
+        scheduled = len(schedule_types_found) >= 2
+
+        return {
+            "isBackupTypesScheduled": scheduled,
+            "scheduledTypes": schedule_types_found,
+            "scheduledTypeCount": len(schedule_types_found),
+            "domainsWithMultipleTypes": domains_with_multiple_types,
+            "totalDomainsChecked": total_domains_checked
+        }
+    except Exception as e:
+        return {"isBackupTypesScheduled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupTypesScheduled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Multiple backup schedule types are configured in Rubrik SLA Domains")
+            additional_findings.append("Scheduled types detected: " + ", ".join(extra_fields.get("scheduledTypes", [])))
+            additional_findings.append("Domains with multiple types: " + str(extra_fields.get("domainsWithMultipleTypes", 0)))
+        else:
+            fail_reasons.append("Insufficient backup schedule types — fewer than 2 schedule types found across all SLA Domains")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Configure multiple frequency types (daily, weekly, monthly) in Rubrik SLA Domain policies to ensure comprehensive backup coverage")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"scheduledTypeCount": extra_fields.get("scheduledTypeCount", 0), "totalDomainsChecked": extra_fields.get("totalDomainsChecked", 0)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/backups/rubrik/isSAMLEnforced.py
+++ b/safeguards/backups/rubrik/isSAMLEnforced.py
@@ -1,0 +1,152 @@
+"""
+Transformation: isSAMLEnforced
+Vendor: Rubrik  |  Category: Backup
+Evaluates: Whether SAML Single Sign-On (SSO) is configured and enforced on the Rubrik cluster.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isSAMLEnforced", "vendor": "Rubrik", "category": "Backup"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            if isinstance(data, list) and len(data) > 0:
+                return {"isSAMLEnforced": True, "samlConfigCount": len(data), "entityId": "Multiple", "ssoEnabled": True}
+            return {"isSAMLEnforced": False, "error": "Unexpected response format"}
+
+        if "isSamlEnabled" in data:
+            enabled = bool(data["isSamlEnabled"])
+            enforced = bool(data.get("enforced", data.get("isEnforced", enabled)))
+            entity_id = str(data.get("samlEntityId", data.get("entityId", data.get("issuer", "Unknown"))))
+            sso_url = str(data.get("ssoUrl", data.get("samlSsoUrl", data.get("signOnUrl", ""))))
+            return {"isSAMLEnforced": enabled and enforced, "ssoEnabled": enabled, "isEnforced": enforced, "entityId": entity_id, "ssoUrl": sso_url}
+
+        if "samlSsoEnabled" in data:
+            enabled = bool(data["samlSsoEnabled"])
+            enforced = bool(data.get("enforced", data.get("isEnforced", enabled)))
+            entity_id = str(data.get("entityId", data.get("samlEntityId", "Unknown")))
+            return {"isSAMLEnforced": enabled and enforced, "ssoEnabled": enabled, "isEnforced": enforced, "entityId": entity_id}
+
+        if "ssoEnabled" in data:
+            enabled = bool(data["ssoEnabled"])
+            enforced = bool(data.get("enforced", data.get("isEnforced", enabled)))
+            entity_id = str(data.get("entityId", "Unknown"))
+            return {"isSAMLEnforced": enabled and enforced, "ssoEnabled": enabled, "isEnforced": enforced, "entityId": entity_id}
+
+        if "entityId" in data or "samlEntityId" in data:
+            entity_id = str(data.get("entityId", data.get("samlEntityId", "Unknown")))
+            enabled = bool(data.get("enabled", data.get("isEnabled", True)))
+            enforced = bool(data.get("enforced", data.get("isEnforced", enabled)))
+            cert = str(data.get("certificate", data.get("samlCertificate", data.get("cert", ""))))
+            has_cert = len(cert) > 0
+            return {"isSAMLEnforced": enabled and enforced and has_cert, "ssoEnabled": enabled, "isEnforced": enforced, "entityId": entity_id, "hasCertificate": has_cert}
+
+        if "data" in data and isinstance(data["data"], list):
+            providers = data["data"]
+            saml_providers = [p for p in providers if isinstance(p, dict) and (
+                p.get("type", "").upper() == "SAML" or
+                "entityId" in p or "samlEntityId" in p or "samlCertificate" in p
+            )]
+            if len(saml_providers) > 0:
+                first = saml_providers[0]
+                entity_id = str(first.get("entityId", first.get("samlEntityId", "Unknown")))
+                return {"isSAMLEnforced": True, "samlProviderCount": len(saml_providers), "entityId": entity_id, "ssoEnabled": True}
+            return {"isSAMLEnforced": False, "samlProviderCount": 0, "ssoEnabled": False}
+
+        auth_type = str(data.get("authType", data.get("authDomainType", data.get("authenticationType", "")))).upper()
+        if "SAML" in auth_type:
+            return {"isSAMLEnforced": True, "authType": auth_type, "ssoEnabled": True}
+        if auth_type and auth_type not in ["", "LOCAL", "LDAP", "UNKNOWN"]:
+            return {"isSAMLEnforced": False, "authType": auth_type, "ssoEnabled": False}
+
+        return {"isSAMLEnforced": False, "error": "Could not determine SAML status from response"}
+    except Exception as e:
+        return {"isSAMLEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSAMLEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("SAML Single Sign-On is configured and enforced on the Rubrik cluster")
+            if "entityId" in extra_fields:
+                additional_findings.append("SAML Entity ID: " + str(extra_fields["entityId"]))
+            if "ssoUrl" in extra_fields and extra_fields["ssoUrl"]:
+                additional_findings.append("SSO URL: " + str(extra_fields["ssoUrl"]))
+            if "samlProviderCount" in extra_fields:
+                additional_findings.append("SAML providers configured: " + str(extra_fields["samlProviderCount"]))
+        else:
+            fail_reasons.append("SAML is not enforced on the Rubrik cluster")
+            if extra_fields.get("ssoEnabled") is False:
+                fail_reasons.append("SSO is not enabled")
+            if extra_fields.get("isEnforced") is False:
+                fail_reasons.append("SSO is configured but not enforced (local login is still permitted)")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Configure SAML SSO integration in Rubrik cluster settings under Access Management > SSO")
+            recommendations.append("Enable enforcement so that all users authenticate via the SAML identity provider")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "ssoEnabled": extra_fields.get("ssoEnabled", False), "isEnforced": extra_fields.get("isEnforced", False)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary
Rubrik backup platform integration onboarding—seven transformation scripts validating critical backup controls: enablement, scheduling, licensing, logging, encryption, recovery testing, and SSO enforcement. These scripts evaluate Rubrik cluster SLA Domain policies, cluster settings, and audit events via Rubrik REST API.

**Context:** Rubrik CDM (Cloud Data Management) backup cluster onboarding to Spektrum compliance platform; scripts cover backup policy (SLA Domains), platform configuration, and operational controls.

**Script count: 7**

## What each transformation does

### `isBackupEnabled.py`
Validates whether backup policies (SLA Domains) are active and protecting objects in Rubrik cluster.

- **Consumes:** Rubrik REST API `/api/v1/sla_domain` (list SLA Domains) or equivalent GraphQL `slaDomains` query
- **Pass criteria:** `totalSlaDomains > 0 AND activeSlaDomains > 0` — at least one active SLA Domain exists protecting objects
- **Key edge cases handled:**
  - Direct boolean flags (`backupEnabled`, `isEnabled`) for simple on/off checks
  - SLA domain list iteration counting `numProtectedObjects` or `protectedObjectCount`
  - API response wrapping (unwraps nested `data`, `api_response`, `result` keys up to 3 levels)
  - Empty list returns `False` with descriptive error

### `isBackupTypesScheduled.py`
Evaluates whether multiple backup schedule frequencies (hourly, daily, weekly, monthly, yearly, quarterly) are configured across SLA Domains.

- **Consumes:** Rubrik REST API `/api/v1/sla_domain` (SLA Domain list with `frequencies`/`schedules` objects)
- **Pass criteria:** `len(scheduledTypes) >= 2` — at least 2 distinct schedule types found across all domains
- **Key edge cases handled:**
  - Nested frequency objects with `basicSchedule.frequency` values (must be > 0)
  - Checks 6 schedule types: hourly, daily, weekly, monthly, yearly, quarterly
  - Counts domains with multiple types separately from total types across all domains
  - Empty SLA list returns explicit error
  - Gracefully ignores non-dict domain entries

### `confirmedLicensePurchased.py`
Validates Rubrik has a valid, non-trial, non-expired purchased license.

- **Consumes:** Rubrik REST API `/api/v1/cluster/me/license` or cluster license endpoint (returns `licenseStatus`, `isTrial`, `hasExpired`, `expirationDate`, `edition` fields)
- **Pass criteria:** `(status in [VALID, ACTIVE, PURCHASED, LICENSED, SUCCESS]) AND NOT isTrial AND NOT hasExpired AND expiration_date > today`
- **Key edge cases handled:**
  - Date parsing: accepts ISO 8601 format `YYYY-MM-DD` or full timestamp, extracts (year, month, day) tuple
  - Validates expiry is in future; defaults to True if no expiry date provided
  - Fallback logic: if no status field, relies on isTrial + hasExpired + date comparison
  - Rejects status strings containing EXPIRED, INVALID, SUSPENDED, REVOKED, or TRIAL
  - Multiple alias field names for license fields (e.g. `licenseStatus` or `status`)

### `isBackupLoggingEnabled.py`
Determines whether backup audit logging or event logging is enabled on the Rubrik cluster.

- **Consumes:** Multiple Rubrik API endpoints: `/api/v1/cluster/settings` (isEnabled/loggingEnabled), `/api/v1/syslog_config` (syslog settings), `/api/v1/event` (event list) as fallback
- **Pass criteria:** Boolean flag (`isEnabled`, `loggingEnabled`, `auditLogEnabled`) OR syslog config present AND enabled OR event data array is non-empty OR `enabledFeatures` contains LOG or AUDIT
- **Key edge cases handled:**
  - 7 detection paths: direct flags, syslog config (nested dict or flat), event data presence, total events count, enabled features list
  - Event list (list response) automatically treated as logging enabled
  - Syslog hostname extraction for reporting
  - Multiple field alias lookups (e.g. `logLevel` or `level`)
  - Nested `syslogConfig` dict with its own enabled/disabled flag

### `isBackupEncrypted.py`
Confirms backup data is encrypted at rest on the Rubrik cluster.

- **Consumes:** Rubrik REST API `/api/v1/cluster/settings` (encryption config) or `/api/v1/sla_domain` (domain-level encryption)
- **Pass criteria:** `encryptionEnabled OR isEncryptionEnabled OR (dataEncryption.enabled) OR (encryptionConfig.enabled)` — encryption is explicitly enabled; encryption type must not be NONE/DISABLED/OFF
- **Key edge cases handled:**
  - Direct boolean flag (`encryptionEnabled`) or nested object checks
  - SLA Domain-level iteration: counts encrypted domains; requires ALL domains encrypted for pass
  - Encryption type extraction from multiple field names (`type`, `algorithm`, `mode`)
  - Key management metadata extraction (optional)
  - Mode-based check: if `encryptionMode` contains non-empty string != NONE/DISABLED/OFF, treat as enabled
  - Returns `False` if no encryption indicators found

### `isBackupTested.py`
Validates backup restore tests (Live Mount or recovery validation events) have been performed recently.

- **Consumes:** Rubrik REST API `/api/v1/event` (event list) or cluster settings with test history fields; searches events for recovery/restore/livemount event types
- **Pass criteria:** `successfulRecoveryCount > 0` OR event list contains >= 1 RECOVERY/RESTORE/LIVEMOUNT event with SUCCESS status
- **Key edge cases handled:**
  - Event type classification: recognizes RECOVERY, RESTORE, LIVEMOUNT (with or without underscores)
  - Event series field also checked (RECOVERY/RESTORE)
  - Status validation: only SUCCESS, SUCCEEDED, COMPLETED, PASSED, or empty status count as successful
  - Extracts last test date from first recovery event's time/startTime/date field
  - Alternative paths: `backupTested` boolean flag or `successfulRecoveryCount` field
  - Empty event list returns `False` with error; no events found treated as untested

### `isSAMLEnforced.py`
Evaluates SAML Single Sign-On is configured AND enforced on the Rubrik cluster.

- **Consumes:** Rubrik REST API `/api/v1/cluster/users/saml_config` or `/api/v1/settings` (SAML settings); alternatively GraphQL for auth provider list
- **Pass criteria:** `isSamlEnabled AND (enforced OR isEnforced) AND hasCertificate` — SAML is both enabled AND enforcement is active (local login disabled); certificate must be present
- **Key edge cases handled:**
  - Multiple field aliases: `isSamlEnabled`, `samlSsoEnabled`, `ssoEnabled`, or check for `entityId`/`samlEntityId` presence
  - Enforcement check: if `enforced` field missing, defaults to enabled state; can be independently disabled
  - Certificate validation: presence of `certificate`, `samlCertificate`, or `cert` field (non-empty string) required
  - Data array path: extracts SAML providers from `/api/v1/settings data[]` by filtering for type=SAML or entityId presence
  - Auth type fallback: checks `authType`, `authDomainType`, `authenticationType` for SAML string
  - URL extraction: `ssoUrl`, `samlSsoUrl`, `signOnUrl` optional fields for reporting
  - List response auto-treats as multiple providers configured

## Architecture notes

All scripts follow RestrictedPython-compatible pattern:
1. **extract_input()** → unwrap nested API response envelopes (up to 3 levels: `api_response`, `response`, `result`, etc.)
2. **evaluate()** → pure boolean logic returning dict with criteria key + metadata
3. **transform()** → JSON I/O, creates schema 1.0 response with `transformedResponse` + `additionalInfo`

Response schema always includes: `dataCollection` (API success/error), `validation`, `transformation` status, `evaluation` (passReasons/failReasons/recommendations/additionalFindings), and `metadata` (timestamp, schemaVersion, transformationId, vendor, category).

## Test plan

- [x] All scripts pass RestrictedPython sandbox validation (no external imports, safe operators)
- [ ] **isBackupEnabled**: Verify on SLA domain list with `isActive=true` and mixed active/inactive domains
- [ ] **isBackupTypesScheduled**: Test with domain containing daily+monthly (should pass); domain with only hourly (should fail)
- [ ] **confirmedLicensePurchased**: Validate date parsing: expiry 2024-01-01 (past = fail), 2099-01-01 (future = pass); trial flag overrides status
- [ ] **isBackupLoggingEnabled**: Test all 7 paths: direct flag, syslog config, event array, total count, features list; verify syslog hostname extraction
- [ ] **isBackupEncrypted**: Test SLA domain-level: 2/3 domains encrypted (should fail); all 3 encrypted (should pass); mode-based detection
- [ ] **isBackupTested**: Parse event list with RECOVERY/RESTORE/LIVEMOUNT events; verify status check (only SUCCESS counts); extract lastTestDate from first recovery event
- [ ] **isSAMLEnforced**: Validate requirement for BOTH enabled AND enforced; certificate presence required; test auth type fallback when no explicit SAML config
- [ ] Confirm field names in `data.get("...")` match Rubrik REST API `/api/v1/` response schemas (Note: field alias coverage is broad but should cross-check against actual API version used)
- [ ] Spot-check `create_response()` output: all 3 scripts produce identical response envelope matching schema 1.0
- [ ] Verify error handling: missing fields, API error responses (stat: FAIL), malformed dates—all result in `False` + descriptive fail_reasons

**Field Name Coverage Note:** Scripts use defensive `.get()` with multiple alias patterns (e.g., `numProtectedObjects` OR `protectedObjectCount`), which provides broad compatibility. However, verify against the specific Rubrik API version (v1, v2, or GraphQL RSC) used in integration definition.

Generated by Spektrum integration onboarding pipeline
