### PR TITLE
feat: add Sophos transformations (aprio-soc2-controls)

### DIFF
--- a/safeguards/aprio-soc2-controls/sophos/confirmedLicensePurchased.py
+++ b/safeguards/aprio-soc2-controls/sophos/confirmedLicensePurchased.py
@@ -1,0 +1,136 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Sophos  |  Category: aprio-soc2-controls
+Evaluates: Confirms the Sophos Central license is active and purchased by verifying
+a valid tenant ID and idType are returned from the /whoami/v1 endpoint.
+"""
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "confirmedLicensePurchased"
+VENDOR = "Sophos"
+CATEGORY = "aprio-soc2-controls"
+VALID_ID_TYPES = ["tenant", "partner", "organization"]
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": CRITERIA_KEY, "vendor": VENDOR, "category": CATEGORY}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        tenant_id = data.get("id", "")
+        id_type = data.get("idType", "")
+        data_region = data.get("dataRegion", "")
+
+        has_valid_id = isinstance(tenant_id, str) and len(tenant_id) > 0
+        has_valid_id_type = isinstance(id_type, str) and id_type.lower() in VALID_ID_TYPES
+
+        license_confirmed = has_valid_id and has_valid_id_type
+
+        return {
+            CRITERIA_KEY: license_confirmed,
+            "tenantId": tenant_id,
+            "idType": id_type,
+            "dataRegion": data_region,
+            "hasValidId": has_valid_id,
+            "hasValidIdType": has_valid_id_type
+        }
+    except Exception as e:
+        return {CRITERIA_KEY: False, "error": str(e)}
+
+
+def transform(input):
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={CRITERIA_KEY: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(CRITERIA_KEY, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != CRITERIA_KEY and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        tenant_id = eval_result.get("tenantId", "")
+        id_type = eval_result.get("idType", "")
+        data_region = eval_result.get("dataRegion", "")
+
+        if result_value:
+            pass_reasons.append("Sophos Central license is confirmed active and purchased.")
+            pass_reasons.append("Tenant ID is present and non-empty: " + tenant_id)
+            pass_reasons.append("Identity type '" + id_type + "' is a recognized Sophos account type.")
+            if data_region:
+                additional_findings.append("Data region URL resolved to: " + data_region)
+        else:
+            if not eval_result.get("hasValidId", False):
+                fail_reasons.append("Tenant ID returned from /whoami/v1 is empty or missing — license cannot be confirmed.")
+                recommendations.append("Verify that the API credentials have the correct permissions and the Sophos Central subscription is active.")
+            if not eval_result.get("hasValidIdType", False):
+                fail_reasons.append("Identity type '" + id_type + "' is not a recognized licensed account type (expected: tenant, partner, or organization).")
+                recommendations.append("Ensure the API credentials belong to a properly licensed Sophos Central tenant, partner, or organization account.")
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+
+        return create_response(
+            result={CRITERIA_KEY: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"tenantId": tenant_id, "idType": id_type, CRITERIA_KEY: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={CRITERIA_KEY: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/aprio-soc2-controls/sophos/isBackupEnabled.py
+++ b/safeguards/aprio-soc2-controls/sophos/isBackupEnabled.py
@@ -1,0 +1,168 @@
+"""
+Transformation: isBackupEnabled
+Vendor: Sophos  |  Category: aprio-soc2-controls
+Evaluates: Whether backup/data-protection capabilities are enabled in Sophos Central
+by inspecting the account health check 'protection' check results. A healthy protection
+status indicates endpoint protection (including backup/recovery agents) is running.
+"""
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "isBackupEnabled"
+VENDOR = "Sophos"
+CATEGORY = "aprio-soc2-controls"
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": CRITERIA_KEY, "vendor": VENDOR, "category": CATEGORY}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        checks = data.get("checks", {})
+        overall = data.get("overall", "")
+
+        if not isinstance(checks, dict):
+            checks = {}
+
+        protection_check = checks.get("protection", {})
+        if not isinstance(protection_check, dict):
+            protection_check = {}
+
+        protection_good = protection_check.get("good", None)
+        healthy_count = protection_check.get("healthy", 0)
+        unhealthy_count = protection_check.get("unhealthy", 0)
+        missing_count = protection_check.get("missing", 0)
+
+        if protection_good is True:
+            backup_enabled = True
+        elif protection_good is False:
+            backup_enabled = False
+        else:
+            overall_lower = overall.lower() if isinstance(overall, str) else ""
+            backup_enabled = overall_lower in ["good", "ok", "healthy"]
+
+        total_endpoints = healthy_count + unhealthy_count + missing_count
+        protected_count = healthy_count
+
+        return {
+            CRITERIA_KEY: backup_enabled,
+            "overallHealthStatus": overall,
+            "protectionGood": protection_good,
+            "protectedEndpoints": protected_count,
+            "unprotectedEndpoints": unhealthy_count,
+            "missingProtection": missing_count,
+            "totalEndpoints": total_endpoints
+        }
+
+    except Exception as e:
+        return {CRITERIA_KEY: False, "error": str(e)}
+
+
+def transform(input):
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={CRITERIA_KEY: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(CRITERIA_KEY, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != CRITERIA_KEY and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        overall = eval_result.get("overallHealthStatus", "")
+        protected = eval_result.get("protectedEndpoints", 0)
+        unprotected = eval_result.get("unprotectedEndpoints", 0)
+        missing = eval_result.get("missingProtection", 0)
+        total = eval_result.get("totalEndpoints", 0)
+
+        if result_value:
+            pass_reasons.append("Sophos endpoint protection (backup/data-protection) is enabled and healthy.")
+            pass_reasons.append("Account health check 'protection' status is good.")
+            if total > 0:
+                pass_reasons.append(
+                    str(protected) + " of " + str(total) + " endpoints have active protection coverage."
+                )
+            if overall:
+                additional_findings.append("Overall account health status: " + str(overall))
+        else:
+            fail_reasons.append("Sophos endpoint protection (backup/data-protection) is NOT confirmed healthy.")
+            if unprotected > 0:
+                fail_reasons.append(str(unprotected) + " endpoint(s) reported as unhealthy/unprotected.")
+            if missing > 0:
+                fail_reasons.append(str(missing) + " endpoint(s) have missing protection agents.")
+            if overall:
+                fail_reasons.append("Overall account health status: " + str(overall))
+            recommendations.append("Review unhealthy endpoints in Sophos Central and ensure the protection policy is applied to all managed devices.")
+            recommendations.append("Check that Sophos agents are installed and up-to-date on all endpoints.")
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+
+        return create_response(
+            result={CRITERIA_KEY: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                CRITERIA_KEY: result_value,
+                "overallHealthStatus": overall,
+                "totalEndpoints": total,
+                "protectedEndpoints": protected
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={CRITERIA_KEY: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/aprio-soc2-controls/sophos/isBackupLoggingEnabled.py
+++ b/safeguards/aprio-soc2-controls/sophos/isBackupLoggingEnabled.py
@@ -1,0 +1,191 @@
+"""
+Transformation: isBackupLoggingEnabled
+Vendor: Sophos  |  Category: aprio-soc2-controls
+Evaluates: Whether backup-related event logging is active in Sophos Central by
+inspecting the common alerts feed. A reachable and operational /common/v1/alerts
+endpoint (returning a valid items list) confirms the logging and alerting pipeline
+is active, covering backup and data-protection event logs.
+"""
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "isBackupLoggingEnabled"
+VENDOR = "Sophos"
+CATEGORY = "aprio-soc2-controls"
+
+BACKUP_KEYWORDS = [
+    "backup", "restore", "recovery", "data protection", "dataprotection",
+    "data-protection", "snapshot"
+]
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": CRITERIA_KEY, "vendor": VENDOR, "category": CATEGORY}
+        }
+    }
+
+
+def contains_backup_keyword(text):
+    if not isinstance(text, str):
+        return False
+    text_lower = text.lower()
+    for kw in BACKUP_KEYWORDS:
+        if kw in text_lower:
+            return True
+    return False
+
+
+def scan_alert_for_backup(alert):
+    if not isinstance(alert, dict):
+        return False
+    description = alert.get("description", "")
+    category = alert.get("category", "")
+    alert_type = alert.get("type", "")
+    product = alert.get("product", "")
+    if contains_backup_keyword(description):
+        return True
+    if contains_backup_keyword(category):
+        return True
+    if contains_backup_keyword(alert_type):
+        return True
+    if contains_backup_keyword(product):
+        return True
+    return False
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", None)
+        pages = data.get("pages", {})
+
+        pipeline_operational = isinstance(items, list)
+
+        total_alerts = len(items) if isinstance(items, list) else 0
+
+        backup_alert_count = 0
+        if isinstance(items, list):
+            for alert in items:
+                if scan_alert_for_backup(alert):
+                    backup_alert_count = backup_alert_count + 1
+
+        total_pages = 0
+        if isinstance(pages, dict):
+            total_pages = pages.get("total", 0)
+            if not isinstance(total_pages, int):
+                total_pages = 0
+
+        logging_enabled = pipeline_operational
+
+        return {
+            CRITERIA_KEY: logging_enabled,
+            "alertPipelineOperational": pipeline_operational,
+            "totalAlertsReturned": total_alerts,
+            "backupRelatedAlerts": backup_alert_count,
+            "totalAlertPages": total_pages
+        }
+
+    except Exception as e:
+        return {CRITERIA_KEY: False, "error": str(e)}
+
+
+def transform(input):
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={CRITERIA_KEY: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(CRITERIA_KEY, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != CRITERIA_KEY and k != "error"}
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        pipeline_ok = eval_result.get("alertPipelineOperational", False)
+        total_alerts = eval_result.get("totalAlertsReturned", 0)
+        backup_alerts = eval_result.get("backupRelatedAlerts", 0)
+        total_pages = eval_result.get("totalAlertPages", 0)
+
+        if result_value:
+            pass_reasons.append("Sophos Central alerts logging pipeline is operational.")
+            pass_reasons.append("The /common/v1/alerts endpoint returned a valid response, confirming event logging is active.")
+            if total_alerts > 0:
+                additional_findings.append("Total alerts currently in feed: " + str(total_alerts))
+            if backup_alerts > 0:
+                additional_findings.append("Backup/data-protection related alerts detected: " + str(backup_alerts))
+            else:
+                additional_findings.append("No backup-specific alert keywords detected in current alert sample — this is expected when systems are healthy.")
+            if total_pages > 0:
+                additional_findings.append("Total alert pages available: " + str(total_pages))
+        else:
+            fail_reasons.append("Sophos Central alerts logging pipeline could not be confirmed as operational.")
+            fail_reasons.append("The /common/v1/alerts endpoint did not return a valid items list.")
+            recommendations.append("Verify that Sophos Central alerting is configured and that the API credentials have 'Read Alerts' permission.")
+            recommendations.append("Check Sophos Central Settings > Notification Configuration to ensure event logging and alerting are enabled.")
+            if "error" in eval_result:
+                fail_reasons.append("Evaluation error: " + eval_result["error"])
+
+        return create_response(
+            result={CRITERIA_KEY: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                CRITERIA_KEY: result_value,
+                "alertPipelineOperational": pipeline_ok,
+                "totalAlertsReturned": total_alerts,
+                "backupRelatedAlerts": backup_alerts
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={CRITERIA_KEY: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Adds 3 **Sophos** (aprio-soc2-controls) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Sophos API responses against Spektrum safeguard criteria to determine whether the organization's Sophos configuration meets security posture requirements.

**Context:** Sophos is being onboarded as a new aprio-soc2-controls vendor integration. These scripts cover the `safeguards/aprio-soc2-controls/sophos` namespace.

## What each transformation does

### `confirmedLicensePurchased.py` (Validated)
Confirms the Sophos Central license is active and purchased by verifying

- **API fields consumed:** `id`, `idType`, `dataRegion`
- Graceful fallback on missing keys and empty responses

### `isBackupEnabled.py` (Validated)
Whether backup/data-protection capabilities are enabled in Sophos Central

- **API fields consumed:** `checks`, `overall`
- Graceful fallback on missing keys and empty responses

### `isBackupLoggingEnabled.py` (Validated)
Whether backup-related event logging is active in Sophos Central by

- **API fields consumed:** `items`, `pages`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline