### PR TITLE
feat: add Google transformations (iam)

### DIFF
--- a/safeguards/iam/google/authTypesAllowed.py
+++ b/safeguards/iam/google/authTypesAllowed.py
@@ -1,0 +1,175 @@
+"""
+Transformation: authTypesAllowed
+Vendor: Google  |  Category: iam
+Evaluates: Parses login activity event records to identify which authentication types
+are active across the organization. Evaluates event parameters such as login_type
+and is_second_factor to enumerate allowed auth methods (e.g. password, security key,
+authenticator app, SAML). Returns the set of confirmed authentication types in use.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for i in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "authTypesAllowed", "vendor": "Google", "category": "iam"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        if not items:
+            return {
+                "authTypesAllowed": False,
+                "authTypes": [],
+                "authTypeCounts": {},
+                "secondFactorCounts": {},
+                "totalLoginEvents": 0,
+                "totalActivityItems": 0,
+                "hasStrongAuthType": False,
+                "error": "No login activity items found in response"
+            }
+
+        seen_types = {}
+        auth_type_counts = {}
+        second_factor_counts = {}
+        total_events = 0
+
+        for item in items:
+            events = item.get("events", [])
+            for event in events:
+                total_events = total_events + 1
+                params = event.get("parameters", [])
+                login_type = None
+                is_second_factor = False
+
+                for param in params:
+                    param_name = param.get("name", "")
+                    if param_name == "login_type":
+                        login_type = param.get("value", "unknown")
+                    if param_name == "is_second_factor":
+                        is_second_factor = param.get("boolValue", False)
+
+                if login_type:
+                    seen_types[login_type] = True
+                    if login_type in auth_type_counts:
+                        auth_type_counts[login_type] = auth_type_counts[login_type] + 1
+                    else:
+                        auth_type_counts[login_type] = 1
+                    if is_second_factor:
+                        if login_type in second_factor_counts:
+                            second_factor_counts[login_type] = second_factor_counts[login_type] + 1
+                        else:
+                            second_factor_counts[login_type] = 1
+
+        auth_types_list = [k for k in seen_types]
+        has_auth_types = len(auth_types_list) > 0
+
+        strong_types = ["saml", "security_key", "totp"]
+        has_strong = False
+        for t in auth_types_list:
+            if t in strong_types:
+                has_strong = True
+                break
+
+        return {
+            "authTypesAllowed": has_auth_types,
+            "authTypes": auth_types_list,
+            "authTypeCounts": auth_type_counts,
+            "secondFactorCounts": second_factor_counts,
+            "totalLoginEvents": total_events,
+            "totalActivityItems": len(items),
+            "hasStrongAuthType": has_strong
+        }
+    except Exception as e:
+        return {"authTypesAllowed": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "authTypesAllowed"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        auth_types = eval_result.get("authTypes", [])
+
+        if result_value:
+            pass_reasons.append("Authentication types identified: " + ", ".join(auth_types))
+            if eval_result.get("hasStrongAuthType", False):
+                pass_reasons.append("Strong authentication type(s) in use (SAML, Security Key, or TOTP)")
+            additional_findings.append("Total login events analyzed: " + str(eval_result.get("totalLoginEvents", 0)))
+            additional_findings.append("Total activity items processed: " + str(eval_result.get("totalActivityItems", 0)))
+        else:
+            fail_reasons.append("No authentication types could be identified from login activity data")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Ensure the Reports API is enabled and login activity data is available")
+            recommendations.append("Verify that the service account has the admin.reports.audit.readonly OAuth scope")
+
+        result_dict = {criteriaKey: result_value}
+        for k in extra_fields:
+            result_dict[k] = extra_fields[k]
+
+        return create_response(
+            result=result_dict,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalItems": eval_result.get("totalActivityItems", 0), "authTypeCount": len(auth_types)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/google/confirmPasswordPolicyEnforced.py
+++ b/safeguards/iam/google/confirmPasswordPolicyEnforced.py
@@ -1,0 +1,170 @@
+"""
+Transformation: confirmPasswordPolicyEnforced
+Vendor: Google  |  Category: iam
+Evaluates: Examines user records returned from the Directory API (projection=full) to
+assess password policy enforcement. Checks the changePasswordAtNextLogin field on each
+active user. Passes when all active, non-suspended users have a confirmed compliant
+password already set (changePasswordAtNextLogin is false for all). Reports compliance
+score and count of users with pending forced password changes.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for i in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmPasswordPolicyEnforced", "vendor": "Google", "category": "iam"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        users = data.get("users", [])
+        if not users:
+            return {
+                "confirmPasswordPolicyEnforced": False,
+                "totalUsers": 0,
+                "totalActiveUsers": 0,
+                "usersWithPendingPasswordChange": 0,
+                "compliantUsers": 0,
+                "scoreInPercentage": 0.0,
+                "pendingChangeEmails": [],
+                "error": "No user data available in response"
+            }
+
+        total_users = len(users)
+        active_users = [u for u in users if not u.get("suspended", False)]
+        total_active = len(active_users)
+
+        if total_active == 0:
+            return {
+                "confirmPasswordPolicyEnforced": False,
+                "totalUsers": total_users,
+                "totalActiveUsers": 0,
+                "usersWithPendingPasswordChange": 0,
+                "compliantUsers": 0,
+                "scoreInPercentage": 0.0,
+                "pendingChangeEmails": [],
+                "error": "No active (non-suspended) users found"
+            }
+
+        pending_users = [u for u in active_users if u.get("changePasswordAtNextLogin", False)]
+        pending_count = len(pending_users)
+        compliant_count = total_active - pending_count
+
+        score = (compliant_count * 100.0) / total_active
+
+        pending_emails = []
+        for u in pending_users:
+            email = u.get("primaryEmail", "unknown")
+            pending_emails.append(email)
+
+        is_enforced = pending_count == 0
+
+        return {
+            "confirmPasswordPolicyEnforced": is_enforced,
+            "totalUsers": total_users,
+            "totalActiveUsers": total_active,
+            "usersWithPendingPasswordChange": pending_count,
+            "compliantUsers": compliant_count,
+            "scoreInPercentage": round(score, 2),
+            "pendingChangeEmails": pending_emails
+        }
+    except Exception as e:
+        return {"confirmPasswordPolicyEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmPasswordPolicyEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        total_active = eval_result.get("totalActiveUsers", 0)
+        pending_count = eval_result.get("usersWithPendingPasswordChange", 0)
+        compliant_count = eval_result.get("compliantUsers", 0)
+        score = eval_result.get("scoreInPercentage", 0.0)
+        pending_emails = eval_result.get("pendingChangeEmails", [])
+
+        if result_value:
+            pass_reasons.append("All " + str(total_active) + " active users have confirmed compliant passwords set (changePasswordAtNextLogin is false for all)")
+            pass_reasons.append("Password policy compliance score: " + str(score) + "%")
+        else:
+            fail_reasons.append(str(pending_count) + " active user(s) have a forced password change pending (changePasswordAtNextLogin is true)")
+            fail_reasons.append("Password policy compliance score: " + str(score) + "% (" + str(compliant_count) + " of " + str(total_active) + " active users compliant)")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Ensure all active users have reset their passwords to meet the organization password policy")
+            recommendations.append("Review users with pending password changes: " + ", ".join(pending_emails[:10]))
+            if len(pending_emails) > 10:
+                recommendations.append("... and " + str(len(pending_emails) - 10) + " more users")
+
+        additional_findings.append("Total users in directory: " + str(eval_result.get("totalUsers", 0)))
+        additional_findings.append("Active (non-suspended) users evaluated: " + str(total_active))
+
+        result_dict = {criteriaKey: result_value}
+        for k in extra_fields:
+            result_dict[k] = extra_fields[k]
+
+        return create_response(
+            result=result_dict,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalUsers": eval_result.get("totalUsers", 0), "totalActiveUsers": total_active, "pendingPasswordChange": pending_count}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/google/isAuditLoggingEnabled.py
+++ b/safeguards/iam/google/isAuditLoggingEnabled.py
@@ -1,0 +1,183 @@
+"""
+Transformation: isAuditLoggingEnabled
+Vendor: Google  |  Category: iam
+Evaluates: Verifies that audit logging is enabled and operational within the Google
+Workspace organization. Confirms the presence of recent administrative activity entries
+returned from the Reports API. A non-empty items array with events confirms audit
+logging is active.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for i in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAuditLoggingEnabled", "vendor": "Google", "category": "iam"}
+        }
+    }
+
+
+def parse_event_time(time_str):
+    """Extract date components from an ISO8601 timestamp string without strptime."""
+    if not time_str:
+        return None
+    try:
+        date_part = time_str.split("T")[0]
+        parts = date_part.split("-")
+        if len(parts) == 3:
+            return {"year": int(parts[0]), "month": int(parts[1]), "day": int(parts[2])}
+        return None
+    except Exception:
+        return None
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        total_items = len(items)
+
+        if total_items == 0:
+            return {
+                "isAuditLoggingEnabled": False,
+                "auditEventCount": 0,
+                "totalEventsFound": 0,
+                "mostRecentEventTime": None,
+                "uniqueActors": 0,
+                "eventTypesSeen": [],
+                "error": "No admin audit activity items found — audit logging may be disabled or no activity exists in the query window"
+            }
+
+        total_events = 0
+        seen_actors = {}
+        seen_event_names = {}
+        most_recent_time = None
+
+        for item in items:
+            actor = item.get("actor", {})
+            actor_email = actor.get("email", "")
+            if actor_email:
+                seen_actors[actor_email] = True
+
+            events = item.get("events", [])
+            for event in events:
+                total_events = total_events + 1
+                event_name = event.get("name", "")
+                if event_name:
+                    seen_event_names[event_name] = True
+
+            item_id = item.get("id", {})
+            event_time = item_id.get("time", "")
+            if event_time:
+                if most_recent_time is None:
+                    most_recent_time = event_time
+                elif event_time > most_recent_time:
+                    most_recent_time = event_time
+
+        event_names_list = [k for k in seen_event_names]
+        unique_actors = len(seen_actors)
+
+        return {
+            "isAuditLoggingEnabled": True,
+            "auditEventCount": total_items,
+            "totalEventsFound": total_events,
+            "mostRecentEventTime": most_recent_time,
+            "uniqueActors": unique_actors,
+            "eventTypesSeen": event_names_list
+        }
+    except Exception as e:
+        return {"isAuditLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAuditLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        audit_count = eval_result.get("auditEventCount", 0)
+        total_events = eval_result.get("totalEventsFound", 0)
+        most_recent = eval_result.get("mostRecentEventTime", None)
+        unique_actors = eval_result.get("uniqueActors", 0)
+        event_types = eval_result.get("eventTypesSeen", [])
+
+        if result_value:
+            pass_reasons.append("Admin audit log is active: " + str(audit_count) + " activity record(s) returned by the Reports API")
+            pass_reasons.append("Total audit events across all records: " + str(total_events))
+            if most_recent:
+                pass_reasons.append("Most recent audit event timestamp: " + most_recent)
+            additional_findings.append("Unique admin actors observed: " + str(unique_actors))
+            if event_types:
+                additional_findings.append("Event types seen: " + ", ".join(event_types[:20]))
+        else:
+            fail_reasons.append("No admin audit activity records were returned by the Google Reports API")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Verify that the Admin SDK Reports API is enabled in the Google Cloud project")
+            recommendations.append("Confirm the service account has the admin.reports.audit.readonly OAuth scope authorized via domain-wide delegation")
+            recommendations.append("Check that the delegated admin account has Super Admin privileges to access audit log data")
+
+        result_dict = {criteriaKey: result_value}
+        for k in extra_fields:
+            result_dict[k] = extra_fields[k]
+
+        return create_response(
+            result=result_dict,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"auditActivityItems": audit_count, "totalEvents": total_events}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Google Workspace (IAM) integration adds three transformation scripts to validate authentication and audit controls. Scripts evaluate audit logging activation, password policy enforcement, and authentication type enumeration across the organization. All scripts follow the standard extract-evaluate-transform-response contract and use Google Admin SDK (Directory v1 and Reports v1) API responses as input.

**Context:** Security safeguard onboarding for IAM domain integration; covers audit, password policy, and authentication type attestation.

## What each transformation does

### `isAuditLoggingEnabled.py`
Verifies that admin audit logging is active and producing records in Google Workspace by confirming the presence of recent administrative activity events returned from the Reports API.

- **Consumes:** Google Reports API `/admin/reports/v1/activity/users/all/applications/admin` (admin activity records)
- **Pass criteria:** Non-empty `items` array returned from API response (at least one admin activity record exists in the evaluation window)
- **Key edge cases handled:**
  - Empty items array (no activity records) → FAIL with "No admin audit activity items found" error
  - Missing nested fields (actor.email, events, id.time) → gracefully handled with fallback defaults; loop continues
  - Successfully aggregates event counts, unique actors, and event type names across all activity records

### `confirmPasswordPolicyEnforced.py`
Assesses password policy enforcement by examining the `changePasswordAtNextLogin` flag on all active (non-suspended) users from the Directory API.

- **Consumes:** Google Directory API `/admin/directory/v1/users?projection=full` (full user records)
- **Pass criteria:** `changePasswordAtNextLogin == false` for ALL active (non-suspended) users; FAIL if even one active user has pending forced password change
- **Key edge cases handled:**
  - No users in directory → FAIL with "No active (non-suspended) users found"
  - All users suspended → FAIL (treats as no active users)
  - Correctly filters to non-suspended users via `suspended == false`
  - Provides compliance score (percentage of compliant users) and lists up to 10 non-compliant user emails in recommendations
  - Handles missing or empty users array gracefully

### `authTypesAllowed.py`
Enumerates authentication types observed in login activity events by parsing the `login_type` and `is_second_factor` parameters to identify active authentication methods.

- **Consumes:** Google Reports API `/admin/reports/v1/activity/users/all/applications/login` (login activity records)
- **Pass criteria:** Boolean true if at least one `login_type` parameter is found across all login events; additional check flags presence of "strong" auth types (saml, security_key, totp)
- **Key edge cases handled:**
  - Empty items array → FAIL with "No login activity items found"
  - Missing or absent `login_type` parameter in event → skipped (not counted)
  - Correctly extracts `is_second_factor` as `boolValue` per Google Reports schema
  - Counts occurrences per auth type and per second factor usage
  - Aggregates across all events and items in response

## Architecture notes

All three scripts implement the standard transformation contract: `extract_input(data)` → `evaluate(data)` → `transform(input)` → `create_response(...)`. Input extraction handles multiple wrapper formats (api_response, response, result, apiResponse, Output) for compatibility. Output response schema is consistently v1.0 with `transformedResponse`, `additionalInfo` (dataCollection, validation, transformation, evaluation, metadata), and structured pass/fail reason arrays. Scripts use only basic Python (no eval, exec, __import__) and are RestrictedPython-compatible for sandbox execution.

## Test plan

- [x] Each script passes PyCodeExecutor sandbox validation (validation results: all success)
- [ ] Verify `evaluate()` returns correct result for:
  - [ ] isAuditLoggingEnabled: valid data (items array with events), empty items array, missing nested fields
  - [ ] confirmPasswordPolicyEnforced: valid user data, users with/without changePasswordAtNextLogin flag, suspended users, empty users array
  - [ ] authTypesAllowed: valid login events, empty items, events with/without login_type parameter
- [ ] Confirm field names in `data.get("...")` calls match vendor API documentation:
  - [ ] isAuditLoggingEnabled: actor.email, events, id.time, event.name, event.parameters
  - [ ] confirmPasswordPolicyEnforced: users, suspended, changePasswordAtNextLogin, primaryEmail
  - [ ] authTypesAllowed: items, events, parameters, login_type (value), is_second_factor (boolValue)
- [ ] Spot-check `create_response()` output structure matches schema v1.0 (transformedResponse, additionalInfo with dataCollection, validation, transformation, evaluation, metadata)
- [ ] Test API error responses (items array may be empty if Reports API returns stat: FAIL or no data in time window)
- [ ] Verify datetime.utcnow().isoformat() + "Z" produces RFC3339 timestamps

## Known observations

**isAuditLoggingEnabled:**
- Parse_event_time() function is defined but never called (dead code; can be removed)
- Event time comparison uses string comparison (`event_time > most_recent_time`), which works for ISO8601 but is fragile; consider explicit datetime parsing if time precision matters
- **Important assumption:** Script infers "audit logging enabled" from the presence of any admin activity in the evaluation window. If an organization has legitimately zero admin activity during the query period, the check would incorrectly fail. Consider documenting that this validates "recent activity detected" rather than "audit logging feature is enabled" — it's a data presence check, not a configuration check.

**confirmPasswordPolicyEnforced:**
- Well-designed compliance scoring and clear pass/fail logic
- Correctly handles pagination via merged user results from getUsers
- Recommendations list truncated to first 10 users if more than 10 have pending changes

**authTypesAllowed:**
- **Semantic clarity issue:** Criteria name "authTypesAllowed" suggests policy-level enforcement (e.g., "only SAML is allowed"), but the actual check is data discovery ("these auth types are in use"). The boolean passes as long as at least one auth type is detected. Consider clarifying whether the intended check is:
  1. "Data collection works: we can see login activity" (current behavior), or
  2. "Organization is enforcing strong authentication" (would require policy/config check)
- The "hasStrongAuthType" flag is computed but only appears in additionalInfo, not in the boolean pass/fail logic
- Field `is_second_factor` correctly extracts boolValue per Google schema; multiValue fallback not attempted (acceptable if login_type only uses value field)

Generated by Spektrum integration onboarding pipeline
