### PR TITLE
feat: add Rubrik transformations (control-objectives-for-information-and-related-technologies-cobit)

### DIFF
--- a/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/confirmedLicensePurchased.py
+++ b/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/confirmedLicensePurchased.py
@@ -1,0 +1,194 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Rubrik  |  Category: control-objectives-for-information-and-related-technologies-cobit
+Evaluates: Confirms the Rubrik Security Cloud subscription is active by verifying that
+authenticated API access returns a valid currentUser object with a non-empty email address
+and at least one assigned role — indicating a licensed RSC instance is in use.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "Rubrik",
+                "category": "control-objectives-for-information-and-related-technologies-cobit"
+            }
+        }
+    }
+
+
+def extract_current_user(data):
+    """
+    Extract currentUser object from multiple possible data shapes.
+    getCurrentUser returnSpec: data = data.currentUser
+    So the transformation input 'data' field should be the currentUser object
+    with shape {email, roles: [{name, description}]}
+    """
+    if isinstance(data, dict):
+        if "email" in data:
+            return data
+        inner = data.get("data", None)
+        if isinstance(inner, dict) and "email" in inner:
+            return inner
+        user = data.get("currentUser", None)
+        if isinstance(user, dict):
+            return user
+        if isinstance(inner, dict):
+            user2 = inner.get("currentUser", None)
+            if isinstance(user2, dict):
+                return user2
+    return {}
+
+
+def evaluate(data):
+    """Core evaluation logic for confirmedLicensePurchased."""
+    try:
+        user = extract_current_user(data)
+
+        email = user.get("email", "")
+        roles = user.get("roles", [])
+        if not isinstance(roles, list):
+            roles = []
+
+        has_valid_email = isinstance(email, str) and len(email) > 0
+        has_roles = len(roles) > 0
+
+        role_names = [r.get("name", "unknown") for r in roles if isinstance(r, dict)]
+
+        confirmed_license_purchased = has_valid_email and has_roles
+
+        return {
+            "confirmedLicensePurchased": confirmed_license_purchased,
+            "authenticatedUserEmail": email,
+            "assignedRoleCount": len(role_names),
+            "assignedRoles": role_names,
+            "hasValidEmail": has_valid_email,
+            "hasAssignedRoles": has_roles
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                "Rubrik Security Cloud subscription confirmed active: authenticated API access "
+                "returned a valid user object with email and assigned roles"
+            )
+            pass_reasons.append(
+                "Authenticated as: " + eval_result.get("authenticatedUserEmail", "unknown")
+            )
+            role_names = eval_result.get("assignedRoles", [])
+            if role_names:
+                additional_findings.append(
+                    "Assigned roles (" + str(len(role_names)) + "): " + ", ".join(role_names)
+                )
+        else:
+            if not eval_result.get("hasValidEmail"):
+                fail_reasons.append(
+                    "No valid email address returned for the authenticated user — "
+                    "API access may be unauthenticated or the account is invalid"
+                )
+            if not eval_result.get("hasAssignedRoles"):
+                fail_reasons.append(
+                    "No roles assigned to the authenticated user — "
+                    "a licensed RSC instance should have at least one role configured"
+                )
+            recommendations.append(
+                "Verify that the Rubrik Security Cloud service account has a valid license and at least one role assigned. "
+                "Confirm the RSC subscription is active at https://<accountName>.my.rubrik.com."
+            )
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+
+        input_summary = {
+            "authenticatedUserEmail": eval_result.get("authenticatedUserEmail", ""),
+            "assignedRoleCount": eval_result.get("assignedRoleCount", 0)
+        }
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_summary,
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupEnabled.py
+++ b/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupEnabled.py
@@ -1,0 +1,237 @@
+"""
+Transformation: isBackupEnabled
+Vendor: Rubrik  |  Category: control-objectives-for-information-and-related-technologies-cobit
+Evaluates: Verifies that at least one active SLA Domain backup policy exists with a configured
+snapshot schedule (daily, weekly, or monthly), AND that the count of objects with
+protectionStatus Protected is greater than zero — confirming backup protection is enabled
+in Rubrik Security Cloud.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isBackupEnabled",
+                "vendor": "Rubrik",
+                "category": "control-objectives-for-information-and-related-technologies-cobit"
+            }
+        }
+    }
+
+
+def find_sla_domains(data):
+    """
+    Attempt to extract SLA domain nodes from multiple possible data shapes.
+    getSLADomains returnSpec: data = data.slaDomains.nodes (array of domain objects)
+    When merged with getProtectedObjects (also uses key 'data'), the SLA domains
+    list may be at the top-level 'data' key or nested under 'slaDomains'.
+    """
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        inner = data.get("data", None)
+        if isinstance(inner, list):
+            return inner
+        sla = data.get("slaDomains", {})
+        if isinstance(sla, dict):
+            nodes = sla.get("nodes", [])
+            if isinstance(nodes, list):
+                return nodes
+        if isinstance(inner, dict):
+            sla2 = inner.get("slaDomains", {})
+            if isinstance(sla2, dict):
+                nodes2 = sla2.get("nodes", [])
+                if isinstance(nodes2, list):
+                    return nodes2
+    return []
+
+
+def find_protected_objects(data):
+    """
+    Attempt to extract snappableConnection from multiple possible data shapes.
+    getProtectedObjects returnSpec: data = data.snappableConnection
+    Returns (count, nodes) tuple.
+    """
+    if isinstance(data, dict):
+        snap = data.get("snappableConnection", None)
+        if isinstance(snap, dict):
+            return snap.get("count", 0), snap.get("nodes", [])
+        inner = data.get("data", {})
+        if isinstance(inner, dict):
+            snap2 = inner.get("snappableConnection", None)
+            if isinstance(snap2, dict):
+                return snap2.get("count", 0), snap2.get("nodes", [])
+        if "count" in data and "nodes" in data:
+            return data.get("count", 0), data.get("nodes", [])
+    return 0, []
+
+
+def has_active_schedule(domain):
+    """Return True if a domain node has at least one configured snapshot schedule."""
+    schedule = domain.get("snapshotSchedule", None)
+    if not isinstance(schedule, dict):
+        return False
+    for period in ["daily", "weekly", "monthly", "yearly"]:
+        period_config = schedule.get(period, None)
+        if isinstance(period_config, dict):
+            basic = period_config.get("basicSchedule", None)
+            if isinstance(basic, dict) and basic.get("frequency", 0):
+                return True
+    return False
+
+
+def evaluate(data):
+    """Core evaluation logic for isBackupEnabled."""
+    try:
+        sla_domains = find_sla_domains(data)
+        protected_count, protected_nodes = find_protected_objects(data)
+
+        total_sla_domains = len(sla_domains)
+        active_sla_domains = [d for d in sla_domains if has_active_schedule(d)]
+        active_sla_count = len(active_sla_domains)
+        active_sla_names = [d.get("name", "unnamed") for d in active_sla_domains]
+
+        if protected_count == 0 and isinstance(protected_nodes, list) and len(protected_nodes) > 0:
+            protected_count = len(protected_nodes)
+
+        sla_enabled = active_sla_count > 0
+        objects_protected = protected_count > 0
+
+        is_backup_enabled = sla_enabled or objects_protected
+
+        return {
+            "isBackupEnabled": is_backup_enabled,
+            "totalSlaDomains": total_sla_domains,
+            "activeSlaDomains": active_sla_count,
+            "activeSlaNames": active_sla_names,
+            "protectedObjectCount": protected_count,
+            "slaDomainCheckPassed": sla_enabled,
+            "protectedObjectsCheckPassed": objects_protected
+        }
+    except Exception as e:
+        return {"isBackupEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            if eval_result.get("slaDomainCheckPassed"):
+                pass_reasons.append(
+                    str(eval_result.get("activeSlaDomains", 0)) +
+                    " active SLA Domain(s) with configured snapshot schedules found"
+                )
+                active_names = eval_result.get("activeSlaNames", [])
+                if active_names:
+                    additional_findings.append("Active SLA Domains: " + ", ".join(active_names))
+            if eval_result.get("protectedObjectsCheckPassed"):
+                pass_reasons.append(
+                    str(eval_result.get("protectedObjectCount", 0)) +
+                    " protected object(s) confirmed under active SLA Domains"
+                )
+        else:
+            if not eval_result.get("slaDomainCheckPassed"):
+                fail_reasons.append(
+                    "No active SLA Domains with configured snapshot schedules found "
+                    "(total SLA Domains: " + str(eval_result.get("totalSlaDomains", 0)) + ")"
+                )
+                recommendations.append(
+                    "Create and activate at least one SLA Domain with a daily, weekly, or monthly snapshot schedule in Rubrik Security Cloud"
+                )
+            if not eval_result.get("protectedObjectsCheckPassed"):
+                fail_reasons.append("No protected objects found under any SLA Domain")
+                recommendations.append(
+                    "Assign workloads to an active SLA Domain to ensure they are protected by backup policies"
+                )
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+
+        input_summary = {
+            "totalSlaDomains": eval_result.get("totalSlaDomains", 0),
+            "activeSlaDomains": eval_result.get("activeSlaDomains", 0),
+            "protectedObjectCount": eval_result.get("protectedObjectCount", 0)
+        }
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_summary,
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupTested.py
+++ b/safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik/isBackupTested.py
@@ -1,0 +1,196 @@
+"""
+Transformation: isBackupTested
+Vendor: Rubrik  |  Category: control-objectives-for-information-and-related-technologies-cobit
+Evaluates: Verifies that recent successful backup activity events exist
+(lastActivityType: Backup, lastActivityStatus: Success) from the activitySeriesConnection,
+confirming that backups have been executed and validated within the Rubrik Security Cloud
+environment.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isBackupTested",
+                "vendor": "Rubrik",
+                "category": "control-objectives-for-information-and-related-technologies-cobit"
+            }
+        }
+    }
+
+
+def extract_activity_connection(data):
+    """
+    Extract activitySeriesConnection from multiple possible data shapes.
+    getRecentBackupActivity returnSpec: data = data.activitySeriesConnection
+    So the transformation input 'data' field should be the activitySeriesConnection object
+    with shape {count, nodes: [{id, lastActivityType, lastActivityStatus, ...}]}
+    """
+    if isinstance(data, dict):
+        if "count" in data and "nodes" in data:
+            return data
+        inner = data.get("data", None)
+        if isinstance(inner, dict) and "count" in inner and "nodes" in inner:
+            return inner
+        conn = data.get("activitySeriesConnection", None)
+        if isinstance(conn, dict):
+            return conn
+        if isinstance(inner, dict):
+            conn2 = inner.get("activitySeriesConnection", None)
+            if isinstance(conn2, dict):
+                return conn2
+    return {}
+
+
+def evaluate(data):
+    """Core evaluation logic for isBackupTested."""
+    try:
+        conn = extract_activity_connection(data)
+        count = conn.get("count", 0)
+        nodes = conn.get("nodes", [])
+        if not isinstance(nodes, list):
+            nodes = []
+
+        confirmed_successful = [
+            n for n in nodes
+            if n.get("lastActivityType", "") == "Backup"
+            and n.get("lastActivityStatus", "") == "Success"
+        ]
+        confirmed_count = len(confirmed_successful)
+
+        effective_count = count if count > 0 else confirmed_count
+
+        sample_objects = []
+        seen = {}
+        for n in confirmed_successful:
+            obj_name = n.get("objectName", "")
+            if obj_name and obj_name not in seen:
+                seen[obj_name] = True
+                sample_objects.append(obj_name)
+            if len(sample_objects) >= 5:
+                break
+
+        is_backup_tested = effective_count > 0
+
+        return {
+            "isBackupTested": is_backup_tested,
+            "successfulBackupActivityCount": effective_count,
+            "confirmedSuccessfulEvents": confirmed_count,
+            "sampleBackedUpObjects": sample_objects
+        }
+    except Exception as e:
+        return {"isBackupTested": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBackupTested"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                str(eval_result.get("successfulBackupActivityCount", 0)) +
+                " recent successful backup activity event(s) confirmed in Rubrik Security Cloud"
+            )
+            sample = eval_result.get("sampleBackedUpObjects", [])
+            if sample:
+                additional_findings.append(
+                    "Sample successfully backed-up objects: " + ", ".join(sample)
+                )
+        else:
+            fail_reasons.append(
+                "No recent successful backup activity events found "
+                "(lastActivityType: Backup, lastActivityStatus: Success)"
+            )
+            recommendations.append(
+                "Ensure backup jobs are running successfully. Review SLA Domain assignments and check for backup failures in the Rubrik Security Cloud activity log."
+            )
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+
+        input_summary = {
+            "successfulBackupActivityCount": eval_result.get("successfulBackupActivityCount", 0),
+            "confirmedSuccessfulEvents": eval_result.get("confirmedSuccessfulEvents", 0)
+        }
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_summary,
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Adds 3 **Rubrik** (control-objectives-for-information-and-related-technologies-cobit) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Rubrik API responses against Spektrum safeguard criteria to determine whether the organization's Rubrik configuration meets security posture requirements.

**Context:** Rubrik is being onboarded as a new control-objectives-for-information-and-related-technologies-cobit vendor integration. These scripts cover the `safeguards/control-objectives-for-information-and-related-technologies-cobit/rubrik` namespace.

## What each transformation does

### `isBackupEnabled.py` (Validated)
Verifies that at least one active SLA Domain backup policy exists with a configured

- **API fields consumed:** `data`, `slaDomains`, `snappableConnection`, `count`, `nodes`
- Graceful fallback on missing keys and empty responses

### `isBackupTested.py` (Validated)
Verifies that recent successful backup activity events exist

- **API fields consumed:** `data`, `activitySeriesConnection`
- Graceful fallback on missing keys and empty responses

### `confirmedLicensePurchased.py` (Validated)
Confirms the Rubrik Security Cloud subscription is active by verifying that

- **API fields consumed:** `data`, `currentUser`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline