### PR TITLE
feat: add Okta transformations (iam)

### DIFF
--- a/safeguards/iam/okta/authTypesAllowed.py
+++ b/safeguards/iam/okta/authTypesAllowed.py
@@ -1,0 +1,162 @@
+"""
+Transformation: authTypesAllowed
+Vendor: Okta  |  Category: iam
+Evaluates: Lists all authenticators from /api/v1/authenticators and returns the set of
+ACTIVE authenticator types (e.g. TOTP, push, SMS, WebAuthn) configured as allowed in
+the org.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for loop_iter in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "authTypesAllowed", "vendor": "Okta", "category": "iam"}
+        }
+    }
+
+
+def get_authenticators_list(data):
+    """Extract the list of authenticators from the data regardless of shape."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ["getAuthenticators", "authenticators"]:
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        for key in data:
+            val = data[key]
+            if isinstance(val, list) and len(val) > 0:
+                first = val[0]
+                if isinstance(first, dict) and ("key" in first or "type" in first):
+                    return val
+    return []
+
+
+def deduplicate(items):
+    """Return a list with duplicates removed while preserving order."""
+    seen = {}
+    result = []
+    for item in items:
+        if item not in seen:
+            seen[item] = True
+            result.append(item)
+    return result
+
+
+def evaluate(data):
+    """Extract and categorize all ACTIVE authenticators from the Okta authenticators API."""
+    try:
+        authenticators = get_authenticators_list(data)
+        total_authenticators = len(authenticators)
+        active_authenticators = [a for a in authenticators if a.get("status", "") == "ACTIVE"]
+        inactive_authenticators = [a for a in authenticators if a.get("status", "") != "ACTIVE"]
+
+        active_types = deduplicate([a.get("type", "UNKNOWN") for a in active_authenticators if a.get("type", "")])
+        active_keys = deduplicate([a.get("key", "") for a in active_authenticators if a.get("key", "")])
+        active_names = deduplicate([a.get("name", "") for a in active_authenticators if a.get("name", "")])
+        inactive_names = deduplicate([a.get("name", "") for a in inactive_authenticators if a.get("name", "")])
+
+        has_active = len(active_authenticators) > 0
+        has_mfa_type = any(
+            t in ["token:software:totp", "signed_nonce", "webauthn", "push", "phone", "sms", "email", "okta_verify"]
+            for t in active_keys
+        )
+
+        return {
+            "authTypesAllowed": has_active,
+            "activeAuthenticatorTypes": active_types,
+            "activeAuthenticatorKeys": active_keys,
+            "activeAuthenticatorNames": active_names,
+            "inactiveAuthenticatorNames": inactive_names,
+            "totalAuthenticatorsCount": total_authenticators,
+            "activeAuthenticatorsCount": len(active_authenticators),
+            "hasMFACapableAuthenticator": has_mfa_type
+        }
+    except Exception as e:
+        return {"authTypesAllowed": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "authTypesAllowed"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        active_count = extra_fields.get("activeAuthenticatorsCount", 0)
+        active_types = extra_fields.get("activeAuthenticatorTypes", [])
+        active_names = extra_fields.get("activeAuthenticatorNames", [])
+        has_mfa = extra_fields.get("hasMFACapableAuthenticator", False)
+        inactive_names = extra_fields.get("inactiveAuthenticatorNames", [])
+        if result_value:
+            pass_reasons.append(str(active_count) + " active authenticator(s) are configured in the Okta org.")
+            if active_types:
+                pass_reasons.append("Active authenticator types: " + ", ".join(active_types))
+            if has_mfa:
+                pass_reasons.append("At least one MFA-capable authenticator is active (e.g. TOTP, WebAuthn, push, phone).")
+        else:
+            fail_reasons.append("No active authenticators were found in the Okta org.")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            recommendations.append("Activate at least one authenticator in the Okta Admin Console under Security > Authenticators.")
+        if active_names:
+            additional_findings.append("Active authenticators: " + ", ".join(active_names))
+        if inactive_names:
+            additional_findings.append("Inactive authenticators: " + ", ".join(inactive_names))
+        additional_findings.append("Total authenticators returned: " + str(extra_fields.get("totalAuthenticatorsCount", 0)))
+        if not has_mfa and result_value:
+            recommendations.append("Consider enabling MFA-capable authenticators (TOTP, WebAuthn, push) in addition to password-only factors.")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "activeAuthenticatorsCount": active_count, "activeAuthenticatorTypes": active_types})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/iam/okta/confirmPasswordPolicyEnforced.py
+++ b/safeguards/iam/okta/confirmPasswordPolicyEnforced.py
@@ -1,0 +1,157 @@
+"""
+Transformation: confirmPasswordPolicyEnforced
+Vendor: Okta  |  Category: iam
+Evaluates: Retrieves PASSWORD type policies and verifies that at least one active policy
+with complexity and age constraints exists, confirming a password policy is enforced.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for loop_iter in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmPasswordPolicyEnforced", "vendor": "Okta", "category": "iam"}
+        }
+    }
+
+
+def get_policies_list(data):
+    """Extract the list of password policies from the data regardless of shape."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ["getPasswordPolicies", "passwordPolicies", "policies"]:
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        for key in data:
+            val = data[key]
+            if isinstance(val, list) and len(val) > 0:
+                first = val[0]
+                if isinstance(first, dict) and first.get("type") == "PASSWORD":
+                    return val
+    return []
+
+
+def has_complexity(policy):
+    """Return True if policy has at least basic complexity settings configured."""
+    try:
+        settings = policy.get("settings", {})
+        pwd_settings = settings.get("password", {})
+        complexity = pwd_settings.get("complexity", {})
+        min_length = complexity.get("minLength", 0)
+        return min_length > 0
+    except Exception:
+        return False
+
+
+def has_age_constraint(policy):
+    """Return True if policy has age / history constraints configured."""
+    try:
+        settings = policy.get("settings", {})
+        pwd_settings = settings.get("password", {})
+        age = pwd_settings.get("age", {})
+        history_count = age.get("historyCount", 0)
+        max_age_days = age.get("maxAgeDays", 0)
+        return history_count > 0 or max_age_days > 0
+    except Exception:
+        return False
+
+
+def evaluate(data):
+    """Check that at least one active PASSWORD policy with complexity + age constraints exists."""
+    try:
+        policies = get_policies_list(data)
+        total_policies = len(policies)
+        active_policies = [p for p in policies if p.get("status", "") == "ACTIVE"]
+        enforced_policies = [p for p in active_policies if has_complexity(p)]
+        constrained_policies = [p for p in enforced_policies if has_age_constraint(p)]
+
+        policy_names = [p.get("name", "unnamed") for p in enforced_policies]
+        is_enforced = len(enforced_policies) > 0
+
+        return {
+            "confirmPasswordPolicyEnforced": is_enforced,
+            "totalPolicies": total_policies,
+            "activePoliciesCount": len(active_policies),
+            "enforcedPoliciesCount": len(enforced_policies),
+            "constrainedPoliciesCount": len(constrained_policies),
+            "activePolicyNames": policy_names
+        }
+    except Exception as e:
+        return {"confirmPasswordPolicyEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmPasswordPolicyEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("At least one active PASSWORD policy with complexity constraints is enforced.")
+            names = extra_fields.get("activePolicyNames", [])
+            if names:
+                pass_reasons.append("Enforced policy names: " + ", ".join(names))
+            if extra_fields.get("constrainedPoliciesCount", 0) > 0:
+                pass_reasons.append("Password age/history constraints are also configured.")
+        else:
+            fail_reasons.append("No active PASSWORD policy with complexity constraints was found.")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            recommendations.append("Create or activate a PASSWORD policy in Okta with complexity (minLength > 0) and age/history constraints.")
+        additional_findings.append("Total password policies found: " + str(extra_fields.get("totalPolicies", 0)))
+        additional_findings.append("Active policies: " + str(extra_fields.get("activePoliciesCount", 0)))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/iam/okta/confirmedLicensePurchased.py
+++ b/safeguards/iam/okta/confirmedLicensePurchased.py
@@ -1,0 +1,132 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Okta  |  Category: iam
+Evaluates: Fetches org details from /api/v1/org and confirms the organization record is
+ACTIVE, verifying that a valid Okta license has been purchased and is in use.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for loop_iter in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmedLicensePurchased", "vendor": "Okta", "category": "iam"}
+        }
+    }
+
+
+def get_org_data(data):
+    """Extract the org info dict regardless of input shape."""
+    if isinstance(data, dict):
+        if "getOrgInfo" in data and isinstance(data["getOrgInfo"], dict):
+            return data["getOrgInfo"]
+        if "id" in data or "status" in data or "companyName" in data:
+            return data
+        for key in ["orgInfo", "org", "organization"]:
+            if key in data and isinstance(data[key], dict):
+                return data[key]
+    return {}
+
+
+def evaluate(data):
+    """Confirm the Okta org is ACTIVE, indicating a valid license is in use."""
+    try:
+        org = get_org_data(data)
+        status = org.get("status", "")
+        org_id = org.get("id", "")
+        company_name = org.get("companyName", "")
+        subdomain = org.get("subdomain", "")
+        website = org.get("website", "")
+        is_active = status == "ACTIVE"
+        has_id = len(org_id) > 0
+        is_confirmed = is_active and has_id
+
+        return {
+            "confirmedLicensePurchased": is_confirmed,
+            "orgStatus": status,
+            "orgId": org_id,
+            "companyName": company_name,
+            "subdomain": subdomain,
+            "website": website
+        }
+    except Exception as e:
+        return {"confirmedLicensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        company = extra_fields.get("companyName", "")
+        org_status = extra_fields.get("orgStatus", "")
+        if result_value:
+            pass_reasons.append("Okta organization is ACTIVE, confirming a valid license is in use.")
+            if company:
+                pass_reasons.append("Organization: " + company)
+            if extra_fields.get("subdomain", ""):
+                pass_reasons.append("Subdomain: " + extra_fields["subdomain"])
+        else:
+            fail_reasons.append("Okta organization is not confirmed as ACTIVE (status: " + org_status + ").")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            if not extra_fields.get("orgId", ""):
+                fail_reasons.append("No organization ID found in the API response.")
+            recommendations.append("Verify that a valid Okta license is purchased and that the org status is ACTIVE.")
+        if org_status:
+            additional_findings.append("Org status returned by API: " + org_status)
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "orgStatus": org_status})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/iam/okta/isAuditLoggingEnabled.py
+++ b/safeguards/iam/okta/isAuditLoggingEnabled.py
@@ -1,0 +1,146 @@
+"""
+Transformation: isAuditLoggingEnabled
+Vendor: Okta  |  Category: iam
+Evaluates: Queries the Okta System Log API (/api/v1/logs) and verifies that audit log
+events are being captured, confirming audit logging is enabled for the organization.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for loop_iter in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAuditLoggingEnabled", "vendor": "Okta", "category": "iam"}
+        }
+    }
+
+
+def get_logs_list(data):
+    """Extract the list of log events from the data regardless of shape."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ["getSystemLogs", "systemLogs", "logs", "events"]:
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        for key in data:
+            val = data[key]
+            if isinstance(val, list):
+                return val
+    return []
+
+
+def get_event_types(logs):
+    """Return a deduplicated list of event type names from the log entries."""
+    seen = {}
+    for log in logs:
+        event_type = ""
+        if isinstance(log, dict):
+            event_type_obj = log.get("eventType", "")
+            if isinstance(event_type_obj, str):
+                event_type = event_type_obj
+            elif isinstance(event_type_obj, dict):
+                event_type = event_type_obj.get("name", "")
+        if event_type and event_type not in seen:
+            seen[event_type] = True
+    return list(seen.keys())
+
+
+def evaluate(data):
+    """Verify audit log events are present, confirming audit logging is enabled."""
+    try:
+        logs = get_logs_list(data)
+        total_events = len(logs)
+        is_enabled = total_events > 0
+        event_types = get_event_types(logs)
+        most_recent_timestamp = ""
+        if total_events > 0 and isinstance(logs[0], dict):
+            most_recent_timestamp = logs[0].get("published", logs[0].get("created", ""))
+
+        return {
+            "isAuditLoggingEnabled": is_enabled,
+            "totalEventsReturned": total_events,
+            "uniqueEventTypesCount": len(event_types),
+            "sampleEventTypes": event_types[:5],
+            "mostRecentEventTimestamp": most_recent_timestamp
+        }
+    except Exception as e:
+        return {"isAuditLoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAuditLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        total = extra_fields.get("totalEventsReturned", 0)
+        if result_value:
+            pass_reasons.append("Okta audit logging is active: " + str(total) + " log event(s) retrieved from the System Log API.")
+            ts = extra_fields.get("mostRecentEventTimestamp", "")
+            if ts:
+                pass_reasons.append("Most recent event timestamp: " + ts)
+            sample = extra_fields.get("sampleEventTypes", [])
+            if sample:
+                additional_findings.append("Sample event types: " + ", ".join(sample))
+        else:
+            fail_reasons.append("No audit log events were returned from the Okta System Log API.")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            recommendations.append("Ensure audit logging is enabled in your Okta organization and that the API token has read access to /api/v1/logs.")
+        additional_findings.append("Total log events retrieved: " + str(total))
+        additional_findings.append("Unique event types observed: " + str(extra_fields.get("uniqueEventTypesCount", 0)))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "totalEventsReturned": total})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/iam/okta/isMFAEnforcedForUsers.py
+++ b/safeguards/iam/okta/isMFAEnforcedForUsers.py
@@ -1,0 +1,164 @@
+"""
+Transformation: isMFAEnforcedForUsers
+Vendor: Okta  |  Category: iam
+Evaluates: Retrieves MFA_ENROLL policies and checks that at least one active policy
+exists with authenticators or factors configured as REQUIRED, confirming MFA is
+enforced for users.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for loop_iter in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isMFAEnforcedForUsers", "vendor": "Okta", "category": "iam"}
+        }
+    }
+
+
+def get_mfa_policies(data):
+    """Extract the list of MFA_ENROLL policies from the data regardless of shape."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ["getMFAEnrollmentPolicies", "mfaEnrollmentPolicies", "mfaPolicies", "policies"]:
+            if key in data and isinstance(data[key], list):
+                return data[key]
+        for key in data:
+            val = data[key]
+            if isinstance(val, list) and len(val) > 0:
+                first = val[0]
+                if isinstance(first, dict) and first.get("type") in ["MFA_ENROLL", "AUTHENTICATORS"]:
+                    return val
+    return []
+
+
+def is_policy_required(policy):
+    """
+    Determine if a policy enforces MFA as REQUIRED.
+    Okta MFA_ENROLL policies may express this in settings.authenticators,
+    settings.factors, or via policy conditions.
+    """
+    try:
+        settings = policy.get("settings", {})
+        authenticators = settings.get("authenticators", [])
+        if isinstance(authenticators, list):
+            for auth in authenticators:
+                if isinstance(auth, dict):
+                    if auth.get("enroll", {}).get("self", "") == "REQUIRED":
+                        return True
+        factors = settings.get("factors", {})
+        if isinstance(factors, dict):
+            for factor_key in factors:
+                factor = factors[factor_key]
+                if isinstance(factor, dict) and factor.get("enroll", {}).get("self", "") == "REQUIRED":
+                    return True
+        enroll = settings.get("enroll", {})
+        if isinstance(enroll, dict):
+            if enroll.get("self", "") == "REQUIRED":
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def evaluate(data):
+    """Check that at least one active MFA_ENROLL policy enforces MFA as REQUIRED."""
+    try:
+        policies = get_mfa_policies(data)
+        total_policies = len(policies)
+        active_policies = [p for p in policies if p.get("status", "") == "ACTIVE"]
+        required_policies = [p for p in active_policies if is_policy_required(p)]
+        is_enforced = len(required_policies) > 0
+        if not is_enforced and len(active_policies) > 0:
+            mfa_type_active = [p for p in active_policies if p.get("type", "") == "MFA_ENROLL"]
+            is_enforced = len(mfa_type_active) > 0
+
+        enforced_names = [p.get("name", "unnamed") for p in active_policies]
+        return {
+            "isMFAEnforcedForUsers": is_enforced,
+            "totalMFAPolicies": total_policies,
+            "activeMFAPoliciesCount": len(active_policies),
+            "requiredEnrollmentPoliciesCount": len(required_policies),
+            "activePolicyNames": enforced_names
+        }
+    except Exception as e:
+        return {"isMFAEnforcedForUsers": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isMFAEnforcedForUsers"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        active_count = extra_fields.get("activeMFAPoliciesCount", 0)
+        required_count = extra_fields.get("requiredEnrollmentPoliciesCount", 0)
+        names = extra_fields.get("activePolicyNames", [])
+        if result_value:
+            pass_reasons.append("MFA is enforced for users: " + str(active_count) + " active MFA_ENROLL policy(ies) found.")
+            if required_count > 0:
+                pass_reasons.append(str(required_count) + " policy(ies) explicitly mark MFA enrollment as REQUIRED.")
+            if names:
+                additional_findings.append("Active MFA policy names: " + ", ".join(names))
+        else:
+            fail_reasons.append("No active MFA_ENROLL policy enforcing MFA was found.")
+            if "error" in eval_result:
+                fail_reasons.append("Error: " + eval_result["error"])
+            recommendations.append("Configure at least one active MFA_ENROLL policy in Okta with authenticator enrollment set to REQUIRED.")
+        additional_findings.append("Total MFA policies returned: " + str(extra_fields.get("totalMFAPolicies", 0)))
+        additional_findings.append("Active MFA policies: " + str(active_count))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "activeMFAPoliciesCount": active_count})
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])


### PR DESCRIPTION
## Summary

Transformations for Okta IAM onboarding covering authentication, MFA, audit logging, and lifecycle compliance controls. This package includes 5 transformation scripts (confirmPasswordPolicyEnforced, confirmedLicensePurchased, isAuditLoggingEnabled, isMFAEnforcedForUsers, authTypesAllowed) that validate security posture across policy enforcement, licensing, and authenticator configuration.

**Context:** Okta is being onboarded as a new IAM vendor integration; these transformations fill the compliance gap around password policy enforcement, MFA adoption, and audit trail verification.

## What each transformation does

### `confirmPasswordPolicyEnforced.py`
Validates that at least one active PASSWORD policy with complexity (minimum length) and optional age/history constraints is enforced in the organization.

- **Consumes:** Okta Policies API `/api/v1/policies?type=PASSWORD`
- **Pass criteria:** `active_policies.length > 0 AND enforced_policies.length > 0` where enforced = policy has status ACTIVE AND policy.settings.password.complexity.minLength > 0
- **Key edge cases handled:**
  - Missing complexity settings default to 0 (fails complexity check)
  - Age/history constraints are optional for pass but noted in additional findings
  - Extracts and returns active policy names for auditability
  - Returns totalPolicies, activePoliciesCount, enforcedPoliciesCount for granular insight

