### PR TITLE
feat: add Crowdstrike transformations (claims-defense)

### DIFF
--- a/safeguards/claims-defense/crowdstrike/confirmLicensePurchased.py
+++ b/safeguards/claims-defense/crowdstrike/confirmLicensePurchased.py
@@ -1,0 +1,107 @@
+"""
+Transformation: confirmLicensePurchased
+Vendor: Crowdstrike  |  Category: claims-defense
+Evaluates: Verify that devices are enrolled and reporting into the CrowdStrike Falcon platform
+(meta.pagination.total > 0), confirming an active product subscription and license is in place.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmLicensePurchased", "vendor": "Crowdstrike", "category": "claims-defense"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not isinstance(resources, list):
+            resources = []
+        total = data.get("total", 0)
+        if not isinstance(total, int):
+            total = 0
+        device_count = len(resources)
+        effective_total = total if total > 0 else device_count
+        is_licensed = effective_total > 0
+        return {
+            "confirmLicensePurchased": is_licensed,
+            "totalDevicesReported": effective_total,
+            "enrolledDeviceCount": device_count
+        }
+    except Exception as e:
+        return {"confirmLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("CrowdStrike Falcon devices are enrolled and actively reporting, confirming an active license.")
+            pass_reasons.append("Total devices reported: " + str(eval_result.get("totalDevicesReported", 0)))
+        else:
+            fail_reasons.append("No devices found reporting into the CrowdStrike Falcon platform.")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Ensure the Falcon sensor is deployed and devices are enrolled in the CrowdStrike Falcon platform.")
+            recommendations.append("Verify that a valid CrowdStrike license is active and the API credentials have Hosts read scope.")
+        additional_findings.append("Enrolled device count: " + str(eval_result.get("enrolledDeviceCount", 0)))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/claims-defense/crowdstrike/isEPPConfiguredToVendorGuidance.py
+++ b/safeguards/claims-defense/crowdstrike/isEPPConfiguredToVendorGuidance.py
@@ -1,0 +1,200 @@
+"""
+Transformation: isEPPConfiguredToVendorGuidance
+Vendor: Crowdstrike  |  Category: claims-defense
+Evaluates: Verify that active Prevention Policies have key protection classes enabled per
+CrowdStrike vendor guidance, inspecting settings.classes for machine learning (ML), exploit
+prevention, behavioral analysis, and process blocking capabilities all in 'ENABLED' or
+'AGGRESSIVE' mode.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPConfiguredToVendorGuidance", "vendor": "Crowdstrike", "category": "claims-defense"}
+        }
+    }
+
+
+REQUIRED_CLASS_IDS = [
+    "MACHINE_LEARNING",
+    "EXPLOIT_MITIGATION",
+    "BEHAVIORAL_ANALYSIS",
+    "PROCESS_BLOCKING"
+]
+
+ACCEPTABLE_MODES = ["ENABLED", "AGGRESSIVE"]
+
+
+def check_policy_classes(policy):
+    settings = policy.get("prevention_settings", policy.get("settings", {}))
+    if not isinstance(settings, dict):
+        settings = {}
+    classes = settings.get("classes", [])
+    if not isinstance(classes, list):
+        classes = []
+    found_ids = {}
+    for cls in classes:
+        if not isinstance(cls, dict):
+            continue
+        class_id = cls.get("id", "")
+        mode = cls.get("prevention_mode", cls.get("mode", "DISABLED"))
+        if not isinstance(mode, str):
+            mode = "DISABLED"
+        found_ids[class_id] = mode.upper()
+    missing = []
+    non_compliant = []
+    compliant = []
+    for req_id in REQUIRED_CLASS_IDS:
+        if req_id not in found_ids:
+            missing.append(req_id)
+        elif found_ids[req_id] not in ACCEPTABLE_MODES:
+            non_compliant.append(req_id + " (mode: " + found_ids[req_id] + ")")
+        else:
+            compliant.append(req_id + " (mode: " + found_ids[req_id] + ")")
+    is_compliant = len(missing) == 0 and len(non_compliant) == 0
+    return is_compliant, compliant, non_compliant, missing
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not isinstance(resources, list):
+            resources = []
+        total_policies = len(resources)
+        enabled_policies = [p for p in resources if isinstance(p, dict) and p.get("enabled", False)]
+        if len(enabled_policies) == 0:
+            return {
+                "isEPPConfiguredToVendorGuidance": False,
+                "totalPolicies": total_policies,
+                "enabledPoliciesCount": 0,
+                "compliantPoliciesCount": 0,
+                "nonCompliantPoliciesCount": 0,
+                "complianceDetails": [],
+                "error": "No enabled Prevention Policies found to evaluate vendor guidance compliance."
+            }
+        compliant_policies = []
+        non_compliant_policies = []
+        compliance_details = []
+        for policy in enabled_policies:
+            policy_name = policy.get("name", "Unknown")
+            policy_id = policy.get("id", "")
+            label = policy_name + " (" + policy_id + ")"
+            is_compliant, compliant_classes, non_compliant_classes, missing_classes = check_policy_classes(policy)
+            detail = {
+                "policy": label,
+                "compliant": is_compliant,
+                "compliantClasses": compliant_classes,
+                "nonCompliantClasses": non_compliant_classes,
+                "missingClasses": missing_classes
+            }
+            compliance_details.append(detail)
+            if is_compliant:
+                compliant_policies.append(label)
+            else:
+                non_compliant_policies.append(label)
+        all_compliant = len(non_compliant_policies) == 0 and len(compliant_policies) > 0
+        return {
+            "isEPPConfiguredToVendorGuidance": all_compliant,
+            "totalPolicies": total_policies,
+            "enabledPoliciesCount": len(enabled_policies),
+            "compliantPoliciesCount": len(compliant_policies),
+            "nonCompliantPoliciesCount": len(non_compliant_policies),
+            "complianceDetails": compliance_details
+        }
+    except Exception as e:
+        return {"isEPPConfiguredToVendorGuidance": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPConfiguredToVendorGuidance"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        extra_fields["totalPolicies"] = eval_result.get("totalPolicies", 0)
+        extra_fields["enabledPoliciesCount"] = eval_result.get("enabledPoliciesCount", 0)
+        extra_fields["compliantPoliciesCount"] = eval_result.get("compliantPoliciesCount", 0)
+        extra_fields["nonCompliantPoliciesCount"] = eval_result.get("nonCompliantPoliciesCount", 0)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("All enabled Prevention Policies are configured per CrowdStrike vendor guidance with required protection classes active.")
+            pass_reasons.append("Compliant policies: " + str(eval_result.get("compliantPoliciesCount", 0)) + " of " + str(eval_result.get("enabledPoliciesCount", 0)) + " enabled policies.")
+        else:
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            else:
+                fail_reasons.append("One or more enabled Prevention Policies do not meet CrowdStrike vendor guidance for required protection class configuration.")
+                fail_reasons.append("Non-compliant policies: " + str(eval_result.get("nonCompliantPoliciesCount", 0)) + " of " + str(eval_result.get("enabledPoliciesCount", 0)) + " enabled policies.")
+            recommendations.append("Enable MACHINE_LEARNING, EXPLOIT_MITIGATION, BEHAVIORAL_ANALYSIS, and PROCESS_BLOCKING classes in ENABLED or AGGRESSIVE mode for all active Prevention Policies.")
+            recommendations.append("Navigate to Endpoint Security > Prevention Policies in the Falcon console, select each active policy, and review the protection class settings.")
+        compliance_details = eval_result.get("complianceDetails", [])
+        for detail in compliance_details:
+            if not isinstance(detail, dict):
+                continue
+            policy_label = detail.get("policy", "Unknown")
+            if detail.get("compliant", False):
+                additional_findings.append("COMPLIANT: " + policy_label)
+            else:
+                nc_classes = detail.get("nonCompliantClasses", [])
+                ms_classes = detail.get("missingClasses", [])
+                finding = "NON-COMPLIANT: " + policy_label
+                if nc_classes:
+                    finding = finding + " | Insufficient mode: " + ", ".join(nc_classes)
+                if ms_classes:
+                    finding = finding + " | Missing classes: " + ", ".join(ms_classes)
+                additional_findings.append(finding)
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/claims-defense/crowdstrike/isEPPEnabled.py
+++ b/safeguards/claims-defense/crowdstrike/isEPPEnabled.py
@@ -1,0 +1,126 @@
+"""
+Transformation: isEPPEnabled
+Vendor: Crowdstrike  |  Category: claims-defense
+Evaluates: Check that at least one Prevention Policy resource has 'enabled: true', confirming
+that endpoint protection (NGAV/EPP) is actively enforced across the environment.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPEnabled", "vendor": "Crowdstrike", "category": "claims-defense"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not isinstance(resources, list):
+            resources = []
+        total_policies = len(resources)
+        enabled_policies = []
+        disabled_policies = []
+        for policy in resources:
+            if not isinstance(policy, dict):
+                continue
+            policy_name = policy.get("name", "Unknown")
+            policy_id = policy.get("id", "")
+            if policy.get("enabled", False):
+                enabled_policies.append(policy_name + " (" + policy_id + ")")
+            else:
+                disabled_policies.append(policy_name + " (" + policy_id + ")")
+        enabled_count = len(enabled_policies)
+        is_epp_enabled = enabled_count > 0
+        return {
+            "isEPPEnabled": is_epp_enabled,
+            "totalPolicies": total_policies,
+            "enabledPoliciesCount": enabled_count,
+            "disabledPoliciesCount": len(disabled_policies),
+            "enabledPolicies": enabled_policies,
+            "disabledPolicies": disabled_policies
+        }
+    except Exception as e:
+        return {"isEPPEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        extra_fields["totalPolicies"] = eval_result.get("totalPolicies", 0)
+        extra_fields["enabledPoliciesCount"] = eval_result.get("enabledPoliciesCount", 0)
+        extra_fields["disabledPoliciesCount"] = eval_result.get("disabledPoliciesCount", 0)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("At least one CrowdStrike Prevention Policy is enabled, confirming EPP is actively enforced.")
+            pass_reasons.append("Enabled prevention policies: " + str(eval_result.get("enabledPoliciesCount", 0)) + " of " + str(eval_result.get("totalPolicies", 0)))
+            enabled_list = eval_result.get("enabledPolicies", [])
+            if enabled_list:
+                additional_findings.append("Enabled policies: " + ", ".join(enabled_list))
+        else:
+            fail_reasons.append("No CrowdStrike Prevention Policies are in an enabled state.")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable at least one Prevention Policy in the CrowdStrike Falcon console to enforce endpoint protection.")
+            recommendations.append("Navigate to Endpoint Security > Prevention Policies and toggle policies to Enabled.")
+        disabled_list = eval_result.get("disabledPolicies", [])
+        if disabled_list:
+            additional_findings.append("Disabled policies: " + ", ".join(disabled_list))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/claims-defense/crowdstrike/isEPPEnabledForCriticalSystems.py
+++ b/safeguards/claims-defense/crowdstrike/isEPPEnabledForCriticalSystems.py
@@ -1,0 +1,144 @@
+"""
+Transformation: isEPPEnabledForCriticalSystems
+Vendor: Crowdstrike  |  Category: claims-defense
+Evaluates: Verify that enabled Prevention Policies (enabled: true) have assigned host groups
+(groups array non-empty), ensuring EPP coverage is deployed to host groups that include
+critical systems.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPEnabledForCriticalSystems", "vendor": "Crowdstrike", "category": "claims-defense"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not isinstance(resources, list):
+            resources = []
+        total_policies = len(resources)
+        enabled_with_groups = []
+        enabled_without_groups = []
+        disabled_policies = []
+        for policy in resources:
+            if not isinstance(policy, dict):
+                continue
+            policy_name = policy.get("name", "Unknown")
+            policy_id = policy.get("id", "")
+            label = policy_name + " (" + policy_id + ")"
+            is_enabled = policy.get("enabled", False)
+            if not is_enabled:
+                disabled_policies.append(label)
+                continue
+            groups = policy.get("groups", [])
+            if not isinstance(groups, list):
+                groups = []
+            if len(groups) > 0:
+                group_names = []
+                for g in groups:
+                    if isinstance(g, dict):
+                        group_names.append(g.get("name", g.get("id", "Unknown")))
+                    else:
+                        group_names.append(str(g))
+                enabled_with_groups.append(label + " [groups: " + ", ".join(group_names) + "]")
+            else:
+                enabled_without_groups.append(label)
+        has_enabled_with_groups = len(enabled_with_groups) > 0
+        return {
+            "isEPPEnabledForCriticalSystems": has_enabled_with_groups,
+            "totalPolicies": total_policies,
+            "enabledPoliciesWithGroupsCount": len(enabled_with_groups),
+            "enabledPoliciesWithoutGroupsCount": len(enabled_without_groups),
+            "disabledPoliciesCount": len(disabled_policies),
+            "enabledPoliciesWithGroups": enabled_with_groups,
+            "enabledPoliciesWithoutGroups": enabled_without_groups
+        }
+    except Exception as e:
+        return {"isEPPEnabledForCriticalSystems": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPEnabledForCriticalSystems"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        extra_fields["totalPolicies"] = eval_result.get("totalPolicies", 0)
+        extra_fields["enabledPoliciesWithGroupsCount"] = eval_result.get("enabledPoliciesWithGroupsCount", 0)
+        extra_fields["enabledPoliciesWithoutGroupsCount"] = eval_result.get("enabledPoliciesWithoutGroupsCount", 0)
+        extra_fields["disabledPoliciesCount"] = eval_result.get("disabledPoliciesCount", 0)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("At least one enabled Prevention Policy has host groups assigned, ensuring EPP coverage extends to critical systems.")
+            pass_reasons.append("Enabled policies with host groups: " + str(eval_result.get("enabledPoliciesWithGroupsCount", 0)))
+            groups_list = eval_result.get("enabledPoliciesWithGroups", [])
+            if groups_list:
+                additional_findings.append("Policies with host group assignments: " + "; ".join(groups_list))
+        else:
+            fail_reasons.append("No enabled Prevention Policies have host groups assigned. EPP coverage is not confirmed for critical systems.")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Assign host groups to enabled Prevention Policies in the CrowdStrike Falcon console.")
+            recommendations.append("Ensure host groups are configured to include critical systems (servers, endpoints with sensitive data).")
+            recommendations.append("Navigate to Endpoint Security > Prevention Policies, select a policy, and add host group assignments.")
+        no_group_list = eval_result.get("enabledPoliciesWithoutGroups", [])
+        if no_group_list:
+            additional_findings.append("Enabled policies without host group assignments: " + ", ".join(no_group_list))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/claims-defense/crowdstrike/isEPPLoggingEnabled.py
+++ b/safeguards/claims-defense/crowdstrike/isEPPLoggingEnabled.py
@@ -1,0 +1,111 @@
+"""
+Transformation: isEPPLoggingEnabled
+Vendor: Crowdstrike  |  Category: claims-defense
+Evaluates: Verify that CrowdStrike Falcon is actively generating and logging detection events
+by checking that detection records exist (total > 0 or resources is non-empty), confirming
+that telemetry collection and event logging is operational.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPLoggingEnabled", "vendor": "Crowdstrike", "category": "claims-defense"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        resources = data.get("resources", [])
+        if not isinstance(resources, list):
+            resources = []
+        total = data.get("total", 0)
+        if not isinstance(total, int):
+            total = 0
+        resource_count = len(resources)
+        effective_total = total if total > 0 else resource_count
+        is_logging_enabled = effective_total > 0
+        return {
+            "isEPPLoggingEnabled": is_logging_enabled,
+            "totalDetections": effective_total,
+            "detectionRecordsReturned": resource_count
+        }
+    except Exception as e:
+        return {"isEPPLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        extra_fields["totalDetections"] = eval_result.get("totalDetections", 0)
+        extra_fields["detectionRecordsReturned"] = eval_result.get("detectionRecordsReturned", 0)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("CrowdStrike Falcon is actively generating and logging detection events, confirming telemetry and event logging is operational.")
+            pass_reasons.append("Total detection events recorded: " + str(eval_result.get("totalDetections", 0)))
+        else:
+            fail_reasons.append("No detection events found in the CrowdStrike Falcon platform. EPP logging may not be operational.")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Verify that the Falcon sensor is deployed and reporting telemetry to the cloud.")
+            recommendations.append("Confirm that the API credentials have Detections read scope and that the time window for detection queries is appropriate.")
+            recommendations.append("Note: A brand-new environment with zero detections may still have logging enabled. Supplement with manual validation if needed.")
+        additional_findings.append("Detection records returned in this query: " + str(eval_result.get("detectionRecordsReturned", 0)))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])


### PR DESCRIPTION
## Summary

Adds 5 **Crowdstrike** (claims-defense) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Crowdstrike API responses against Spektrum safeguard criteria to determine whether the organization's Crowdstrike configuration meets security posture requirements.

**Context:** Crowdstrike is being onboarded as a new claims-defense vendor integration. These scripts cover the `safeguards/claims-defense/crowdstrike` namespace.

## What each transformation does

### `confirmLicensePurchased.py` (Validated)
Verify that devices are enrolled and reporting into the CrowdStrike Falcon platform

- **API fields consumed:** `resources`, `total`
- Graceful fallback on missing keys and empty responses

### `isEPPEnabled.py` (Validated)
Check that at least one Prevention Policy resource has 'enabled: true', confirming

- **API fields consumed:** `resources`
- Graceful fallback on missing keys and empty responses

### `isEPPLoggingEnabled.py` (Validated)
Verify that CrowdStrike Falcon is actively generating and logging detection events

- **API fields consumed:** `resources`, `total`
- Graceful fallback on missing keys and empty responses

### `isEPPEnabledForCriticalSystems.py` (Validated)
Verify that enabled Prevention Policies (enabled: true) have assigned host groups

- **API fields consumed:** `resources`
- **Pass criteria:** `policy.get("enabled", False)`
- Graceful fallback on missing keys and empty responses

### `isEPPConfiguredToVendorGuidance.py` (Validated)
Verify that active Prevention Policies have key protection classes enabled per

- **API fields consumed:** `classes`, `resources`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline