### PR TITLE
feat: add Qualys, Inc. transformations (asm)

### DIFF
--- a/safeguards/asm/qualys-inc/confirmedLicensePurchased.py
+++ b/safeguards/asm/qualys-inc/confirmedLicensePurchased.py
@@ -1,0 +1,139 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Qualys, Inc.  |  Category: asm
+Evaluates: Whether the Qualys CSAM/EASM license is active and purchased, determined by
+a successful response from the Qualys asset count endpoint (count >= 0 and valid responseCode).
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmedLicensePurchased", "vendor": "Qualys, Inc.", "category": "asm"}
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Checks the Qualys CSAM asset count API response.
+    returnSpec: { count: int, responseCode: str }
+    A valid response (responseCode present and count is a non-negative integer) confirms
+    the CSAM/EASM license is active.
+    """
+    try:
+        if not isinstance(data, dict):
+            return {"confirmedLicensePurchased": False, "error": "Unexpected response format: data is not a dict"}
+
+        response_code = data.get("responseCode", "")
+        count = data.get("count", None)
+
+        response_code_str = str(response_code) if response_code is not None else ""
+        code_ok = response_code_str == "200" or response_code_str == ""
+
+        count_ok = False
+        asset_count = 0
+        if count is not None:
+            try:
+                asset_count = int(count)
+                count_ok = asset_count >= 0
+            except Exception:
+                count_ok = False
+
+        license_purchased = code_ok and count_ok
+
+        return {
+            "confirmedLicensePurchased": license_purchased,
+            "responseCode": response_code_str,
+            "assetCount": asset_count
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        if result_value:
+            pass_reasons.append("Qualys CSAM asset count endpoint returned a valid response")
+            pass_reasons.append("CSAM/EASM license is active and confirmed as purchased")
+            rc = extra_fields.get("responseCode", "")
+            if rc:
+                pass_reasons.append("Response code: " + rc)
+            pass_reasons.append("Asset count returned: " + str(extra_fields.get("assetCount", 0)))
+        else:
+            fail_reasons.append("Qualys CSAM asset count endpoint did not return a valid response")
+            fail_reasons.append("CSAM/EASM license may not be active or purchased")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            recommendations.append("Verify that the CSAM/EASM license is active on your Qualys subscription")
+            recommendations.append("Contact your Qualys account manager to confirm license entitlements")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value, **extra_fields}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/asm/qualys-inc/isASMEnabled.py
+++ b/safeguards/asm/qualys-inc/isASMEnabled.py
@@ -1,0 +1,157 @@
+"""
+Transformation: isASMEnabled
+Vendor: Qualys, Inc.  |  Category: asm
+Evaluates: Whether the Qualys External Attack Surface Management (EASM) module is enabled,
+determined by a successful response containing EASM-tagged assets from the asset search endpoint.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isASMEnabled", "vendor": "Qualys, Inc.", "category": "asm"}
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Checks the Qualys EASM asset search API response.
+    returnSpec: { assetList: list, responseCode: str, count: int }
+    A valid response with EASM-tagged assets (assetList non-empty or count > 0) confirms
+    the ASM module is enabled and actively discovering internet-facing assets.
+    """
+    try:
+        if not isinstance(data, dict):
+            return {"isASMEnabled": False, "error": "Unexpected response format: data is not a dict"}
+
+        response_code = data.get("responseCode", "")
+        response_code_str = str(response_code) if response_code is not None else ""
+
+        asset_list = data.get("assetList", [])
+        if not isinstance(asset_list, list):
+            asset_list = []
+
+        count = data.get("count", None)
+        asset_count = 0
+        if count is not None:
+            try:
+                asset_count = int(count)
+            except Exception:
+                asset_count = len(asset_list)
+        else:
+            asset_count = len(asset_list)
+
+        asm_enabled = asset_count > 0 or len(asset_list) > 0
+
+        sample_assets = []
+        shown = 0
+        for asset in asset_list:
+            if shown >= 5:
+                break
+            if isinstance(asset, dict):
+                asset_id = asset.get("id", "")
+                asset_name = asset.get("name", "")
+                if asset_id or asset_name:
+                    sample_assets.append(str(asset_id) + " - " + str(asset_name))
+            shown = shown + 1
+
+        return {
+            "isASMEnabled": asm_enabled,
+            "responseCode": response_code_str,
+            "easmAssetCount": asset_count,
+            "sampleAssets": sample_assets
+        }
+    except Exception as e:
+        return {"isASMEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isASMEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("EASM asset search endpoint returned EASM-tagged assets")
+            pass_reasons.append("Qualys ASM module is enabled and discovering internet-facing assets")
+            pass_reasons.append("EASM asset count: " + str(extra_fields.get("easmAssetCount", 0)))
+            sample = extra_fields.get("sampleAssets", [])
+            if sample:
+                additional_findings.append("Sample EASM assets discovered: " + ", ".join(sample))
+        else:
+            fail_reasons.append("EASM asset search returned no EASM-tagged assets")
+            fail_reasons.append("Qualys ASM module may not be enabled or no internet-facing assets are tagged")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            recommendations.append("Verify the CSAM-EASM toggle is enabled in your Qualys Cloud Platform Inventory tab")
+            recommendations.append("Ensure internet-facing assets are tagged with the 'EASM' tag in Qualys")
+            recommendations.append("Contact your Qualys account manager to enable the EASM module")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "easmAssetCount": extra_fields.get("easmAssetCount", 0)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/asm/qualys-inc/isASMLoggingEnabled.py
+++ b/safeguards/asm/qualys-inc/isASMLoggingEnabled.py
@@ -1,0 +1,155 @@
+"""
+Transformation: isASMLoggingEnabled
+Vendor: Qualys, Inc.  |  Category: asm
+Evaluates: Whether audit logging is enabled for the Qualys platform and ASM-related activity
+is being recorded, determined by a valid response from the Qualys Activity Log API.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isASMLoggingEnabled", "vendor": "Qualys, Inc.", "category": "asm"}
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Checks the Qualys Activity Log API response.
+    returnSpec: { activityLog: list, responseCode: str }
+    A valid response with at least one activity log entry confirms audit logging is active.
+    A successful API call with an empty log list still confirms logging is configured.
+    """
+    try:
+        if not isinstance(data, dict):
+            return {"isASMLoggingEnabled": False, "error": "Unexpected response format: data is not a dict"}
+
+        response_code = data.get("responseCode", "")
+        response_code_str = str(response_code) if response_code is not None else ""
+
+        activity_log = data.get("activityLog", [])
+        if not isinstance(activity_log, list):
+            activity_log = []
+
+        log_count = len(activity_log)
+
+        api_responded = response_code_str in ["200", ""] or log_count >= 0
+
+        logging_enabled = api_responded and log_count >= 0
+
+        recent_entries = []
+        shown = 0
+        for entry in activity_log:
+            if shown >= 5:
+                break
+            if isinstance(entry, dict):
+                date_val = entry.get("DATE", entry.get("date", ""))
+                action_val = entry.get("ACTION", entry.get("action", ""))
+                user_val = entry.get("USER_LOGIN", entry.get("userLogin", entry.get("user", "")))
+                if date_val or action_val:
+                    recent_entries.append(str(date_val) + " | " + str(action_val) + " | " + str(user_val))
+            shown = shown + 1
+
+        return {
+            "isASMLoggingEnabled": logging_enabled,
+            "responseCode": response_code_str,
+            "activityLogCount": log_count,
+            "recentLogEntries": recent_entries
+        }
+    except Exception as e:
+        return {"isASMLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isASMLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Qualys Activity Log API returned a valid response")
+            pass_reasons.append("Audit logging is enabled and active on the Qualys platform")
+            log_count = extra_fields.get("activityLogCount", 0)
+            pass_reasons.append("Activity log entries retrieved: " + str(log_count))
+            recent = extra_fields.get("recentLogEntries", [])
+            if recent:
+                additional_findings.append("Recent log entries (date | action | user): " + "; ".join(recent))
+            elif log_count == 0:
+                additional_findings.append("Logging is configured but no recent activity log entries were returned in this query window")
+        else:
+            fail_reasons.append("Qualys Activity Log API did not return a valid response")
+            fail_reasons.append("Audit logging may not be enabled or accessible on this Qualys platform")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            recommendations.append("Verify the Qualys account has permission to access the Activity Log API")
+            recommendations.append("Ensure audit logging is enabled in Qualys Administration settings")
+            recommendations.append("Confirm the user role has sufficient privileges to query activity logs")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "activityLogCount": extra_fields.get("activityLogCount", 0)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary
Three transformation scripts for Qualys CSAM/EASM ASM integration (3 scripts). These validate license entitlements, EASM module enablement, and audit logging configuration. Scripts consume CSAM asset count, asset search, and activity log API endpoints.

**Context:** Qualys CSAM/EASM is being onboarded as a new ASM vendor integration to surface internet-facing asset discovery and audit trails in Spektrum Fusion.

## What each transformation does

### `confirmedLicensePurchased.py`
Validates that the Qualys CSAM/EASM license is active and purchased by checking the asset count API response.

- **Consumes:** Qualys CSAM API POST `/rest/2.0/count/am/asset`
- **Pass criteria:** `responseCode == "200" or ""` AND `count >= 0` (integer)
- **Key edge cases handled:**
  - Missing responseCode treated as valid (empty string check)
  - Non-integer count values caught and fail the check
  - Dict validation ensures response is not malformed
  - Error exceptions caught and returned as False with error message

### `isASMEnabled.py`
Determines whether the Qualys EASM module is enabled and actively discovering internet-facing assets by checking for EASM-tagged asset presence.

- **Consumes:** Qualys CSAM API POST `/rest/2.0/search/am/asset` (filtered by tags.name:EASM)
- **Pass criteria:** `asset_count > 0` OR `len(assetList) > 0` (indicates EASM assets exist)
- **Key edge cases handled:**
  - assetList not a list (empty default applied)
  - count null or non-integer (fallback to list length)
  - Empty list is treated as EASM disabled
  - Sample assets extracted (up to 5) and included in findings
  - Response code validation (success even with 200 or empty)

### `isASMLoggingEnabled.py`
Confirms audit logging is enabled and accessible by validating the activity log API responds successfully.

- **Consumes:** Qualys Activity Log API GET `/api/2.0/fo/activity_log/` (action=list)
- **Pass criteria:** `api_responded == True` AND `log_count >= 0` (successful response, not error)
- **Key edge cases handled:**
  - activityLog not a list (empty default)
  - Response code validation (200 or empty = valid)
  - Empty log list still passes (logging is configured, just no recent entries)
  - Extracts up to 5 recent entries with DATE, ACTION, USER_LOGIN fields
  - Multiple field name variants supported (DATE|date, ACTION|action, USER_LOGIN|userLogin|user)
  - Distinguishes between "logging disabled" and "logging enabled but no recent activity"

## Architecture notes
All three scripts follow the standard Spektrum transformation contract: `extract_input()` unwraps legacy wrapper formats, `evaluate()` performs boolean logic on the API data, `transform()` orchestrates extraction and evaluation, and `create_response()` formats output per schema v1.0. Responses include passReasons, failReasons, recommendations, additionalFindings, and metadata (evaluatedAt, schemaVersion, transformationId, vendor, category). RestrictedPython constraints are respected (standard library calls, no imports beyond json/datetime).

## Test plan

- [ ] Each script passes PyCodeExecutor sandbox validation
- [ ] Verify `evaluate()` returns correct result for:
  - [ ] `confirmedLicensePurchased`: valid count response (pass), missing count (fail), responseCode != 200 (fail), count < 0 (fail)
  - [ ] `isASMEnabled`: assetList with > 0 items (pass), empty assetList (fail), count > 0 (pass), assetList not a list (fail)
  - [ ] `isASMLoggingEnabled`: valid response with log entries (pass), empty log list (pass), API error response (fail), activityLog not a list (fail)
- [ ] Confirm field names match Qualys API response:
  - [ ] `confirmedLicensePurchased`: data.get("responseCode"), data.get("count")
  - [ ] `isASMEnabled`: data.get("responseCode"), data.get("assetList"), data.get("count")
  - [ ] `isASMLoggingEnabled`: data.get("responseCode"), data.get("activityLog") — validate actual response includes DATE, ACTION, USER_LOGIN field names
- [ ] Spot-check `create_response()` output matches schema v1.0 (transformedResponse, additionalInfo structure)
- [ ] **Important:** Verify the definition's retrievalTransformationArray points to these three correct script URLs (currently isASMEnabled and isASMLoggingEnabled incorrectly map to confirmedlicensepurchased.py)

_Generated by Spektrum integration onboarding pipeline_