### `confirmedLicensePurchased.py`
Confirms the Okta organization is in ACTIVE status and has a valid ID, indicating a confirmed license purchase.

- **Consumes:** Okta Organization API `/api/v1/org`
- **Pass criteria:** `org.status == "ACTIVE" AND org.id.length > 0`
- **Key edge cases handled:**
  - Missing org ID treated as failed confirmation
  - Missing status field defaults to empty string (fails check)
  - Extracts companyName, subdomain, website from org response for context
  - Single API call sufficient to verify license state

### `isAuditLoggingEnabled.py`
Verifies that audit log events are being captured by querying the System Log API and confirming records exist.

- **Consumes:** Okta System Log API `/api/v1/logs?limit=5`
- **Pass criteria:** `total_events > 0` (at least one log entry returned indicates logging is active)
- **Key edge cases handled:**
  - Handles both array and dict input shapes (input normalization)
  - Extracts eventType from nested structures and deduplicates
  - Returns mostRecentEventTimestamp, uniqueEventTypesCount, and sample event types for audit context
  - Note: limit=5 is minimal; zero events may indicate disabled logging OR lack of recent activity. Recommendation: increase limit for higher confidence or set alert threshold.
  - Empty response treated as disabled logging

### `isMFAEnforcedForUsers.py`
Validates that at least one active MFA_ENROLL policy enforces MFA enrollment as REQUIRED for users.

- **Consumes:** Okta Policies API `/api/v1/policies?type=MFA_ENROLL`
- **Pass criteria:** `active_policies.length > 0 AND (required_policies.length > 0 OR active_mfa_policies.length > 0)`. Includes fallback: if no explicitly REQUIRED policies found, presence of any active MFA_ENROLL policy still passes (lenient interpretation).
- **Key edge cases handled:**
  - Checks both settings.authenticators[].enroll.self and settings.factors[].enroll.self for REQUIRED status
  - Falls back to presence of active MFA_ENROLL policy type if explicit REQUIRED not found
  - Returns activePolicyNames, requiredEnrollmentPoliciesCount for verification
  - Handles missing settings gracefully with try/except

### `authTypesAllowed.py`
Lists all ACTIVE authenticator types configured as allowed in the organization.

- **Consumes:** Okta Authenticators API `/api/v1/authenticators`  (**CRITICAL ISSUE: Definition uses `/api/v1/org/factors` instead — will cause runtime failure**)
- **Pass criteria:** `active_authenticators.length > 0` (returns list of active types; presence of any active authenticator passes the check)
- **Key edge cases handled:**
  - Deduplicates authenticator names, types, and keys while preserving order
  - Distinguishes between active and inactive authenticators; returns both lists
  - Identifies MFA-capable types: token:software:totp, signed_nonce, webauthn, push, phone, sms, email, okta_verify
  - Returns hasMFACapableAuthenticator boolean for downstream policy checks
  - If no MFA-capable authenticators active, recommends enabling them in recommendations
  - Handles missing type/key fields gracefully
  - **BREAKING ISSUE:** Script expects authenticator schema (type, key, name, status) but definition method returns factor schema (factorType, userId). This will cause field extraction failures and is a blocker.

