### PR TITLE
feat: add Proofpoint transformations (bec-automation)

### DIFF
--- a/safeguards/bec-automation/proofpoint/isAntiPhishingEnabled.py
+++ b/safeguards/bec-automation/proofpoint/isAntiPhishingEnabled.py
@@ -1,0 +1,138 @@
+"""
+Transformation: isAntiPhishingEnabled
+Vendor: Proofpoint  |  Category: bec-automation
+Evaluates: Whether anti-phishing and anti-spoofing protections are active in org features
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAntiPhishingEnabled", "vendor": "Proofpoint", "category": "bec-automation"}
+        }
+    }
+
+
+def check_feature_value(val):
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() in ["true", "enabled", "active", "1"]
+    if isinstance(val, int):
+        return val == 1
+    return False
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"isAntiPhishingEnabled": False, "error": "Unexpected data format: expected dict"}
+
+        antiphish_keys = [
+            "anti_spoofing", "antiSpoofing", "impersonation_protection", "impersonationProtection",
+            "anti_phishing", "antiPhishing", "phishing_protection", "phishingProtection",
+            "bec_detection", "becDetection", "spoof_protection", "spoofProtection"
+        ]
+
+        findings = []
+        enabled_features = []
+
+        features_src = data
+        nested_features = data.get("features", {})
+        if isinstance(nested_features, dict) and len(nested_features) > 0:
+            features_src = nested_features
+
+        for key in antiphish_keys:
+            val = features_src.get(key, None)
+            if val is not None:
+                is_on = check_feature_value(val)
+                if is_on:
+                    enabled_features.append(key)
+                findings.append(key + "=" + str(val))
+
+        is_enabled = len(enabled_features) > 0
+
+        return {
+            "isAntiPhishingEnabled": is_enabled,
+            "enabledFeatures": ", ".join(enabled_features) if enabled_features else "none",
+            "featuresChecked": ", ".join(findings) if findings else "none_found"
+        }
+    except Exception as e:
+        return {"isAntiPhishingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAntiPhishingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False}, validation=validation,
+                fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append(criteriaKey + " check passed")
+            for k in extra_fields:
+                pass_reasons.append(k + ": " + str(extra_fields[k]))
+        else:
+            fail_reasons.append(criteriaKey + " check failed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable anti-spoofing and impersonation protection features in Proofpoint Essentials to defend against phishing and BEC attacks.")
+        result = {criteriaKey: result_value}
+        for k in extra_fields:
+            result[k] = extra_fields[k]
+        input_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            input_summary[k] = extra_fields[k]
+        return create_response(
+            result=result, validation=validation,
+            pass_reasons=pass_reasons, fail_reasons=fail_reasons,
+            recommendations=recommendations, input_summary=input_summary)
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/bec-automation/proofpoint/isAutoForwardDisabled.py
+++ b/safeguards/bec-automation/proofpoint/isAutoForwardDisabled.py
@@ -1,0 +1,191 @@
+"""
+Transformation: isAutoForwardDisabled
+Vendor: Proofpoint  |  Category: bec-automation
+Evaluates: Whether automatic email forwarding is blocked via org filter policies
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAutoForwardDisabled", "vendor": "Proofpoint", "category": "bec-automation"}
+        }
+    }
+
+
+AUTO_FORWARD_TERMS = [
+    "auto-forward", "autoforward", "auto forward", "automatic forward",
+    "inbox rule", "inboxrule", "x-ms-exchange-inbox-rules-loop",
+    "forwarding rule", "forwardingrule", "auto-replied", "autoreply",
+    "external forward", "externalforward", "redirect", "mail forward"
+]
+
+BLOCKING_ACTIONS = [
+    "block", "reject", "discard", "deny", "quarantine", "drop", "delete"
+]
+
+
+def contains_forward_term(text):
+    lowered = text.lower()
+    for term in AUTO_FORWARD_TERMS:
+        if term in lowered:
+            return True
+    return False
+
+
+def contains_blocking_action(text):
+    lowered = text.lower()
+    for action in BLOCKING_ACTIONS:
+        if action in lowered:
+            return True
+    return False
+
+
+def filter_blocks_auto_forward(f):
+    name_val = f.get("name", "")
+    desc_val = f.get("description", "")
+    action_val = f.get("action", "")
+    rule_val = f.get("rule", "")
+    cond_val = f.get("condition", "")
+    header_val = f.get("header", "")
+    type_val = f.get("type", "")
+    combined = str(name_val) + " " + str(desc_val) + " " + str(rule_val) + " " + str(cond_val) + " " + str(header_val) + " " + str(type_val)
+    action_combined = str(action_val)
+    if isinstance(f.get("actions"), list):
+        for a in f.get("actions"):
+            action_combined = action_combined + " " + str(a)
+    has_forward = contains_forward_term(combined)
+    has_block = contains_blocking_action(action_combined)
+    if not has_block:
+        has_block = contains_blocking_action(combined)
+    return has_forward and has_block
+
+
+def evaluate(data):
+    try:
+        filters = []
+
+        if isinstance(data, list):
+            filters = data
+        elif isinstance(data, dict):
+            for candidate_key in ["filters", "policies", "rules", "data"]:
+                val = data.get(candidate_key, None)
+                if isinstance(val, list):
+                    filters = val
+                    break
+            if len(filters) == 0:
+                direct_keys = [
+                    "auto_forward_disabled", "autoForwardDisabled",
+                    "block_auto_forward", "blockAutoForward",
+                    "disable_auto_forward", "disableAutoForward"
+                ]
+                for key in direct_keys:
+                    if key in data:
+                        raw_val = data[key]
+                        is_disabled = False
+                        if isinstance(raw_val, bool):
+                            is_disabled = raw_val
+                        elif isinstance(raw_val, str):
+                            is_disabled = raw_val.lower() in ["true", "enabled", "active", "1"]
+                        elif isinstance(raw_val, int):
+                            is_disabled = raw_val == 1
+                        return {
+                            "isAutoForwardDisabled": is_disabled,
+                            "detectedField": key,
+                            "detectedValue": str(raw_val),
+                            "matchingFilters": 0
+                        }
+
+        matching = []
+        for f in filters:
+            if isinstance(f, dict) and filter_blocks_auto_forward(f):
+                name = f.get("name", f.get("id", "unnamed"))
+                matching.append(str(name))
+
+        is_disabled = len(matching) > 0
+
+        return {
+            "isAutoForwardDisabled": is_disabled,
+            "matchingFilters": len(matching),
+            "totalFilters": len(filters),
+            "matchingFilterNames": ", ".join(matching) if matching else "none"
+        }
+    except Exception as e:
+        return {"isAutoForwardDisabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAutoForwardDisabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False}, validation=validation,
+                fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append(criteriaKey + " check passed")
+            for k in extra_fields:
+                pass_reasons.append(k + ": " + str(extra_fields[k]))
+        else:
+            fail_reasons.append(criteriaKey + " check failed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Configure a filter policy in Proofpoint Essentials to block or discard outbound messages identified as auto-forwarded, including those matching X-MS-Exchange-Inbox-Rules-Loop or similar headers.")
+        result = {criteriaKey: result_value}
+        for k in extra_fields:
+            result[k] = extra_fields[k]
+        input_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            input_summary[k] = extra_fields[k]
+        return create_response(
+            result=result, validation=validation,
+            pass_reasons=pass_reasons, fail_reasons=fail_reasons,
+            recommendations=recommendations, input_summary=input_summary)
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/bec-automation/proofpoint/isLegacyAuthBlocked.py
+++ b/safeguards/bec-automation/proofpoint/isLegacyAuthBlocked.py
@@ -1,0 +1,188 @@
+"""
+Transformation: isLegacyAuthBlocked
+Vendor: Proofpoint  |  Category: bec-automation
+Evaluates: Whether legacy authentication protocols are blocked via org filter policies
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isLegacyAuthBlocked", "vendor": "Proofpoint", "category": "bec-automation"}
+        }
+    }
+
+
+LEGACY_AUTH_TERMS = [
+    "legacy_auth", "legacyauth", "legacy auth", "basic auth", "basicauth",
+    "smtp auth", "smtpauth", "pop3", "imap", "ntlm", "digest auth",
+    "legacy authentication", "basic authentication", "older protocol",
+    "legacy_protocol", "legacy protocol"
+]
+
+BLOCKING_ACTIONS = [
+    "block", "reject", "discard", "deny", "quarantine", "drop", "delete"
+]
+
+
+def contains_legacy_auth_term(text):
+    lowered = text.lower()
+    for term in LEGACY_AUTH_TERMS:
+        if term in lowered:
+            return True
+    return False
+
+
+def contains_blocking_action(text):
+    lowered = text.lower()
+    for action in BLOCKING_ACTIONS:
+        if action in lowered:
+            return True
+    return False
+
+
+def filter_matches_legacy_auth_block(f):
+    name_val = f.get("name", "")
+    desc_val = f.get("description", "")
+    action_val = f.get("action", "")
+    rule_val = f.get("rule", "")
+    cond_val = f.get("condition", "")
+    type_val = f.get("type", "")
+    combined = str(name_val) + " " + str(desc_val) + " " + str(rule_val) + " " + str(cond_val) + " " + str(type_val)
+    action_combined = str(action_val)
+    if isinstance(f.get("actions"), list):
+        for a in f.get("actions"):
+            action_combined = action_combined + " " + str(a)
+    has_legacy = contains_legacy_auth_term(combined)
+    has_block = contains_blocking_action(action_combined)
+    if not has_block:
+        has_block = contains_blocking_action(combined)
+    return has_legacy and has_block
+
+
+def evaluate(data):
+    try:
+        filters = []
+
+        if isinstance(data, list):
+            filters = data
+        elif isinstance(data, dict):
+            for candidate_key in ["filters", "policies", "rules", "data"]:
+                val = data.get(candidate_key, None)
+                if isinstance(val, list):
+                    filters = val
+                    break
+            if len(filters) == 0:
+                direct_check_keys = [
+                    "block_legacy_auth", "blockLegacyAuth", "legacy_auth_blocked", "legacyAuthBlocked"
+                ]
+                for key in direct_check_keys:
+                    if key in data:
+                        raw_val = data[key]
+                        is_blocked = False
+                        if isinstance(raw_val, bool):
+                            is_blocked = raw_val
+                        elif isinstance(raw_val, str):
+                            is_blocked = raw_val.lower() in ["true", "enabled", "active", "1"]
+                        elif isinstance(raw_val, int):
+                            is_blocked = raw_val == 1
+                        return {
+                            "isLegacyAuthBlocked": is_blocked,
+                            "detectedField": key,
+                            "detectedValue": str(raw_val),
+                            "matchingFilters": 0
+                        }
+
+        matching = []
+        for f in filters:
+            if isinstance(f, dict) and filter_matches_legacy_auth_block(f):
+                name = f.get("name", f.get("id", "unnamed"))
+                matching.append(str(name))
+
+        is_blocked = len(matching) > 0
+
+        return {
+            "isLegacyAuthBlocked": is_blocked,
+            "matchingFilters": len(matching),
+            "totalFilters": len(filters),
+            "matchingFilterNames": ", ".join(matching) if matching else "none"
+        }
+    except Exception as e:
+        return {"isLegacyAuthBlocked": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isLegacyAuthBlocked"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False}, validation=validation,
+                fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append(criteriaKey + " check passed")
+            for k in extra_fields:
+                pass_reasons.append(k + ": " + str(extra_fields[k]))
+        else:
+            fail_reasons.append(criteriaKey + " check failed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Create or enable a filter policy in Proofpoint Essentials that blocks or rejects connections using legacy authentication protocols such as SMTP AUTH, POP3, IMAP, and NTLM.")
+        result = {criteriaKey: result_value}
+        for k in extra_fields:
+            result[k] = extra_fields[k]
+        input_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            input_summary[k] = extra_fields[k]
+        return create_response(
+            result=result, validation=validation,
+            pass_reasons=pass_reasons, fail_reasons=fail_reasons,
+            recommendations=recommendations, input_summary=input_summary)
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/bec-automation/proofpoint/isMailboxAuditingEnabled.py
+++ b/safeguards/bec-automation/proofpoint/isMailboxAuditingEnabled.py
@@ -1,0 +1,134 @@
+"""
+Transformation: isMailboxAuditingEnabled
+Vendor: Proofpoint  |  Category: bec-automation
+Evaluates: Whether mailbox-level auditing and activity logging is enabled in org audit settings
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isMailboxAuditingEnabled", "vendor": "Proofpoint", "category": "bec-automation"}
+        }
+    }
+
+
+def check_feature_value(val):
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() in ["true", "enabled", "active", "1"]
+    if isinstance(val, int):
+        return val == 1
+    return False
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"isMailboxAuditingEnabled": False, "error": "Unexpected data format: expected dict"}
+
+        audit_enabled_keys = [
+            "audit_enabled", "auditEnabled", "logging_enabled", "loggingEnabled",
+            "audit_logging", "auditLogging", "mailbox_audit", "mailboxAudit",
+            "audit_trail", "auditTrail", "activity_logging", "activityLogging",
+            "enabled"
+        ]
+
+        detected_key = "none"
+        detected_value = None
+        found = False
+
+        for key in audit_enabled_keys:
+            if key in data:
+                detected_key = key
+                detected_value = data[key]
+                found = True
+                break
+
+        is_enabled = check_feature_value(detected_value) if found else False
+
+        return {
+            "isMailboxAuditingEnabled": is_enabled,
+            "detectedField": detected_key,
+            "detectedValue": str(detected_value) if detected_value is not None else "not_found"
+        }
+    except Exception as e:
+        return {"isMailboxAuditingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isMailboxAuditingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False}, validation=validation,
+                fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append(criteriaKey + " check passed")
+            for k in extra_fields:
+                pass_reasons.append(k + ": " + str(extra_fields[k]))
+        else:
+            fail_reasons.append(criteriaKey + " check failed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable mailbox auditing and activity logging in Proofpoint Essentials to maintain an audit trail for security investigations and compliance.")
+        result = {criteriaKey: result_value}
+        for k in extra_fields:
+            result[k] = extra_fields[k]
+        input_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            input_summary[k] = extra_fields[k]
+        return create_response(
+            result=result, validation=validation,
+            pass_reasons=pass_reasons, fail_reasons=fail_reasons,
+            recommendations=recommendations, input_summary=input_summary)
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/bec-automation/proofpoint/isSMTPAuthDisabled.py
+++ b/safeguards/bec-automation/proofpoint/isSMTPAuthDisabled.py
@@ -1,0 +1,156 @@
+"""
+Transformation: isSMTPAuthDisabled
+Vendor: Proofpoint  |  Category: bec-automation
+Evaluates: Whether SMTP AUTH is disabled or restricted at the organizational level in org details
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isSMTPAuthDisabled", "vendor": "Proofpoint", "category": "bec-automation"}
+        }
+    }
+
+
+def check_feature_value(val):
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() in ["true", "enabled", "active", "1"]
+    if isinstance(val, int):
+        return val == 1
+    return False
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"isSMTPAuthDisabled": False, "error": "Unexpected data format: expected dict"}
+
+        smtp_auth_enabled_keys = [
+            "smtp_auth_enabled", "smtpAuthEnabled", "smtp_auth", "smtpAuth",
+            "smtp_authentication", "smtpAuthentication", "allow_smtp_auth", "allowSmtpAuth"
+        ]
+
+        detected_key = "none"
+        detected_value = None
+        found = False
+
+        for key in smtp_auth_enabled_keys:
+            if key in data:
+                detected_key = key
+                detected_value = data[key]
+                found = True
+                break
+
+        if not found:
+            smtp_disabled_keys = [
+                "smtp_auth_disabled", "smtpAuthDisabled", "disable_smtp_auth", "disableSmtpAuth"
+            ]
+            for key in smtp_disabled_keys:
+                if key in data:
+                    detected_key = key
+                    detected_value = data[key]
+                    is_disabled = check_feature_value(detected_value)
+                    return {
+                        "isSMTPAuthDisabled": is_disabled,
+                        "detectedField": detected_key,
+                        "detectedValue": str(detected_value)
+                    }
+
+        if not found:
+            return {
+                "isSMTPAuthDisabled": False,
+                "detectedField": "none",
+                "detectedValue": "not_found",
+                "note": "No SMTP auth field detected; assuming enabled (not disabled)"
+            }
+
+        smtp_auth_is_enabled = check_feature_value(detected_value)
+        is_disabled = not smtp_auth_is_enabled
+
+        return {
+            "isSMTPAuthDisabled": is_disabled,
+            "detectedField": detected_key,
+            "detectedValue": str(detected_value)
+        }
+    except Exception as e:
+        return {"isSMTPAuthDisabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSMTPAuthDisabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False}, validation=validation,
+                fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append(criteriaKey + " check passed")
+            for k in extra_fields:
+                pass_reasons.append(k + ": " + str(extra_fields[k]))
+        else:
+            fail_reasons.append(criteriaKey + " check failed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Disable SMTP AUTH at the organizational level in Proofpoint Essentials to reduce the risk of credential-based email abuse.")
+        result = {criteriaKey: result_value}
+        for k in extra_fields:
+            result[k] = extra_fields[k]
+        input_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            input_summary[k] = extra_fields[k]
+        return create_response(
+            result=result, validation=validation,
+            pass_reasons=pass_reasons, fail_reasons=fail_reasons,
+            recommendations=recommendations, input_summary=input_summary)
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/bec-automation/proofpoint/isSafeAttachmentsEnabled.py
+++ b/safeguards/bec-automation/proofpoint/isSafeAttachmentsEnabled.py
@@ -1,0 +1,142 @@
+"""
+Transformation: isSafeAttachmentsEnabled
+Vendor: Proofpoint  |  Category: bec-automation
+Evaluates: Whether Attachment Defense is enabled in org features
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isSafeAttachmentsEnabled", "vendor": "Proofpoint", "category": "bec-automation"}
+        }
+    }
+
+
+def check_feature_value(val):
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() in ["true", "enabled", "active", "1"]
+    if isinstance(val, int):
+        return val == 1
+    return False
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"isSafeAttachmentsEnabled": False, "error": "Unexpected data format: expected dict"}
+
+        attachment_keys = [
+            "attachment_defense", "attachmentdefense", "sandbox", "attachment_sandboxing",
+            "attachmentDefense", "attachmentSandboxing", "malware_defense", "malwareDefense"
+        ]
+
+        detected_key = "none"
+        detected_value = None
+        found = False
+
+        for key in attachment_keys:
+            if key in data:
+                detected_key = key
+                detected_value = data[key]
+                found = True
+                break
+
+        if not found:
+            features = data.get("features", {})
+            if isinstance(features, dict):
+                for key in attachment_keys:
+                    if key in features:
+                        detected_key = key
+                        detected_value = features[key]
+                        found = True
+                        break
+
+        is_enabled = check_feature_value(detected_value) if found else False
+
+        return {
+            "isSafeAttachmentsEnabled": is_enabled,
+            "detectedField": detected_key,
+            "detectedValue": str(detected_value) if detected_value is not None else "not_found"
+        }
+    except Exception as e:
+        return {"isSafeAttachmentsEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSafeAttachmentsEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False}, validation=validation,
+                fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append(criteriaKey + " check passed")
+            for k in extra_fields:
+                pass_reasons.append(k + ": " + str(extra_fields[k]))
+        else:
+            fail_reasons.append(criteriaKey + " check failed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable Attachment Defense in Proofpoint Essentials to sandbox and analyze potentially malicious email attachments.")
+        result = {criteriaKey: result_value}
+        for k in extra_fields:
+            result[k] = extra_fields[k]
+        input_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            input_summary[k] = extra_fields[k]
+        return create_response(
+            result=result, validation=validation,
+            pass_reasons=pass_reasons, fail_reasons=fail_reasons,
+            recommendations=recommendations, input_summary=input_summary)
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])

