### PR TITLE
feat: add Sophos transformations (epp)

### DIFF
--- a/safeguards/epp/sophos/confirmedLicensePurchased.py
+++ b/safeguards/epp/sophos/confirmedLicensePurchased.py
@@ -1,0 +1,101 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Sophos  |  Category: epp
+Evaluates: Confirms a valid Sophos Central license is active by verifying a successful response
+           from the account health check API (healthCheck method). A 200 response with an
+           endpoint or policy sub-object is taken as proof of an active license.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmedLicensePurchased", "vendor": "Sophos", "category": "epp"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        has_endpoint_data = "endpoint" in data and isinstance(data.get("endpoint"), dict)
+        has_policy_data = "policy" in data and isinstance(data.get("policy"), dict)
+        has_items = "items" in data and isinstance(data.get("items"), list)
+        license_confirmed = has_endpoint_data or has_policy_data or has_items
+        return {
+            "confirmedLicensePurchased": license_confirmed,
+            "hasEndpointData": has_endpoint_data,
+            "hasPolicyData": has_policy_data,
+            "endpointHealthAvailable": has_endpoint_data,
+            "policyHealthAvailable": has_policy_data
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append("Sophos Central account health check returned valid data confirming an active license")
+            for k, v in extra_fields.items():
+                pass_reasons.append(k + ": " + str(v))
+        else:
+            fail_reasons.append("Account health check did not return expected endpoint or policy data; license may not be active")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Verify that a valid Sophos Central license is purchased and the API credentials have sufficient access")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/epp/sophos/isEPPConfigured.py
+++ b/safeguards/epp/sophos/isEPPConfigured.py
@@ -1,0 +1,128 @@
+"""
+Transformation: isEPPConfigured
+Vendor: Sophos  |  Category: epp
+Evaluates: EPP configuration health by inspecting the 'endpoint.protection' sub-object of the
+           Sophos account health check response. Passes when notFullyProtected counts for
+           both 'computer' and 'server' are zero (all devices are fully protected).
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPConfigured", "vendor": "Sophos", "category": "epp"}
+        }
+    }
+
+
+def get_not_fully_protected(protection_obj, device_type):
+    if not isinstance(protection_obj, dict):
+        return 0
+    type_data = protection_obj.get(device_type, {})
+    if not isinstance(type_data, dict):
+        return 0
+    return int(type_data.get("notFullyProtected", 0))
+
+
+def evaluate(data):
+    try:
+        endpoint_health = data.get("endpoint", {})
+        if not isinstance(endpoint_health, dict):
+            endpoint_health = {}
+        protection = endpoint_health.get("protection", {})
+        if not isinstance(protection, dict):
+            protection = {}
+        computers_not_protected = get_not_fully_protected(protection, "computer")
+        servers_not_protected = get_not_fully_protected(protection, "server")
+        total_not_protected = computers_not_protected + servers_not_protected
+        has_health_data = "endpoint" in data and isinstance(data.get("endpoint"), dict)
+        configured = has_health_data and total_not_protected == 0
+        return {
+            "isEPPConfigured": configured,
+            "computersNotFullyProtected": computers_not_protected,
+            "serversNotFullyProtected": servers_not_protected,
+            "totalNotFullyProtected": total_not_protected,
+            "hasHealthCheckData": has_health_data
+        }
+    except Exception as e:
+        return {"isEPPConfigured": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPConfigured"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("All endpoints are fully protected — no notFullyProtected computers or servers reported in account health check")
+        else:
+            if not extra_fields.get("hasHealthCheckData", False):
+                fail_reasons.append("Account health check endpoint data is unavailable; EPP configuration status cannot be determined")
+                recommendations.append("Ensure the Sophos Central API credentials have access to the account health check endpoint")
+            else:
+                total = extra_fields.get("totalNotFullyProtected", 0)
+                fail_reasons.append(str(total) + " endpoint(s) are not fully protected according to the Sophos account health check")
+                comp = extra_fields.get("computersNotFullyProtected", 0)
+                srv = extra_fields.get("serversNotFullyProtected", 0)
+                if comp > 0:
+                    additional_findings.append(str(comp) + " computer(s) not fully protected")
+                if srv > 0:
+                    additional_findings.append(str(srv) + " server(s) not fully protected")
+                recommendations.append("Review and remediate unprotected endpoints in Sophos Central to achieve full EPP coverage")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "totalNotFullyProtected": extra_fields.get("totalNotFullyProtected", 0)})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/epp/sophos/isEPPEnabled.py
+++ b/safeguards/epp/sophos/isEPPEnabled.py
@@ -1,0 +1,126 @@
+"""
+Transformation: isEPPEnabled
+Vendor: Sophos  |  Category: epp
+Evaluates: Checks that Sophos Endpoint Protection is enabled across managed endpoints by verifying
+           that at least one endpoint has 'endpointProtection' in assignedProducts and that its
+           health.services.status is not 'bad'.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPEnabled", "vendor": "Sophos", "category": "epp"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        if not isinstance(items, list):
+            items = []
+        total = len(items)
+        if total == 0:
+            return {"isEPPEnabled": False, "totalEndpoints": 0, "eppAssignedCount": 0, "unhealthyCount": 0}
+        epp_assigned_count = 0
+        unhealthy_count = 0
+        for endpoint in items:
+            assigned = endpoint.get("assignedProducts", [])
+            if not isinstance(assigned, list):
+                assigned = []
+            has_epp = False
+            for product in assigned:
+                if isinstance(product, dict) and product.get("code", "") == "endpointProtection":
+                    has_epp = True
+                    break
+            if has_epp:
+                epp_assigned_count = epp_assigned_count + 1
+                health = endpoint.get("health", {})
+                if isinstance(health, dict):
+                    services = health.get("services", {})
+                    if isinstance(services, dict):
+                        svc_status = services.get("status", "")
+                        if svc_status == "bad":
+                            unhealthy_count = unhealthy_count + 1
+        enabled = epp_assigned_count > 0
+        return {
+            "isEPPEnabled": enabled,
+            "totalEndpoints": total,
+            "eppAssignedCount": epp_assigned_count,
+            "unhealthyCount": unhealthy_count
+        }
+    except Exception as e:
+        return {"isEPPEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Sophos Endpoint Protection (endpointProtection) is assigned to " + str(extra_fields.get("eppAssignedCount", 0)) + " of " + str(extra_fields.get("totalEndpoints", 0)) + " endpoints")
+            unhealthy = extra_fields.get("unhealthyCount", 0)
+            if unhealthy > 0:
+                additional_findings.append(str(unhealthy) + " EPP-assigned endpoint(s) have health.services.status of 'bad'")
+        else:
+            fail_reasons.append("No endpoints have Sophos Endpoint Protection (endpointProtection) assigned")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Assign the Endpoint Protection product to all managed endpoints in Sophos Central")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalEndpoints": extra_fields.get("totalEndpoints", 0), criteriaKey: result_value})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/epp/sophos/isEPPLoggingEnabled.py
+++ b/safeguards/epp/sophos/isEPPLoggingEnabled.py
@@ -1,0 +1,145 @@
+"""
+Transformation: isEPPLoggingEnabled
+Vendor: Sophos  |  Category: epp
+Evaluates: Checks that Sophos logging / event-collection services are running on at least one
+           EPP-assigned endpoint by inspecting health.services.serviceDetails for service names
+           that indicate Sophos logging or telemetry activity.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPLoggingEnabled", "vendor": "Sophos", "category": "epp"}
+        }
+    }
+
+
+def has_logging_service(service_details):
+    if not isinstance(service_details, list):
+        return False
+    logging_keywords = ["log", "event", "telemetry", "siem", "journal", "collector"]
+    for svc in service_details:
+        if not isinstance(svc, dict):
+            continue
+        name = svc.get("name", "").lower()
+        status = svc.get("status", "").lower()
+        for keyword in logging_keywords:
+            if keyword in name:
+                if status in ("running", "good", "ok", "active"):
+                    return True
+    return False
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        if not isinstance(items, list):
+            items = []
+        total = len(items)
+        if total == 0:
+            return {"isEPPLoggingEnabled": False, "totalEndpoints": 0, "eppEndpointsChecked": 0, "loggingEnabledCount": 0}
+        epp_checked = 0
+        logging_enabled_count = 0
+        for endpoint in items:
+            assigned = endpoint.get("assignedProducts", [])
+            if not isinstance(assigned, list):
+                assigned = []
+            has_epp = False
+            for product in assigned:
+                if isinstance(product, dict) and product.get("code", "") == "endpointProtection":
+                    has_epp = True
+                    break
+            if not has_epp:
+                continue
+            epp_checked = epp_checked + 1
+            health = endpoint.get("health", {})
+            if not isinstance(health, dict):
+                continue
+            services = health.get("services", {})
+            if not isinstance(services, dict):
+                continue
+            service_details = services.get("serviceDetails", [])
+            if has_logging_service(service_details):
+                logging_enabled_count = logging_enabled_count + 1
+        enabled = logging_enabled_count > 0
+        return {
+            "isEPPLoggingEnabled": enabled,
+            "totalEndpoints": total,
+            "eppEndpointsChecked": epp_checked,
+            "loggingEnabledCount": logging_enabled_count
+        }
+    except Exception as e:
+        return {"isEPPLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append("Sophos logging/event-collection services are running on " + str(extra_fields.get("loggingEnabledCount", 0)) + " EPP-assigned endpoint(s)")
+        else:
+            epp_checked = extra_fields.get("eppEndpointsChecked", 0)
+            if epp_checked == 0:
+                fail_reasons.append("No EPP-assigned endpoints were found to evaluate logging status")
+                recommendations.append("Assign Endpoint Protection to managed endpoints and confirm logging services are enabled")
+            else:
+                fail_reasons.append("No running logging or event-collection services detected on any of the " + str(epp_checked) + " EPP-assigned endpoint(s)")
+                recommendations.append("Ensure Sophos logging and telemetry services are running on all managed endpoints")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"totalEndpoints": extra_fields.get("totalEndpoints", 0), criteriaKey: result_value})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/epp/sophos/isSSOEnabled.py
+++ b/safeguards/epp/sophos/isSSOEnabled.py
@@ -1,0 +1,130 @@
+"""
+Transformation: isSSOEnabled
+Vendor: Sophos  |  Category: epp
+Evaluates: Checks whether an Identity Provider (SSO/SAML) is configured and enabled in Sophos
+           Central by inspecting the items[] array returned from the getIdentityProvider endpoint.
+           At least one active IDP entry must be present for the check to pass.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isSSOEnabled", "vendor": "Sophos", "category": "epp"}
+        }
+    }
+
+
+def is_active_idp(idp_item):
+    if not isinstance(idp_item, dict):
+        return False
+    enabled_flag = idp_item.get("enabled", None)
+    if enabled_flag is True:
+        return True
+    status = str(idp_item.get("status", "")).lower()
+    if status in ("active", "enabled", "configured"):
+        return True
+    if enabled_flag is None and "id" in idp_item:
+        return True
+    return False
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        if not isinstance(items, list):
+            items = []
+        total_providers = len(items)
+        active_providers = 0
+        provider_names = []
+        for idp in items:
+            if is_active_idp(idp):
+                active_providers = active_providers + 1
+                name = idp.get("name", idp.get("type", "Unknown"))
+                provider_names.append(str(name))
+        sso_enabled = active_providers > 0
+        return {
+            "isSSOEnabled": sso_enabled,
+            "totalIdentityProviders": total_providers,
+            "activeIdentityProviders": active_providers,
+            "providerNames": provider_names
+        }
+    except Exception as e:
+        return {"isSSOEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSSOEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            active = extra_fields.get("activeIdentityProviders", 0)
+            names = extra_fields.get("providerNames", [])
+            pass_reasons.append(str(active) + " active Identity Provider(s) configured in Sophos Central")
+            if names:
+                additional_findings.append("Configured providers: " + ", ".join(names))
+        else:
+            total = extra_fields.get("totalIdentityProviders", 0)
+            if total == 0:
+                fail_reasons.append("No Identity Providers found in Sophos Central IDP settings")
+            else:
+                fail_reasons.append(str(total) + " Identity Provider(s) found but none are active/enabled")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Configure an Identity Provider (SAML/SSO) in Sophos Central under Global Settings > Identity Provider")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "totalIdentityProviders": extra_fields.get("totalIdentityProviders", 0)})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/epp/sophos/requiredCoveragePercentage.py
+++ b/safeguards/epp/sophos/requiredCoveragePercentage.py
@@ -1,0 +1,110 @@
+"""
+Transformation: requiredCoveragePercentage
+Vendor: Sophos  |  Category: epp
+Evaluates: Percentage of endpoints with Sophos Endpoint Protection (endpointProtection) product assigned,
+           calculated from the getEndpoints items[] array.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "requiredCoveragePercentage", "vendor": "Sophos", "category": "epp"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        if not isinstance(items, list):
+            items = []
+        total = len(items)
+        if total == 0:
+            return {"requiredCoveragePercentage": 0.0, "totalEndpoints": 0, "protectedEndpoints": 0}
+        protected = 0
+        for endpoint in items:
+            assigned = endpoint.get("assignedProducts", [])
+            if not isinstance(assigned, list):
+                assigned = []
+            for product in assigned:
+                if isinstance(product, dict) and product.get("code", "") == "endpointProtection":
+                    protected = protected + 1
+                    break
+        percentage = round((protected / total) * 100, 2)
+        return {
+            "requiredCoveragePercentage": percentage,
+            "totalEndpoints": total,
+            "protectedEndpoints": protected
+        }
+    except Exception as e:
+        return {"requiredCoveragePercentage": 0.0, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "requiredCoveragePercentage"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: 0.0}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, 0.0)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value > 0:
+            pass_reasons.append("Endpoint Protection coverage: " + str(result_value) + "%")
+            for k, v in extra_fields.items():
+                pass_reasons.append(k + ": " + str(v))
+        else:
+            fail_reasons.append("No endpoints have Sophos Endpoint Protection (endpointProtection) assigned")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Deploy Sophos Endpoint Protection to all managed endpoints via Sophos Central")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"totalEndpoints": extra_fields.get("totalEndpoints", 0), "protectedEndpoints": extra_fields.get("protectedEndpoints", 0), criteriaKey: result_value})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: 0.0},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])


### PR DESCRIPTION
## Summary

Adds 6 **Sophos** (epp) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Sophos API responses against Spektrum safeguard criteria to determine whether the organization's Sophos configuration meets security posture requirements.

**Context:** Sophos is being onboarded as a new epp vendor integration. These scripts cover the `safeguards/epp/sophos` namespace.

## What each transformation does

### `requiredCoveragePercentage.py` (Validated)
Percentage of endpoints with Sophos Endpoint Protection (endpointProtection) product assigned, calculated from the getEndpoints items[] array.

- **API fields consumed:** `items`
- Graceful fallback on missing keys and empty responses

### `confirmedLicensePurchased.py` (Validated)
Confirms a valid Sophos Central license is active by verifying a successful response from the account health check API (healthCheck method). A 200 response with an endpoint or policy sub-object is taken as proof of an active license.

- **API fields consumed:** `endpoint`, `policy`, `items`
- Graceful fallback on missing keys and empty responses

### `isEPPEnabled.py` (Validated)
Checks that Sophos Endpoint Protection is enabled across managed endpoints by verifying that at least one endpoint has 'endpointProtection' in assignedProducts and that its health.services.status is not 'bad'.

- **API fields consumed:** `items`
- Graceful fallback on missing keys and empty responses

### `isEPPLoggingEnabled.py` (Validated)
Checks that Sophos logging / event-collection services are running on at least one EPP-assigned endpoint by inspecting health.services.serviceDetails for service names that indicate Sophos logging or telemetry activity.

- **API fields consumed:** `items`
- Graceful fallback on missing keys and empty responses

### `isEPPConfigured.py` (Validated)
EPP configuration health by inspecting the 'endpoint.protection' sub-object of the Sophos account health check response. Passes when notFullyProtected counts for both 'computer' and 'server' are zero (all devices are fully protected).

- **API fields consumed:** `notFullyProtected`, `endpoint`
- Graceful fallback on missing keys and empty responses

### `isSSOEnabled.py` (Validated)
Checks whether an Identity Provider (SSO/SAML) is configured and enabled in Sophos Central by inspecting the items[] array returned from the getIdentityProvider endpoint. At least one active IDP entry must be present for the check to pass.

- **API fields consumed:** `items`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline