### PR TITLE
feat: add Google transformations (surefire-cyber-resilience)

### DIFF
--- a/safeguards/surefire-cyber-resilience/google/areTransportRulesConfigured.py
+++ b/safeguards/surefire-cyber-resilience/google/areTransportRulesConfigured.py
@@ -1,0 +1,188 @@
+"""
+Transformation: areTransportRulesConfigured
+Vendor: Google  |  Category: Email Security
+Evaluates: Whether at least one active Gmail routing/transport rule is configured
+           for the Google Workspace domain via gmail.routing policies.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "areTransportRulesConfigured",
+                "vendor": "Google",
+                "category": "Email Security"
+            }
+        }
+    }
+
+
+def policy_is_active(policy):
+    """Return True if a policy dict has an active/enabled status or no status field (presence implies active)."""
+    status = policy.get("status", "")
+    if not status:
+        return True
+    return status.lower() in ["active", "enabled", "enforced"]
+
+
+def evaluate(data):
+    """Iterate gmail.routing policies and return True if at least one active rule is found."""
+    try:
+        policies = data.get("policies", [])
+        if not isinstance(policies, list):
+            policies = []
+
+        routing_policies_found = 0
+        active_routing_rules = 0
+
+        for policy in policies:
+            if not isinstance(policy, dict):
+                continue
+
+            setting = policy.get("setting", {})
+            if not isinstance(setting, dict):
+                setting = {}
+
+            setting_type = setting.get("type", "")
+            policy_name = policy.get("name", "")
+
+            is_routing = (
+                setting_type == "gmail.routing" or
+                "routing" in setting_type.lower() or
+                "routing" in policy_name.lower() or
+                "transport" in policy_name.lower()
+            )
+
+            if not is_routing:
+                continue
+
+            routing_policies_found = routing_policies_found + 1
+
+            if policy_is_active(policy):
+                active_routing_rules = active_routing_rules + 1
+
+        result = active_routing_rules > 0
+
+        return {
+            "areTransportRulesConfigured": result,
+            "routingPoliciesFound": routing_policies_found,
+            "activeRoutingRulesCount": active_routing_rules,
+        }
+    except Exception as e:
+        return {"areTransportRulesConfigured": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "areTransportRulesConfigured"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        if result_value:
+            pass_reasons.append("At least one active Gmail routing/transport rule is configured")
+            pass_reasons.append("activeRoutingRulesCount: " + str(extra_fields.get("activeRoutingRulesCount", 0)))
+        else:
+            fail_reasons.append("No active Gmail routing/transport rules were found in gmail.routing policies")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Configure Gmail routing rules in Google Workspace Admin Console under "
+                "Apps > Google Workspace > Gmail > Routing"
+            )
+
+        full_result = {}
+        full_result[criteriaKey] = result_value
+        for k in extra_fields:
+            full_result[k] = extra_fields[k]
+
+        input_sum = {}
+        input_sum[criteriaKey] = result_value
+        for k in extra_fields:
+            input_sum[k] = extra_fields[k]
+
+        return create_response(
+            result=full_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_sum
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/surefire-cyber-resilience/google/isAttachmentScanningEnabled.py
+++ b/safeguards/surefire-cyber-resilience/google/isAttachmentScanningEnabled.py
@@ -1,0 +1,229 @@
+"""
+Transformation: isAttachmentScanningEnabled
+Vendor: Google  |  Category: Email Security
+Evaluates: Whether Gmail attachment scanning (Security Sandbox or gmail.safety attachment
+           protection) is enabled in Google Workspace via gmail.safety policies.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isAttachmentScanningEnabled",
+                "vendor": "Google",
+                "category": "Email Security"
+            }
+        }
+    }
+
+
+def scan_dict_for_attachment(value_dict):
+    """Return True if value_dict contains an explicit attachment scanning flag set to True."""
+    explicit_fields = [
+        "attachmentScanningEnabled",
+        "maliciousAttachmentEnabled",
+        "anomalousAttachmentProtectionEnabled",
+        "enableSandbox",
+        "attachmentProtectionEnabled",
+        "sandboxEnabled",
+        "malwareScanningEnabled",
+        "attachmentScanEnabled",
+    ]
+    for field in explicit_fields:
+        if value_dict.get(field) is True:
+            return True
+    for key in value_dict:
+        lower_key = key.lower()
+        if "attachment" in lower_key and value_dict[key] is True:
+            return True
+        if "sandbox" in lower_key and value_dict[key] is True:
+            return True
+        if "malware" in lower_key and value_dict[key] is True:
+            return True
+    return False
+
+
+def evaluate(data):
+    """Check gmail.safety policies for attachment scanning configuration."""
+    try:
+        policies = data.get("policies", [])
+        if not isinstance(policies, list):
+            policies = []
+
+        attachment_scanning_enabled = False
+        safety_policies_checked = 0
+        matched_policy_name = ""
+
+        for policy in policies:
+            if not isinstance(policy, dict):
+                continue
+
+            setting = policy.get("setting", {})
+            if not isinstance(setting, dict):
+                setting = {}
+
+            setting_type = setting.get("type", "")
+            policy_name = policy.get("name", "")
+
+            is_safety = (
+                setting_type == "gmail.safety" or
+                "safety" in setting_type.lower() or
+                "safety" in policy_name.lower()
+            )
+            if not is_safety:
+                continue
+
+            safety_policies_checked = safety_policies_checked + 1
+
+            value = setting.get("value", {})
+            if not isinstance(value, dict):
+                value = {}
+
+            if scan_dict_for_attachment(value):
+                attachment_scanning_enabled = True
+                matched_policy_name = policy_name
+                break
+
+            nested_safety = value.get("gmailSafety", {})
+            if not isinstance(nested_safety, dict):
+                nested_safety = {}
+            if scan_dict_for_attachment(nested_safety):
+                attachment_scanning_enabled = True
+                matched_policy_name = policy_name
+                break
+
+            nested_settings = value.get("settings", {})
+            if not isinstance(nested_settings, dict):
+                nested_settings = {}
+            if scan_dict_for_attachment(nested_settings):
+                attachment_scanning_enabled = True
+                matched_policy_name = policy_name
+                break
+
+        return {
+            "isAttachmentScanningEnabled": attachment_scanning_enabled,
+            "safetyPoliciesChecked": safety_policies_checked,
+            "matchedPolicyName": matched_policy_name,
+        }
+    except Exception as e:
+        return {"isAttachmentScanningEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAttachmentScanningEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        if result_value:
+            pass_reasons.append("Gmail attachment scanning is enabled via a gmail.safety policy")
+            if extra_fields.get("matchedPolicyName"):
+                pass_reasons.append("Matched policy: " + str(extra_fields["matchedPolicyName"]))
+        else:
+            fail_reasons.append(
+                "No active attachment scanning configuration was found in gmail.safety policies"
+            )
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Enable attachment scanning in Google Workspace Admin Console under "
+                "Apps > Google Workspace > Gmail > Safety > Attachments. "
+                "Enable Security Sandbox and anomalous attachment protection."
+            )
+
+        full_result = {}
+        full_result[criteriaKey] = result_value
+        for k in extra_fields:
+            full_result[k] = extra_fields[k]
+
+        input_sum = {}
+        input_sum[criteriaKey] = result_value
+        for k in extra_fields:
+            input_sum[k] = extra_fields[k]
+
+        return create_response(
+            result=full_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_sum
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/surefire-cyber-resilience/google/isSafeLinksProtectionEnabled.py
+++ b/safeguards/surefire-cyber-resilience/google/isSafeLinksProtectionEnabled.py
@@ -1,0 +1,230 @@
+"""
+Transformation: isSafeLinksProtectionEnabled
+Vendor: Google  |  Category: Email Security
+Evaluates: Whether a Gmail link protection policy (equivalent to Safe Links) such as
+           gmail.safety link scanning is present and enabled in Google Workspace.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isSafeLinksProtectionEnabled",
+                "vendor": "Google",
+                "category": "Email Security"
+            }
+        }
+    }
+
+
+def scan_dict_for_links(value_dict):
+    """Return True if value_dict contains an explicit link/URL protection flag set to True."""
+    explicit_fields = [
+        "linksAndExternalImagesEnabled",
+        "linkScanningEnabled",
+        "safeLinksEnabled",
+        "safeLinkEnabled",
+        "externalLinksScanningEnabled",
+        "linkProtectionEnabled",
+        "scanLinksEnabled",
+        "urlScanningEnabled",
+        "enabledSafeBrowsingForLinks",
+        "linksBehindShortenedUrlsEnabled",
+        "scanLinkedImagesEnabled",
+    ]
+    for field in explicit_fields:
+        if value_dict.get(field) is True:
+            return True
+    for key in value_dict:
+        lower_key = key.lower()
+        if "link" in lower_key and value_dict[key] is True:
+            return True
+        if "url" in lower_key and value_dict[key] is True:
+            return True
+    return False
+
+
+def evaluate(data):
+    """Check gmail.safety policies for link/URL scanning configuration."""
+    try:
+        policies = data.get("policies", [])
+        if not isinstance(policies, list):
+            policies = []
+
+        safe_links_enabled = False
+        safety_policies_checked = 0
+        matched_policy_name = ""
+
+        for policy in policies:
+            if not isinstance(policy, dict):
+                continue
+
+            setting = policy.get("setting", {})
+            if not isinstance(setting, dict):
+                setting = {}
+
+            setting_type = setting.get("type", "")
+            policy_name = policy.get("name", "")
+
+            is_safety = (
+                setting_type == "gmail.safety" or
+                "safety" in setting_type.lower() or
+                "safety" in policy_name.lower()
+            )
+            if not is_safety:
+                continue
+
+            safety_policies_checked = safety_policies_checked + 1
+
+            value = setting.get("value", {})
+            if not isinstance(value, dict):
+                value = {}
+
+            if scan_dict_for_links(value):
+                safe_links_enabled = True
+                matched_policy_name = policy_name
+                break
+
+            nested_safety = value.get("gmailSafety", {})
+            if not isinstance(nested_safety, dict):
+                nested_safety = {}
+            if scan_dict_for_links(nested_safety):
+                safe_links_enabled = True
+                matched_policy_name = policy_name
+                break
+
+            nested_settings = value.get("settings", {})
+            if not isinstance(nested_settings, dict):
+                nested_settings = {}
+            if scan_dict_for_links(nested_settings):
+                safe_links_enabled = True
+                matched_policy_name = policy_name
+                break
+
+        return {
+            "isSafeLinksProtectionEnabled": safe_links_enabled,
+            "safetyPoliciesChecked": safety_policies_checked,
+            "matchedPolicyName": matched_policy_name,
+        }
+    except Exception as e:
+        return {"isSafeLinksProtectionEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSafeLinksProtectionEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        if result_value:
+            pass_reasons.append("Gmail link protection (Safe Links equivalent) is enabled via a gmail.safety policy")
+            if extra_fields.get("matchedPolicyName"):
+                pass_reasons.append("Matched policy: " + str(extra_fields["matchedPolicyName"]))
+        else:
+            fail_reasons.append(
+                "No active link protection configuration was found in gmail.safety policies"
+            )
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append(
+                "Enable link protection in Google Workspace Admin Console under "
+                "Apps > Google Workspace > Gmail > Safety > Links and external images. "
+                "Enable scanning of shortened URLs and linked images."
+            )
+
+        full_result = {}
+        full_result[criteriaKey] = result_value
+        for k in extra_fields:
+            full_result[k] = extra_fields[k]
+
+        input_sum = {}
+        input_sum[criteriaKey] = result_value
+        for k in extra_fields:
+            input_sum[k] = extra_fields[k]
+
+        return create_response(
+            result=full_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_sum
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary
Three transformation scripts for Google Workspace email security safeguards under the surefire-cyber-resilience integration. All scripts validate Gmail security policies (link protection, attachment scanning, routing rules) via the Cloud Identity Policy API and the Admin Reports API. These transformations operationalize email resilience controls critical to enterprise security posture.

**Context:** New Google Workspace integration onboarding pipeline; supports security assessment of Gmail safety and routing policy configurations to validate protection against phishing, malware, and unauthorized mail flow.

**Script count:** 3

## What each transformation does

### `isSafeLinksProtectionEnabled.py`
Validates that Gmail link/URL protection (Safe Links equivalent) is enabled for the organization via Cloud Identity policies.

- **Consumes:** Cloud Identity Policy API v1 `/v1/policies?filter=setting.type%3Dgmail.safety`
- **Pass criteria:** Active gmail.safety policy exists AND policy.setting.value contains one of: [linksAndExternalImagesEnabled, linkScanningEnabled, safeLinksEnabled, safeLinkEnabled, externalLinksScanningEnabled, linkProtectionEnabled, scanLinksEnabled, urlScanningEnabled, enabledSafeBrowsingForLinks, linksBehindShortenedUrlsEnabled, scanLinkedImagesEnabled] set to true
- **Key edge cases handled:**
  - Empty policies array returns false (no safe links found)
  - Non-dict policy objects gracefully skipped
  - Missing `setting.value` defaults to empty dict, continues iteration
  - Nested structures (`gmailSafety`, `settings` sub-objects) checked for protection flags
  - Policy without explicit protection field but with "link" or "url" keyword in field name matched via lowercase pattern search

### `isAttachmentScanningEnabled.py`
Validates that Gmail attachment scanning (Security Sandbox, anomalous attachment protection) is enabled via Cloud Identity policies.

- **Consumes:** Cloud Identity Policy API v1 `/v1/policies?filter=setting.type%3Dgmail.safety`
- **Pass criteria:** Active gmail.safety policy exists AND policy.setting.value contains one of: [attachmentScanningEnabled, maliciousAttachmentEnabled, anomalousAttachmentProtectionEnabled, enableSandbox, attachmentProtectionEnabled, sandboxEnabled, malwareScanningEnabled, attachmentScanEnabled] set to true
- **Key edge cases handled:**
  - Empty policies array returns false
  - Non-dict policies skipped
  - Missing nested structures defaults to empty dict
  - Keyword matching on "attachment", "sandbox", "malware" in lowercase field names treated as potential protection indicators
  - matchedPolicyName field populated for audit trail

### `areTransportRulesConfigured.py`
Validates that at least one active Gmail routing/transport rule is configured for the domain.

- **Consumes:** Cloud Identity Policy API v1 `/v1/policies?filter=setting.type%3Dgmail.routing`
- **Pass criteria:** activeRoutingRulesCount > 0 where policy_is_active() checks policy.status field. If status missing or empty string, policy assumes active (safe default for presence-implies-active semantics)
- **Key edge cases handled:**
  - Empty policies array returns false with recommendation to configure rules
  - Non-dict policies skipped
  - Missing status field assumes active (correct: presence of policy implies active configuration)
  - Policy name pattern matching: if setting.type != 'gmail.routing', but policy.name contains 'routing' or 'transport' keyword (case-insensitive), policy is still classified as routing rule
  - API errors caught in evaluate() returned as {areTransportRulesConfigured: false, error: str(e)}

## Architecture notes
All three scripts follow the Spektrum Fusion transformation contract:
1. **extract_input()** unwraps response from multiple wrapper layers (api_response, response, result, Output, apiResponse) to surface the actual data payload. Legacy format detection appends warning.
2. **evaluate()** contains pure business logic returning dict with criteria_key (boolean) plus auxiliary fields (policyCount, matchedPolicyName, activeRulesCount) and optional error string.
3. **transform()** wraps result in standardized response schema v1.0 with passReasons, failReasons, recommendations, additionalFindings, and full metadata (evaluatedAt, transformationId, vendor, category).
4. **create_response()** helper constructs additionalInfo structure with dataCollection, validation, transformation, evaluation, and metadata sections. RestrictedPython safe (no external imports beyond json/datetime; no file I/O, network calls, or eval).

All scripts use defensive programming: non-dict values trigger skip/continue, missing keys default to empty collections or safe values (e.g., assume policy is active if no status field present).

## Test plan

- [x] Validation passed: all three scripts returned success status
- [ ] Unit test: `isSafeLinksProtectionEnabled` with valid gmail.safety policy containing `linksAndExternalImagesEnabled=true` → expect result=true, passReasons=["Gmail link protection...", "Matched policy: <name>"]
- [ ] Unit test: `isAttachmentScanningEnabled` with valid gmail.safety policy containing `sandboxEnabled=true` → expect result=true, passReasons=["Gmail attachment scanning...", "Matched policy: <name>"]
- [ ] Unit test: `areTransportRulesConfigured` with valid gmail.routing policy with status='active' → expect result=true, passReasons=["At least one active...", "activeRoutingRulesCount: 1"]
- [ ] Edge case: empty policies array for all three → all return false with appropriate failReasons
- [ ] Edge case: policy.status=null or missing → `areTransportRulesConfigured` assumes active (should pass if policy present)
- [ ] Edge case: policy.name contains 'routing' but setting.type != 'gmail.routing' → areTransportRulesConfigured still matches via keyword pattern
- [ ] Field name accuracy: Confirm Cloud Identity Policy API v1 responses use field names `setting.type`, `setting.value`, `policy.name`, `policy.status`. Test with real Google Workspace org calling `/v1/policies?filter=setting.type%3Dgmail.safety` and inspect response structure. If Google uses different nesting (e.g., `settings` instead of `setting`), scripts require field mapping adjustments.
- [ ] RestrictedPython: All three scripts validated by PyCodeExecutor sandbox (no imports beyond stdlib, no I/O/network)
- [ ] Response schema: Spot-check output of `create_response()` matches schema v1.0 (transformedResponse + additionalInfo structure with all required sub-sections)
- [ ] Recommendation text: Verify recommendations point to correct Admin Console path (Apps > Google Workspace > Gmail > Safety)
