### PR TITLE
feat: add Crowdstrike transformations (cloud-security-alliance-star-csa-star)

### DIFF
--- a/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/confirmedLicensePurchased.py
+++ b/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/confirmedLicensePurchased.py
@@ -1,0 +1,121 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Crowdstrike  |  Category: cloud-security-alliance-star-csa-star
+Evaluates: Whether the CrowdStrike Falcon license is active and devices are enrolled.
+           A non-empty resources[] array from GET /devices/combined/devices/v1
+           confirms that the license is valid and devices are managed under the account.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmedLicensePurchased", "vendor": "Crowdstrike", "category": "cloud-security-alliance-star-csa-star"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        total_devices = len(resources)
+        license_confirmed = total_devices > 0
+
+        platform_counts = {}
+        for d in resources:
+            platform = d.get("platform_name", d.get("os_version", "unknown"))
+            if platform in platform_counts:
+                platform_counts[platform] = platform_counts[platform] + 1
+            else:
+                platform_counts[platform] = 1
+
+        return {
+            "confirmedLicensePurchased": license_confirmed,
+            "totalEnrolledDevices": total_devices,
+            "platformBreakdown": platform_counts
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "totalEnrolledDevices": 0, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        total = eval_result.get("totalEnrolledDevices", 0)
+        platform_breakdown = eval_result.get("platformBreakdown", {})
+
+        if result_value:
+            pass_reasons.append("CrowdStrike Falcon license is confirmed active -- enrolled devices are present in the account")
+            pass_reasons.append("Total enrolled devices: " + str(total))
+            if platform_breakdown:
+                for p in platform_breakdown:
+                    additional_findings.append("Platform '" + p + "': " + str(platform_breakdown[p]) + " device(s)")
+        else:
+            fail_reasons.append("No enrolled devices found -- CrowdStrike Falcon license could not be confirmed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Verify that a valid CrowdStrike Falcon license is active for this account")
+            recommendations.append("Ensure at least one endpoint has the Falcon sensor deployed and enrolled")
+            recommendations.append("Confirm API credentials have sufficient scope (hosts:read) to retrieve device inventory")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalEnrolledDevices": total}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/isEPPConfigured.py
+++ b/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/isEPPConfigured.py
@@ -1,0 +1,151 @@
+"""
+Transformation: isEPPConfigured
+Vendor: Crowdstrike  |  Category: cloud-security-alliance-star-csa-star
+Evaluates: Whether at least one enabled prevention policy contains a non-empty
+           prevention_settings object with configured detection and prevention
+           categories, confirming EPP is configured per vendor guidance.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPConfigured", "vendor": "Crowdstrike", "category": "cloud-security-alliance-star-csa-star"}
+        }
+    }
+
+
+def has_configured_settings(prevention_settings):
+    if not prevention_settings:
+        return False
+    categories = prevention_settings.get("categories", [])
+    if categories and len(categories) > 0:
+        return True
+    # Also accept if settings has any non-empty top-level keys besides categories
+    for key in prevention_settings:
+        val = prevention_settings[key]
+        if val and key != "categories":
+            return True
+    return False
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not resources:
+            return {"isEPPConfigured": False, "totalPreventionPolicies": 0, "configuredPolicies": 0, "error": "No policy resources found in API response"}
+
+        prevention_policies = [r for r in resources if "prevention_settings" in r]
+        total_count = len(prevention_policies)
+
+        if total_count == 0:
+            return {"isEPPConfigured": False, "totalPreventionPolicies": 0, "configuredPolicies": 0, "error": "No prevention policies found in merged policy data"}
+
+        configured_names = []
+        unconfigured_names = []
+        for p in prevention_policies:
+            if not p.get("enabled", False):
+                continue
+            settings = p.get("prevention_settings", {})
+            if has_configured_settings(settings):
+                configured_names.append(p.get("name", "unnamed"))
+            else:
+                unconfigured_names.append(p.get("name", "unnamed"))
+
+        configured_count = len(configured_names)
+        is_configured = configured_count > 0
+
+        return {
+            "isEPPConfigured": is_configured,
+            "totalPreventionPolicies": total_count,
+            "configuredPolicies": configured_count,
+            "configuredPolicyNames": configured_names,
+            "unconfiguredEnabledPolicyNames": unconfigured_names
+        }
+    except Exception as e:
+        return {"isEPPConfigured": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPConfigured"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        total = eval_result.get("totalPreventionPolicies", 0)
+        configured = eval_result.get("configuredPolicies", 0)
+        configured_names = eval_result.get("configuredPolicyNames", [])
+        unconfigured_names = eval_result.get("unconfiguredEnabledPolicyNames", [])
+
+        if result_value:
+            pass_reasons.append("At least one enabled prevention policy has configured prevention_settings categories")
+            pass_reasons.append("Configured policies: " + str(configured) + " of " + str(total) + " total prevention policies")
+            if configured_names:
+                additional_findings.append("Configured policy names: " + ", ".join(configured_names))
+        else:
+            fail_reasons.append("No enabled prevention policy with configured prevention_settings categories found")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Configure prevention settings categories in at least one enabled prevention policy")
+            recommendations.append("In the Falcon console, navigate to Endpoint Security > Prevention Policies and configure detection/prevention categories")
+            if unconfigured_names:
+                additional_findings.append("Enabled policies with empty or missing settings: " + ", ".join(unconfigured_names))
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalPreventionPolicies": total, "configuredPolicies": configured}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/isEPPEnabled.py
+++ b/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/isEPPEnabled.py
@@ -1,0 +1,124 @@
+"""
+Transformation: isEPPEnabled
+Vendor: Crowdstrike  |  Category: cloud-security-alliance-star-csa-star
+Evaluates: Whether at least one CrowdStrike prevention policy has enabled: true,
+           confirming EPP/NGAV prevention is actively enforced in the environment.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPEnabled", "vendor": "Crowdstrike", "category": "cloud-security-alliance-star-csa-star"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not resources:
+            return {"isEPPEnabled": False, "totalPreventionPolicies": 0, "enabledPreventionPolicies": 0, "error": "No policy resources found in API response"}
+
+        # Prevention policies are distinguished from sensor-update policies by having prevention_settings
+        prevention_policies = [r for r in resources if "prevention_settings" in r]
+        total_count = len(prevention_policies)
+
+        if total_count == 0:
+            return {"isEPPEnabled": False, "totalPreventionPolicies": 0, "enabledPreventionPolicies": 0, "error": "No prevention policies found in merged policy data"}
+
+        enabled_policies = [p for p in prevention_policies if p.get("enabled", False)]
+        enabled_count = len(enabled_policies)
+        enabled_names = [p.get("name", "unnamed") for p in enabled_policies]
+
+        is_enabled = enabled_count > 0
+        return {
+            "isEPPEnabled": is_enabled,
+            "totalPreventionPolicies": total_count,
+            "enabledPreventionPolicies": enabled_count,
+            "enabledPolicyNames": enabled_names
+        }
+    except Exception as e:
+        return {"isEPPEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        total = eval_result.get("totalPreventionPolicies", 0)
+        enabled = eval_result.get("enabledPreventionPolicies", 0)
+        names = eval_result.get("enabledPolicyNames", [])
+
+        if result_value:
+            pass_reasons.append("At least one CrowdStrike prevention policy is actively enabled")
+            pass_reasons.append("Enabled prevention policies: " + str(enabled) + " of " + str(total))
+            if names:
+                additional_findings.append("Enabled policy names: " + ", ".join(names))
+        else:
+            fail_reasons.append("No enabled CrowdStrike prevention policies found")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable at least one prevention policy in the CrowdStrike Falcon console to enforce EPP/NGAV protection")
+            recommendations.append("Navigate to Endpoint Security > Prevention Policies and ensure policies are enabled and assigned to host groups")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalPreventionPolicies": total, "enabledPreventionPolicies": enabled}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/isEPPLoggingEnabled.py
+++ b/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/isEPPLoggingEnabled.py
@@ -1,0 +1,140 @@
+"""
+Transformation: isEPPLoggingEnabled
+Vendor: Crowdstrike  |  Category: cloud-security-alliance-star-csa-star
+Evaluates: Whether CrowdStrike sensor update policies are active (enabled: true),
+           ensuring sensors are managed and updated so that endpoint telemetry
+           and logging pipelines remain operational for EPP event visibility.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPLoggingEnabled", "vendor": "Crowdstrike", "category": "cloud-security-alliance-star-csa-star"}
+        }
+    }
+
+
+def is_sensor_update_policy(resource):
+    # Sensor update policies have a 'settings' key with sensor-specific fields
+    # and do NOT have 'prevention_settings'
+    if "prevention_settings" in resource:
+        return False
+    settings = resource.get("settings", None)
+    if settings is not None:
+        return True
+    # Fallback: check for known sensor update policy fields
+    if "build" in resource or "uninstall_protection" in resource:
+        return True
+    return False
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not resources:
+            return {"isEPPLoggingEnabled": False, "totalSensorUpdatePolicies": 0, "enabledSensorUpdatePolicies": 0, "error": "No policy resources found in API response"}
+
+        sensor_policies = [r for r in resources if is_sensor_update_policy(r)]
+        total_count = len(sensor_policies)
+
+        if total_count == 0:
+            return {"isEPPLoggingEnabled": False, "totalSensorUpdatePolicies": 0, "enabledSensorUpdatePolicies": 0, "error": "No sensor update policies found in merged policy data"}
+
+        enabled_policies = [p for p in sensor_policies if p.get("enabled", False)]
+        enabled_count = len(enabled_policies)
+        enabled_names = [p.get("name", "unnamed") for p in enabled_policies]
+
+        is_enabled = enabled_count > 0
+        return {
+            "isEPPLoggingEnabled": is_enabled,
+            "totalSensorUpdatePolicies": total_count,
+            "enabledSensorUpdatePolicies": enabled_count,
+            "enabledPolicyNames": enabled_names
+        }
+    except Exception as e:
+        return {"isEPPLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        total = eval_result.get("totalSensorUpdatePolicies", 0)
+        enabled = eval_result.get("enabledSensorUpdatePolicies", 0)
+        names = eval_result.get("enabledPolicyNames", [])
+
+        if result_value:
+            pass_reasons.append("At least one CrowdStrike sensor update policy is actively enabled")
+            pass_reasons.append("Enabled sensor update policies: " + str(enabled) + " of " + str(total))
+            pass_reasons.append("Active sensor update policies ensure endpoint telemetry and logging pipelines remain operational")
+            if names:
+                additional_findings.append("Enabled sensor update policy names: " + ", ".join(names))
+        else:
+            fail_reasons.append("No enabled sensor update policies found")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable at least one sensor update policy to ensure sensors are managed and updated")
+            recommendations.append("Navigate to Endpoint Security > Sensor Update Policies in the Falcon console and enable policies")
+            recommendations.append("Active sensor update policies are required to maintain EPP event visibility and logging pipelines")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalSensorUpdatePolicies": total, "enabledSensorUpdatePolicies": enabled}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/requiredCoveragePercentage.py
+++ b/safeguards/cloud-security-alliance-star-csa-star/crowdstrike/requiredCoveragePercentage.py
@@ -1,0 +1,148 @@
+"""
+Transformation: requiredCoveragePercentage
+Vendor: Crowdstrike  |  Category: cloud-security-alliance-star-csa-star
+Evaluates: The percentage of managed endpoints with an active CrowdStrike sensor
+           (status: 'normal'). Passes when coverage meets or exceeds 80%.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "requiredCoveragePercentage", "vendor": "Crowdstrike", "category": "cloud-security-alliance-star-csa-star"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        total_devices = len(resources)
+
+        if total_devices == 0:
+            return {
+                "requiredCoveragePercentage": 0,
+                "totalDevices": 0,
+                "activeDevices": 0,
+                "inactiveDevices": 0,
+                "coverageMeetsThreshold": False,
+                "coverageThreshold": 80,
+                "error": "No device resources found in API response"
+            }
+
+        active_devices = [d for d in resources if d.get("status", "") == "normal"]
+        active_count = len(active_devices)
+        inactive_count = total_devices - active_count
+
+        coverage_percentage = (active_count * 100) / total_devices
+        coverage_rounded = int(coverage_percentage * 100) / 100
+        threshold = 80
+        meets_threshold = coverage_percentage >= threshold
+
+        status_breakdown = {}
+        for d in resources:
+            s = d.get("status", "unknown")
+            if s in status_breakdown:
+                status_breakdown[s] = status_breakdown[s] + 1
+            else:
+                status_breakdown[s] = 1
+
+        return {
+            "requiredCoveragePercentage": coverage_rounded,
+            "totalDevices": total_devices,
+            "activeDevices": active_count,
+            "inactiveDevices": inactive_count,
+            "coverageMeetsThreshold": meets_threshold,
+            "coverageThreshold": threshold,
+            "statusBreakdown": status_breakdown
+        }
+    except Exception as e:
+        return {"requiredCoveragePercentage": 0, "coverageMeetsThreshold": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "requiredCoveragePercentage"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: 0, "coverageMeetsThreshold": False}, validation=validation, fail_reasons=["Input validation failed"])
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, 0)
+        meets_threshold = eval_result.get("coverageMeetsThreshold", False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        total = eval_result.get("totalDevices", 0)
+        active = eval_result.get("activeDevices", 0)
+        threshold = eval_result.get("coverageThreshold", 80)
+        status_breakdown = eval_result.get("statusBreakdown", {})
+
+        if meets_threshold:
+            pass_reasons.append("EPP agent coverage meets or exceeds the required " + str(threshold) + "% threshold")
+            pass_reasons.append("Coverage: " + str(result_value) + "% (" + str(active) + " of " + str(total) + " devices with active sensor)")
+        else:
+            fail_reasons.append("EPP agent coverage is below the required " + str(threshold) + "% threshold")
+            fail_reasons.append("Current coverage: " + str(result_value) + "% (" + str(active) + " of " + str(total) + " devices with active sensor)")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Investigate and remediate devices not reporting as 'normal' status")
+            recommendations.append("Ensure the CrowdStrike Falcon sensor is deployed and running on all managed endpoints")
+            recommendations.append("Review devices in 'reduced_functionality_mode' or containment states")
+
+        if status_breakdown:
+            for s in status_breakdown:
+                additional_findings.append("Status '" + s + "': " + str(status_breakdown[s]) + " device(s)")
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalDevices": total, "activeDevices": active, "coveragePercentage": result_value}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: 0, "coverageMeetsThreshold": False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Adding five transformation scripts for CrowdStrike Falcon endpoint protection platform integration (cloud-security-alliance-star-csa-star category). These scripts evaluate EPP/NGAV enablement, configuration depth, logging pipeline health, agent deployment coverage, and license validity across the managed endpoint fleet.

**Context:** CrowdStrike is being onboarded as a new Cloud Workload Protection Platform vendor to validate endpoint security posture against CSA STAR compliance benchmarks. The five criteria cover the critical control surface: policy activation, prevention rule depth, telemetry visibility, agent penetration, and subscription status.

## What each transformation does

### `isEPPEnabled.py`
Evaluates whether at least one CrowdStrike prevention policy has `enabled: true`, confirming EPP/NGAV prevention is actively enforced.

- **Consumes:** CrowdStrike Admin API `GET /policy/combined/prevention/v1` (Prevention Policy endpoint)
- **Pass criteria:** `len([p for p in resources if p.get("prevention_settings") and p.get("enabled")]) > 0` — At least one prevention policy object contains the `prevention_settings` field (distinguishing it from sensor-update policies) AND has `enabled: true`
- **Key edge cases handled:**
  - No policy resources found → fails with descriptive error (empty API response)
  - Policy object lacks `prevention_settings` → treated as non-prevention-policy (sensor-update policies also returned by merged payload)
  - All policies disabled → fails with count of enabled policies (0)
  - Exception during iteration → caught and returned as transformation error

### `isEPPConfigured.py`
Evaluates whether at least one enabled prevention policy contains a non-empty `prevention_settings` object with configured detection/prevention categories.

- **Consumes:** CrowdStrike Admin API `GET /policy/combined/prevention/v1` (Prevention Policy endpoint)
- **Pass criteria:** `len([p for p in prevention_policies if p.get("enabled") and (p.get("prevention_settings", {}).get("categories", []) or any(p.get("prevention_settings", {})))]) > 0` — At least one enabled prevention policy must have `prevention_settings.categories` as a non-empty list OR contain other non-empty keys in `prevention_settings`
- **Key edge cases handled:**
  - Policy `enabled: false` → explicitly skipped (no point validating disabled policy configuration)
  - `prevention_settings: null` or `{}` (empty dict) → flagged as unconfigured, separated into distinct list for recommendations
  - Enabled policy with empty categories → counts as unconfigured but tracked separately for visibility
  - Exception handling preserves context (total, configured, unconfigured counts)

### `isEPPLoggingEnabled.py`
Evaluates whether CrowdStrike sensor update policies are active (`enabled: true`), ensuring sensors remain managed and updated for telemetry pipeline health.

- **Consumes:** CrowdStrike Admin API `GET /policy/combined/sensor-update/v2` (Sensor Update Policy endpoint)
- **Pass criteria:** `len([p for p in resources if is_sensor_update_policy(p) and p.get("enabled")]) > 0` — Helper function `is_sensor_update_policy()` filters to sensor-update policies (those with `settings` field and NOT `prevention_settings`), then at least one must have `enabled: true`
- **Key edge cases handled:**
  - Prevention policies returned in merged payload → explicitly excluded via `is_sensor_update_policy()` check (looks for `settings` key and absence of `prevention_settings`)
  - Sensor policy `enabled: false` → not counted toward pass (inactive policies do not ensure logging pipelines remain operational)
  - Resource with neither `prevention_settings` nor `settings` → treated as sensor-update if it has known sensor-specific fields (`build`, `uninstall_protection`)
  - Empty resources array → fails with "No sensor update policies found" error

### `requiredCoveragePercentage.py`
Computes the percentage of managed endpoints with active CrowdStrike sensor (`status: 'normal'`) and passes when coverage meets or exceeds 80%.

- **Consumes:** CrowdStrike Admin API `GET /devices/combined/devices/v1` (Host/Device endpoint)
- **Pass criteria:** `(active_device_count / total_device_count) * 100 >= 80` — Devices with `status == 'normal'` are counted as active; result rounded to 2 decimal places; threshold is 80%
- **Key edge cases handled:**
  - Zero devices enrolled → coverage = 0%, fails with error "No device resources found"
  - Mixed status values (`normal`, `reduced_functionality_mode`, `containment`) → all non-normal statuses aggregated into `inactiveDevices`; status breakdown provided in additional findings
  - Pagination via limit/offset → framework handles accumulation via merge=true; script evaluates final merged array
  - Rounding: `int((percentage * 100)) / 100` ensures 2 decimal places (e.g., 85.667 becomes 85.66)

### `confirmedLicensePurchased.py`
Evaluates whether a valid CrowdStrike Falcon license is active by confirming a non-empty device roster and valid API authentication.

- **Consumes:** CrowdStrike Admin API `GET /devices/combined/devices/v1` (Host/Device endpoint)
- **Pass criteria:** `len(resources) > 0` — A successful HTTP 200 response with at least one device object in the `resources` array indicates an active license and at least one enrolled endpoint. Empty resources array indicates no license or no enrolled devices.
- **Key edge cases handled:**
  - API authentication failure → handled upstream by auth layer; transformation receives successful 200 or API error is reported as `data_collection` error (not transformation error)
  - Zero devices in resources → explicitly passes `False` with recommendation to verify license validity and enroll endpoints
  - Platform breakdown (Windows, Linux, macOS) — computed from `platform_name` field and included in additional findings for visibility
  - Exception in evaluate() → caught and returned as transformation error with fail reason

## Architecture notes

All five scripts follow the standard Spektrum transformation contract: `extract_input()` unwraps legacy nested payloads, `evaluate()` contains the core security control logic and returns a dict with the criteria key + context fields, and `transform()` orchestrates input validation → evaluation → response construction. The response schema includes structured `additionalInfo` (dataCollection, validation, transformation, evaluation sections) with metadata marking schema version 1.0 and transformation ID. Input validation checks for `data` and `validation` keys; if missing, input is treated as raw API response and unwrapped via known keys (api_response, response, result, apiResponse, Output). All scripts are RestrictedPython-compatible and avoid file I/O, network calls, and dynamic imports.

## Test plan

- [x] Each script passes `PyCodeExecutor` sandbox validation (no disallowed imports or operations)
- [x] `evaluate()` returns correct result for: valid resources array, zero resources, missing fields, policy state variations
- [x] Confirm field names in `data.get("...")` match CrowdStrike API response schema:
  - `resources[]` (common to all)
  - `prevention_policies[]` → `enabled`, `name`, `prevention_settings` (categories, etc.)
  - `sensor_update_policies[]` → `enabled`, `name`, `settings`, `build`, `uninstall_protection`
  - `devices[]` → `status` (normal, reduced_functionality_mode, etc.), `platform_name`, `os_version`
- [x] Verify `create_response()` output includes all schema 1.0 fields: `transformedResponse`, `additionalInfo.dataCollection`, `.validation`, `.transformation`, `.evaluation`, `.metadata`
- [x] Edge case verification:
  - `isEPPEnabled`: No policies vs. disabled policies vs. enabled policies
  - `isEPPConfigured`: Empty prevention_settings vs. configured categories
  - `isEPPLoggingEnabled`: Mixed prevention/sensor policies in merged payload → correctly filtered
  - `requiredCoveragePercentage`: 0%, 50%, 80%, 100% coverage scenarios; rounding accuracy
  - `confirmedLicensePurchased`: 0 devices vs. multi-platform enrollment
- [x] API error responses (stat: FAIL) handled upstream; transformation receives empty or error-wrapped data and returns descriptive fail_reasons


Generated by Spektrum integration onboarding pipeline
