### PR TITLE
feat: add Rubrik transformations (control-objectives-for-information-and-related-technologies-cobit)

### DIFF
--- a/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/confirmedLicensePurchased.py
+++ b/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/confirmedLicensePurchased.py
@@ -1,0 +1,202 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Rubrik  |  Category: control-objectives-for-information-and-related-technologies-cobit
+Evaluates: Whether a valid Rubrik CDM license has been purchased and the cluster is actively deployed.
+Checks GET /api/v1/cluster/me for a non-empty cluster id and version, confirming the product
+is licensed and operational.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "Rubrik",
+                "category": "control-objectives-for-information-and-related-technologies-cobit"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        cluster_id = data.get("id", "")
+        version = data.get("version", "")
+        api_version = data.get("apiVersion", "")
+        cluster_name = data.get("name", "")
+        accepted_eula = data.get("acceptedEulaVersion", "")
+        latest_eula = data.get("latestEulaVersion", "")
+
+        has_cluster_id = isinstance(cluster_id, str) and len(cluster_id) > 0
+        has_version = isinstance(version, str) and len(version) > 0
+        eula_accepted = False
+        if accepted_eula and latest_eula:
+            eula_accepted = accepted_eula == latest_eula
+        elif accepted_eula:
+            eula_accepted = True
+
+        license_confirmed = has_cluster_id and has_version
+
+        return {
+            "confirmedLicensePurchased": license_confirmed,
+            "clusterId": cluster_id,
+            "clusterName": cluster_name,
+            "clusterVersion": version,
+            "apiVersion": api_version,
+            "acceptedEulaVersion": accepted_eula,
+            "latestEulaVersion": latest_eula,
+            "eulaUpToDate": eula_accepted,
+            "hasClusterId": has_cluster_id,
+            "hasVersion": has_version
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        cluster_id = eval_result.get("clusterId", "")
+        cluster_name = eval_result.get("clusterName", "")
+        cluster_version = eval_result.get("clusterVersion", "")
+        api_version = eval_result.get("apiVersion", "")
+        accepted_eula = eval_result.get("acceptedEulaVersion", "")
+        latest_eula = eval_result.get("latestEulaVersion", "")
+        eula_up_to_date = eval_result.get("eulaUpToDate", False)
+        has_cluster_id = eval_result.get("hasClusterId", False)
+        has_version = eval_result.get("hasVersion", False)
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                "Rubrik CDM cluster is operational and returned a valid cluster ID and version, "
+                "confirming a licensed product is actively deployed."
+            )
+            if cluster_name:
+                pass_reasons.append("Cluster name: " + cluster_name)
+            if cluster_version:
+                additional_findings.append("Rubrik CDM version: " + cluster_version)
+            if api_version:
+                additional_findings.append("REST API version: " + api_version)
+            if eula_up_to_date:
+                additional_findings.append(
+                    "EULA is accepted and up to date (version: " + accepted_eula + ")."
+                )
+            elif accepted_eula and latest_eula and accepted_eula != latest_eula:
+                additional_findings.append(
+                    "EULA version mismatch: accepted=" + accepted_eula +
+                    ", latest=" + latest_eula + ". Consider accepting the updated EULA."
+                )
+        else:
+            if not has_cluster_id:
+                fail_reasons.append(
+                    "GET /api/v1/cluster/me did not return a valid cluster ID. "
+                    "The Rubrik CDM cluster may not be properly licensed or accessible."
+                )
+            if not has_version:
+                fail_reasons.append(
+                    "GET /api/v1/cluster/me did not return a software version. "
+                    "The Rubrik CDM cluster may not be properly licensed or accessible."
+                )
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+            recommendations.append(
+                "Verify that the Rubrik CDM cluster is fully operational and that a valid Rubrik "
+                "license has been applied. Ensure the cluster address and credentials are correct."
+            )
+
+        return create_response(
+            result={
+                criteriaKey: result_value,
+                "clusterId": cluster_id,
+                "clusterName": cluster_name,
+                "clusterVersion": cluster_version,
+                "apiVersion": api_version,
+                "eulaUpToDate": eula_up_to_date
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "clusterId": cluster_id,
+                "clusterVersion": cluster_version,
+                "confirmedLicensePurchased": result_value
+            }
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupEnabled.py
+++ b/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupEnabled.py
@@ -1,0 +1,161 @@
+"""
+Transformation: isBackupEnabled
+Vendor: Rubrik  |  Category: control-objectives-for-information-and-related-technologies-cobit
+Evaluates: Whether backup policies (SLA Domains) are configured in Rubrik CDM.
+A non-empty data array from GET /api/v1/sla_domain indicates that one or more SLA Domain
+backup policies are active, confirming backups are enabled.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isBackupEnabled",
+                "vendor": "Rubrik",
+                "category": "control-objectives-for-information-and-related-technologies-cobit"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        sla_domains = data.get("data", [])
+        if not isinstance(sla_domains, list):
+            sla_domains = []
+
+        total_domains = len(sla_domains)
+        is_enabled = total_domains > 0
+
+        domain_names = []
+        for domain in sla_domains:
+            name = domain.get("name", "")
+            if name:
+                domain_names.append(name)
+
+        return {
+            "isBackupEnabled": is_enabled,
+            "totalSlaDomains": total_domains,
+            "slaDomainNames": domain_names
+        }
+    except Exception as e:
+        return {"isBackupEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        total_domains = eval_result.get("totalSlaDomains", 0)
+        domain_names = eval_result.get("slaDomainNames", [])
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                "Rubrik CDM has " + str(total_domains) + " active SLA Domain backup polic" +
+                ("ies" if total_domains != 1 else "y") + " configured, confirming backups are enabled."
+            )
+            if domain_names:
+                additional_findings.append("Active SLA Domains: " + ", ".join(domain_names))
+        else:
+            fail_reasons.append(
+                "No SLA Domain backup policies were found in Rubrik CDM. "
+                "The GET /api/v1/sla_domain response returned an empty data array."
+            )
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+            recommendations.append(
+                "Create at least one SLA Domain in Rubrik CDM to define backup schedules "
+                "and retention policies for your protected workloads."
+            )
+
+        return create_response(
+            result={
+                criteriaKey: result_value,
+                "totalSlaDomains": total_domains,
+                "slaDomainNames": domain_names
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "totalSlaDomains": total_domains,
+                "isBackupEnabled": result_value
+            }
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupTested.py
+++ b/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupTested.py
@@ -1,0 +1,205 @@
+"""
+Transformation: isBackupTested
+Vendor: Rubrik  |  Category: control-objectives-for-information-and-related-technologies-cobit
+Evaluates: Whether recent backup jobs have executed successfully in Rubrik CDM.
+Checks GET /api/v1/event/latest (event_type=Backup) for events with a successful completion
+status, confirming that backups have been run and tested.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isBackupTested",
+                "vendor": "Rubrik",
+                "category": "control-objectives-for-information-and-related-technologies-cobit"
+            }
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        events = data.get("data", [])
+        if not isinstance(events, list):
+            events = []
+
+        total_events = len(events)
+        successful_count = 0
+        failed_count = 0
+        running_count = 0
+        successful_objects = []
+        failed_objects = []
+
+        success_statuses = ["Success", "Succeeded", "Succeeded with warnings", "SucceededWithWarnings"]
+
+        for event in events:
+            latest = event.get("latestEvent", event)
+            status = latest.get("eventStatus", latest.get("status", ""))
+            obj_name = latest.get("objectName", latest.get("objectId", "unknown"))
+
+            if status in success_statuses:
+                successful_count = successful_count + 1
+                successful_objects.append(obj_name)
+            elif status in ["Failure", "Failed"]:
+                failed_count = failed_count + 1
+                failed_objects.append(obj_name)
+            elif status in ["Running", "Queued"]:
+                running_count = running_count + 1
+
+        is_tested = successful_count > 0
+
+        return {
+            "isBackupTested": is_tested,
+            "totalBackupEvents": total_events,
+            "successfulBackups": successful_count,
+            "failedBackups": failed_count,
+            "runningBackups": running_count,
+            "successfulObjects": successful_objects,
+            "failedObjects": failed_objects
+        }
+    except Exception as e:
+        return {"isBackupTested": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupTested"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        total_events = eval_result.get("totalBackupEvents", 0)
+        successful_count = eval_result.get("successfulBackups", 0)
+        failed_count = eval_result.get("failedBackups", 0)
+        running_count = eval_result.get("runningBackups", 0)
+        successful_objects = eval_result.get("successfulObjects", [])
+        failed_objects = eval_result.get("failedObjects", [])
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                str(successful_count) + " of " + str(total_events) +
+                " recent backup job event(s) completed successfully, confirming backups have been tested."
+            )
+            if successful_objects:
+                trimmed = successful_objects[:5]
+                additional_findings.append(
+                    "Sample successfully backed-up objects: " + ", ".join(trimmed)
+                )
+        else:
+            if total_events == 0:
+                fail_reasons.append(
+                    "No backup job events were returned by GET /api/v1/event/latest. "
+                    "No backup activity could be confirmed."
+                )
+            else:
+                fail_reasons.append(
+                    str(total_events) + " backup event(s) found but none have a successful completion status. "
+                    "Backups may not be running or may be consistently failing."
+                )
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+            recommendations.append(
+                "Ensure Rubrik SLA Domain policies are assigned to workloads and that backup jobs "
+                "are completing successfully. Review the Rubrik event log for failure details."
+            )
+
+        if failed_count > 0:
+            additional_findings.append(
+                str(failed_count) + " failed backup job(s) detected for: " + ", ".join(failed_objects[:5])
+            )
+        if running_count > 0:
+            additional_findings.append(str(running_count) + " backup job(s) currently running or queued.")
+
+        return create_response(
+            result={
+                criteriaKey: result_value,
+                "totalBackupEvents": total_events,
+                "successfulBackups": successful_count,
+                "failedBackups": failed_count,
+                "runningBackups": running_count
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "totalBackupEvents": total_events,
+                "successfulBackups": successful_count,
+                "failedBackups": failed_count,
+                "isBackupTested": result_value
+            }
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Onboards Rubrik CDM (Cloud Data Management) as a new backup/disaster recovery vendor for COBIT compliance assessment. Three transformations evaluate backup policy configuration, recent backup success, and license validity through REST API calls to Rubrik's v1 endpoints. All scripts follow the standard Spektrum transformation contract and pass RestrictedPython sandbox validation.

**Context:** Rubrik CDM integration pipeline; validates backup configuration and execution state for disaster recovery readiness in COBIT control domain.

## What each transformation does

### `isBackupEnabled.py`
Confirms that at least one SLA Domain (backup policy) is configured in Rubrik CDM, indicating the backup system is enabled and ready to protect workloads.

- **Consumes:** Rubrik CDM REST API v1 `GET /api/v1/sla_domain` (paginated list of SLA Domains)
- **Pass criteria:** `data` array returned from `/api/v1/sla_domain` contains at least one SLA Domain object (len(sla_domains) > 0)
- **Key edge cases handled:**
  - Empty SLA Domains array (`data: []`) → FAIL with recommendation to create at least one SLA Domain
  - Missing or malformed `data` field → defaults to empty list, evaluates as FAIL
  - Non-list `data` value → type-checks and defaults to empty list
  - Successfully extracted domain names added to additionalFindings for visibility

### `isBackupTested.py`
Verifies that recent backup jobs have executed successfully by examining event records from the Rubrik event log, confirming the backup system is actively protecting data.

- **Consumes:** Rubrik CDM REST API v1 `GET /api/v1/event/latest?event_type=Backup&limit=100&order_by_time=desc` (recent backup job events)
- **Pass criteria:** At least one event exists in the `data` array AND at least one event has `eventStatus` or `status` field matching one of: "Success", "Succeeded", "Succeeded with warnings", or "SucceededWithWarnings"
- **Key edge cases handled:**
  - No events returned (`data: []`) → FAIL with specific message "No backup job events were returned"
  - Events present but none successful → FAIL with count of successful vs. total
  - Mixed status events → counts successful, failed, and running separately; additionalFindings reports all three categories
  - Nested event structure (latestEvent within event object) → checks both `latestEvent.eventStatus` and direct `status` field
  - Sample object names (up to 5) extracted and included in findings for audit trail

### `confirmedLicensePurchased.py`
Verifies that a valid Rubrik CDM license is active by confirming the cluster is operational and returns valid cluster metadata including ID, version, and EULA acceptance status.

- **Consumes:** Rubrik CDM REST API v1 `GET /api/v1/cluster/me` (authenticated cluster information endpoint)
- **Pass criteria:** BOTH `id` field is non-empty string AND `version` field is non-empty string. Optional: checks EULA acceptance (accepted version matches latest version) and reports mismatch as informational finding.
- **Key edge cases handled:**
  - Missing `id` or `version` field → FAIL with specific detail on which field is missing
  - Empty string values for id/version → treated as missing (len > 0 check)
  - EULA version mismatch (accepted != latest) → PASS but include warning in additionalFindings
  - No EULA info in response → does not block pass, only reports if both versions present
  - Cluster name, API version included in additionalFindings for context

## Architecture notes

All three scripts implement the standard Spektrum transformation contract:
1. **extract_input()** - Unwraps nested API response wrappers (api_response, response, result, apiResponse, Output) up to 3 levels deep; returns (data dict, validation status)
2. **evaluate()** - Core business logic; returns dict with criteriaKey boolean result + supporting data (counts, lists, errors)
3. **create_response()** - Standardized schema v1.0 wrapping; includes transformation metadata, validation info, evaluation reasons (pass/fail/recommendations), and additional findings
4. **transform()** - Entry point; handles JSON/bytes input parsing, calls extract_input/evaluate, builds detailed response with human-readable reasoning

Each script returns `{transformedResponse, additionalInfo}` where additionalInfo includes dataCollection status, validation warnings, transformation errors, and evaluation reasons (passReasons, failReasons, recommendations, additionalFindings). Metadata includes evaluatedAt timestamp, schemaVersion (1.0), transformationId, vendor, and category.

## Test plan

- [x] Each script passes `PyCodeExecutor` sandbox validation (per validation results: all status="success")
- [ ] Verify `evaluate()` returns correct result for:
  - [x] Valid data: isBackupEnabled (empty array → false, non-empty → true), isBackupTested (success statuses present → true), confirmedLicensePurchased (id + version present → true)
  - [x] Missing fields: all scripts check field existence with .get() defaults and type validation
  - [x] API error responses: scripts handle stat: FAIL implicitly (no fatal exception, return False result)
- [ ] Confirm field names in `data.get("...")` match vendor API documentation:
  - [x] `/sla_domain` returns `{data: [], total: int, hasMore: bool}` - confirmed
  - [x] `/event/latest` returns `{data: [{latestEvent or direct status/objectName}]}` - confirmed via Rubrik scripts reference
  - [x] `/cluster/me` returns `{id, version, apiVersion, name, acceptedEulaVersion, latestEulaVersion}` - confirmed via API docs
- [ ] Spot-check `create_response()` output matches schema version 1.0:
  - [x] transformedResponse contains criteriaKey boolean + supporting fields
  - [x] additionalInfo.evaluation contains {passReasons, failReasons, recommendations, additionalFindings}
  - [x] additionalInfo.metadata includes evaluatedAt, schemaVersion: 1.0, transformationId, vendor, category
- [ ] Manual integration test: run isBackupEnabled with real/mocked GET /sla_domain response to verify pass/fail reasoning is clear
- [ ] Manual integration test: run isBackupTested with event response containing mixed statuses to verify all three counters (successful, failed, running) are correct
- [ ] Manual integration test: run confirmedLicensePurchased with missing version field to verify fail reason is specific

**Generated by Spektrum integration onboarding pipeline**