--- a/safeguards/bec-automation/proofpoint/isSafeLinksEnabled.py
+++ b/safeguards/bec-automation/proofpoint/isSafeLinksEnabled.py
@@ -1,0 +1,142 @@
+"""
+Transformation: isSafeLinksEnabled
+Vendor: Proofpoint  |  Category: bec-automation
+Evaluates: Whether URL Defense (Proofpoint's Safe Links equivalent) is enabled in org features
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for attempt in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isSafeLinksEnabled", "vendor": "Proofpoint", "category": "bec-automation"}
+        }
+    }
+
+
+def check_feature_value(val):
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.lower() in ["true", "enabled", "active", "1"]
+    if isinstance(val, int):
+        return val == 1
+    return False
+
+
+def evaluate(data):
+    try:
+        if not isinstance(data, dict):
+            return {"isSafeLinksEnabled": False, "error": "Unexpected data format: expected dict"}
+
+        url_defense_keys = [
+            "url_defense", "urldefense", "url_rewriting", "click_protection",
+            "url_protection", "urlDefense", "urlRewriting", "clickProtection"
+        ]
+
+        detected_key = "none"
+        detected_value = None
+        found = False
+
+        for key in url_defense_keys:
+            if key in data:
+                detected_key = key
+                detected_value = data[key]
+                found = True
+                break
+
+        if not found:
+            features = data.get("features", {})
+            if isinstance(features, dict):
+                for key in url_defense_keys:
+                    if key in features:
+                        detected_key = key
+                        detected_value = features[key]
+                        found = True
+                        break
+
+        is_enabled = check_feature_value(detected_value) if found else False
+
+        return {
+            "isSafeLinksEnabled": is_enabled,
+            "detectedField": detected_key,
+            "detectedValue": str(detected_value) if detected_value is not None else "not_found"
+        }
+    except Exception as e:
+        return {"isSafeLinksEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSafeLinksEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False}, validation=validation,
+                fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {}
+        for k in eval_result:
+            if k != criteriaKey and k != "error":
+                extra_fields[k] = eval_result[k]
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value:
+            pass_reasons.append(criteriaKey + " check passed")
+            for k in extra_fields:
+                pass_reasons.append(k + ": " + str(extra_fields[k]))
+        else:
+            fail_reasons.append(criteriaKey + " check failed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Enable URL Defense in Proofpoint Essentials to protect users from malicious URLs in emails.")
+        result = {criteriaKey: result_value}
+        for k in extra_fields:
+            result[k] = extra_fields[k]
+        input_summary = {criteriaKey: result_value}
+        for k in extra_fields:
+            input_summary[k] = extra_fields[k]
+        return create_response(
+            result=result, validation=validation,
+            pass_reasons=pass_reasons, fail_reasons=fail_reasons,
+            recommendations=recommendations, input_summary=input_summary)
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)])


### PR DESCRIPTION
## Summary
Proofpoint Essentials is being onboarded as a new email security vendor integration for the BEC-automation safeguard category. These 7 transformations evaluate 7 security controls spanning anti-phishing/spoofing protection, URL and attachment defense, legacy authentication blocking, SMTP AUTH restrictions, auto-forwarding controls, and mailbox auditing. All scripts pass PyCodeExecutor sandbox validation.

**Context:** Proofpoint Essentials customers need to validate email security posture against BEC/phishing attack vectors. These transformations enable compliance checks against organizational policy configurations accessible via the REST API.

## What each transformation does

### `isAntiPhishingEnabled.py`
Validates that anti-spoofing and impersonation protection features are active to defend against phishing and BEC attacks.

- **Consumes:** Proofpoint Essentials API `/api/v1/orgs/{domain}/features`
- **Pass criteria:** At least one of: `anti_spoofing`, `impersonation_protection`, `anti_phishing`, `bec_detection`, or `spoof_protection` set to true/enabled/active (checked at root level or nested under `features` dict)
- **Key edge cases handled:**
  - Script gracefully extracts from both root and nested `features` key
  - Boolean, string ("true"/"enabled"/"active"/"1"), and integer (1) values supported
  - Missing fields default to false (safe fail)
  - Returns `enabledFeatures` list and `featuresChecked` for observability

### `isSafeLinksEnabled.py`
Evaluates whether URL Defense (Proofpoint's equivalent of Safe Links) is enabled for click-time protection against malicious URLs.

- **Consumes:** Proofpoint Essentials API `/api/v1/orgs/{domain}/features`
- **Pass criteria:** Field `url_defense`, `urldefense`, `url_rewriting`, `click_protection`, or equivalent variant set to true/enabled/active
- **Key edge cases handled:**
  - Searches multiple field name variations (camelCase, snake_case, synonyms)
  - Returns `detectedField` and `detectedValue` for verification
  - Nested `features` dict supported
  - Missing field defaults to false (safe fail)

### `isSafeAttachmentsEnabled.py`
Checks whether Attachment Defense (sandbox-based malware analysis) is enabled.

- **Consumes:** Proofpoint Essentials API `/api/v1/orgs/{domain}/features`
- **Pass criteria:** Field `attachment_defense`, `attachmentdefense`, `sandbox`, `malware_defense`, or equivalent set to true/enabled/active
- **Key edge cases handled:**
  - Comprehensive field name search (including `malwareDefense`, `attachmentSandboxing`)
  - Returns detected field name and value for debugging
  - Nested features dict supported

### `isLegacyAuthBlocked.py`
Validates that filter policies exist to block legacy authentication protocols (SMTP AUTH, POP3, IMAP, NTLM, Digest Auth).

- **Consumes:** Proofpoint Essentials API `/api/v1/orgs/{domain}/filters`
- **Pass criteria:** At least one filter rule exists with name/description/condition containing legacy auth terms ("legacy_auth", "smtp auth", "pop3", "imap", "ntlm", "digest auth", etc.) AND action field contains blocking term ("block", "reject", "discard", "deny", "quarantine")
- **Key edge cases handled:**
  - Accepts filters as list directly or extracts from dict.filters/policies/rules/data keys
  - Falls back to direct boolean field check: `block_legacy_auth`, `legacy_auth_blocked`, etc.
  - Case-insensitive substring matching on filter name/description/actions
  - Returns `matchingFilters` count, `totalFilters`, and `matchingFilterNames` for audit trail
  - **CAVEAT:** String matching on policy names is heuristic; may miss policies written in non-English or with non-standard naming

### `isAutoForwardDisabled.py`
Evaluates whether mail flow filter policies block automatic email forwarding to prevent account takeover lateral movement.

- **Consumes:** Proofpoint Essentials API `/api/v1/orgs/{domain}/filters`
- **Pass criteria:** At least one filter rule exists with name/description/header containing auto-forward terms ("auto-forward", "forwarding rule", "x-ms-exchange-inbox-rules-loop", "redirect", "mail forward") AND action contains block/reject/discard/deny/quarantine
- **Key edge cases handled:**
  - Detects both outbound auto-forward rules and inbox rule headers (X-MS-Exchange-Inbox-Rules-Loop)
  - Case-insensitive fuzzy matching on filter conditions and actions
  - Fallback to direct field check: `auto_forward_disabled`, `block_auto_forward`, etc.
  - Returns matching filter names and counts
  - **CAVEAT:** String-based detection; weak if org uses vendor-specific header names or policy naming conventions

### `isSMTPAuthDisabled.py`
Validates that SMTP AUTH is disabled or restricted at the organization level to reduce credential-based abuse risk.

- **Consumes:** Proofpoint Essentials API `/api/v1/orgs/{domain}` (getOrgDetails)
- **Pass criteria:** Either a field `smtp_auth_disabled` set to true, OR field `smtp_auth_enabled` set to false (inverted logic)
- **Key edge cases handled:**
  - Checks both naming patterns: enabled/disabled variants
  - Boolean, string ("true"/"enabled"), and integer (1) coerced correctly
  - **RISK:** If field not found, script defaults to false (assumes SMTP AUTH is enabled, not disabled). This is conservative but means missing field = fail.
  - Returns `detectedField`, `detectedValue`, and optional `note` explaining assumption

### `isMailboxAuditingEnabled.py`
Checks whether mailbox-level activity logging and audit trail collection is enabled for forensics and compliance.

- **Consumes:** Proofpoint Essentials API `/api/v1/orgs/{domain}/audit` (getAuditSettings)
- **Pass criteria:** Any of: `audit_enabled`, `logging_enabled`, `audit_logging`, `mailbox_audit`, `audit_trail`, `activity_logging`, or `enabled` set to true
- **Key edge cases handled:**
  - Broad field name search for compatibility
  - Returns detected field and value
  - **RISK:** Using generic key `"enabled"` is fragile; could collide with unrelated config flags if API response includes other boolean settings. Recommend validating actual API response schema before deployment.

## Architecture notes

All scripts follow the Spektrum transformation contract: `extract_input() -> evaluate() -> transform()` with unified response schema v1.0. The `extract_input()` function handles legacy wrapper variations (api_response, response, result, etc.) for backwards compatibility. The `evaluate()` function is the pure logic core (no side effects) returning intermediate results. The `transform()` function wraps evaluation, builds the standardized response envelope with `additionalInfo` (dataCollection, validation, transformation, evaluation metadata, schemaVersion: "1.0"), and handles exceptions gracefully. All response objects include `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for actionable feedback. RestrictedPython constraints: scripts use only built-in string/dict/list operations and datetime.utcnow(); no file I/O, imports (except json, datetime), or network calls.

## Test plan

- [x] All 7 scripts pass PyCodeExecutor sandbox validation (validation results provided)
- [ ] Integration test: Call each method against live/sandbox Proofpoint Essentials tenant
  - [ ] Verify `getOrgFeatures` response contains expected field names (url_defense, attachment_defense, anti_spoofing, etc.) — **CRITICAL:** Field names not yet confirmed in official API docs; may require empirical discovery
  - [ ] Verify `getOrgFilters` response structure (confirm filters are list, contain name/description/action fields)
  - [ ] Verify `getAuditSettings` response contains audit enable/disable flags
  - [ ] Verify `getOrgDetails` contains smtp_auth_* fields
- [ ] Edge case validation:
  - [ ] Test with missing feature flags (should default false)
  - [ ] Test with empty filters list (should fail)
  - [ ] Test with null/undefined fields
  - [ ] Test with API error responses (if endpoint returns {stat: "FAIL"}, script should return false)
- [ ] Field accuracy:
  - [ ] **isSafeLinksEnabled / isSafeAttachmentsEnabled / isAntiPhishingEnabled:** Confirm actual API field names match one of the variants in script's search list. If Proofpoint uses different naming, list must be updated.
  - [ ] **isMailboxAuditingEnabled:** Isolate which field in /audit endpoint indicates auditing is enabled; remove generic `"enabled"` from search if it creates false positives.
  - [ ] **isLegacyAuthBlocked / isAutoForwardDisabled:** Manual review of filter policies in test tenant to confirm script detects expected rules correctly.
- [ ] Response schema:
  - [ ] Confirm all pass/fail scenarios return schema v1.0 with correct metadata (schemaVersion, transformationId, vendor, category)
  - [ ] Verify `evaluatedAt` timestamp is ISO format with Z suffix
  - [ ] Spot-check `passReasons`, `failReasons`, `recommendations` are populated correctly

## Known risks & remediation

1. **Field name assumptions (High):** Scripts search for multiple field name variants, but Proofpoint API field naming is not fully documented in public API docs. Recommend:
   - Call `/api/v1/orgs/{domain}/features`, `/api/v1/orgs/{domain}/audit`, etc. against actual tenant
   - Log all returned field names
   - Cross-reference with script's search lists; adjust if needed

2. **isSMTPAuthDisabled fallback assumption (Medium):** If field not found, defaults to false (conservatively fails the check). Confirm this is correct semantics with Proofpoint docs or support.

3. **isMailboxAuditingEnabled generic 'enabled' key (Medium):** May collide with other settings. Recommend narrowing to `audit_enabled`, `logging_enabled`, `audit_*` patterns only.

4. **isLegacyAuthBlocked / isAutoForwardDisabled string matching (Medium):** Heuristic approach via substring matching on filter names. Will miss policies using non-English descriptions or custom naming. Recommend:
   - Validate against production filter policies
   - Document expected filter name patterns for customers
   - Consider adding config option to whitelist specific filter IDs by name

Generated by Spektrum integration onboarding pipeline