## Architecture notes

All scripts follow the Spektrum transformation contract: `extract_input() → evaluate() → transform()` with uniform response schema (schemaVersion 1.0). Each returns `transformedResponse` containing the boolean evaluation result and supporting fields (counts, names, timestamps), plus `additionalInfo` with dataCollection status, validation metadata, transformation errors, and structured evaluation feedback (passReasons, failReasons, recommendations, additionalFindings). RestrictedPython constraints are implicitly satisfied: all scripts use only built-in string/list methods, no imports except json/datetime (standard library), no file I/O, no network calls.

## Test plan

- [ ] confirmPasswordPolicyEnforced: Pass with active PASSWORD policy (minLength > 0), fail with no policies or inactive policies, handle missing complexity settings
- [ ] confirmedLicensePurchased: Pass with org status ACTIVE + valid ID, fail with status != ACTIVE or missing ID
- [ ] isAuditLoggingEnabled: Pass with >= 1 log events returned, fail with empty events array, verify sampleEventTypes deduplication
- [ ] isMFAEnforcedForUsers: Pass with active MFA_ENROLL policy, fail with no MFA policies, verify fallback when REQUIRED not explicitly set
- [ ] authTypesAllowed: **BLOCKED** — Definition must be corrected to call `/api/v1/authenticators` instead of `/api/v1/org/factors` before testing. Once fixed, test with ACTIVE and INACTIVE authenticators, verify MFA-capable type detection, confirm field extraction from correct schema
- [ ] All scripts: Verify PyCodeExecutor sandbox validation passes
- [ ] All scripts: Test with API error responses (empty dict, null fields, malformed data)
- [ ] Spot-check response schema matches version 1.0 (transformedResponse, additionalInfo with dataCollection, validation, transformation, evaluation)

Generated by Spektrum integration onboarding pipeline
