### PR TITLE
feat: add Google transformations (iam)

### DIFF
--- a/safeguards/iam/google/isMFAEnabled.py
+++ b/safeguards/iam/google/isMFAEnabled.py
@@ -1,0 +1,167 @@
+"""
+Transformation: isMFAEnabled
+Vendor: Google  |  Category: IAM
+Evaluates: Check if MFA (2-Step Verification) is enabled in the Google Workspace domain
+by inspecting the isEnrolledIn2Sv field on user objects returned by the Directory API.
+Passes if at least one user is enrolled, indicating 2SV is available and in use.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isMFAEnabled", "vendor": "Google", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        users = data.get("users", [])
+        if not isinstance(users, list):
+            users = []
+
+        total_users = len(users)
+        enrolled_count = 0
+        not_enrolled = []
+
+        for user in users:
+            email = user.get("primaryEmail", user.get("email", "unknown"))
+            enrolled = user.get("isEnrolledIn2Sv", False)
+            if enrolled:
+                enrolled_count = enrolled_count + 1
+            else:
+                not_enrolled.append(email)
+
+        if total_users == 0:
+            return {
+                "isMFAEnabled": False,
+                "totalUsers": 0,
+                "enrolledCount": 0,
+                "notEnrolledCount": 0,
+                "enrollmentPercentage": 0,
+                "notEnrolledUsers": [],
+                "error": "No users found in API response"
+            }
+
+        not_enrolled_count = total_users - enrolled_count
+        percentage = (enrolled_count * 100) // total_users
+
+        mfa_enabled = enrolled_count > 0
+
+        return {
+            "isMFAEnabled": mfa_enabled,
+            "totalUsers": total_users,
+            "enrolledCount": enrolled_count,
+            "notEnrolledCount": not_enrolled_count,
+            "enrollmentPercentage": percentage,
+            "notEnrolledUsers": not_enrolled
+        }
+    except Exception as e:
+        return {"isMFAEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isMFAEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        total_users = eval_result.get("totalUsers", 0)
+        enrolled_count = eval_result.get("enrolledCount", 0)
+        not_enrolled_count = eval_result.get("notEnrolledCount", 0)
+        enrollment_percentage = eval_result.get("enrollmentPercentage", 0)
+        not_enrolled_users = eval_result.get("notEnrolledUsers", [])
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                "MFA (2-Step Verification) is enabled: " + str(enrolled_count) +
+                " of " + str(total_users) + " users are enrolled (" +
+                str(enrollment_percentage) + "%)"
+            )
+        else:
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            else:
+                fail_reasons.append(
+                    "No users are enrolled in 2-Step Verification out of " +
+                    str(total_users) + " total users"
+                )
+            recommendations.append(
+                "Enable and enforce 2-Step Verification (2SV) for all users in the Google Workspace Admin Console under Security > 2-Step Verification"
+            )
+
+        if not_enrolled_count > 0:
+            additional_findings.append(
+                str(not_enrolled_count) + " user(s) are not enrolled in 2SV"
+            )
+
+        extra_fields = {
+            "totalUsers": total_users,
+            "enrolledCount": enrolled_count,
+            "notEnrolledCount": not_enrolled_count,
+            "enrollmentPercentage": enrollment_percentage,
+            "notEnrolledUsers": not_enrolled_users
+        }
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalUsers": total_users, "enrolledCount": enrolled_count}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/google/isMFAEnforcedForAdminAccess.py
+++ b/safeguards/iam/google/isMFAEnforcedForAdminAccess.py
@@ -1,0 +1,179 @@
+"""
+Transformation: isMFAEnforcedForAdminAccess
+Vendor: Google  |  Category: IAM
+Evaluates: Verify that MFA (2-Step Verification) is enforced for all administrator accounts
+by checking the isEnforcedIn2Sv field on admin users returned by the Directory API
+with query=isAdmin=true. Passes if all admin users have isEnforcedIn2Sv=true.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isMFAEnforcedForAdminAccess", "vendor": "Google", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        users = data.get("users", [])
+        if not isinstance(users, list):
+            users = []
+
+        admin_users = [u for u in users if u.get("isAdmin", False) or u.get("isDelegatedAdmin", False)]
+
+        if not admin_users:
+            admin_users = users
+
+        total_admins = len(admin_users)
+
+        if total_admins == 0:
+            return {
+                "isMFAEnforcedForAdminAccess": False,
+                "totalAdminUsers": 0,
+                "enforcedCount": 0,
+                "notEnforcedCount": 0,
+                "notEnforcedAdmins": [],
+                "notEnrolledAdmins": [],
+                "error": "No admin users found in API response"
+            }
+
+        enforced_count = 0
+        not_enforced = []
+        not_enrolled = []
+
+        for user in admin_users:
+            email = user.get("primaryEmail", user.get("email", "unknown"))
+            enforced = user.get("isEnforcedIn2Sv", False)
+            enrolled = user.get("isEnrolledIn2Sv", False)
+            if enforced:
+                enforced_count = enforced_count + 1
+            else:
+                not_enforced.append(email)
+            if not enrolled:
+                not_enrolled.append(email)
+
+        not_enforced_count = total_admins - enforced_count
+        all_enforced = enforced_count == total_admins
+
+        return {
+            "isMFAEnforcedForAdminAccess": all_enforced,
+            "totalAdminUsers": total_admins,
+            "enforcedCount": enforced_count,
+            "notEnforcedCount": not_enforced_count,
+            "notEnforcedAdmins": not_enforced,
+            "notEnrolledAdmins": not_enrolled
+        }
+    except Exception as e:
+        return {"isMFAEnforcedForAdminAccess": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isMFAEnforcedForAdminAccess"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        total_admins = eval_result.get("totalAdminUsers", 0)
+        enforced_count = eval_result.get("enforcedCount", 0)
+        not_enforced_count = eval_result.get("notEnforcedCount", 0)
+        not_enforced_admins = eval_result.get("notEnforcedAdmins", [])
+        not_enrolled_admins = eval_result.get("notEnrolledAdmins", [])
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                "2-Step Verification is enforced for all " + str(total_admins) +
+                " administrator account(s)"
+            )
+        else:
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            else:
+                fail_reasons.append(
+                    str(not_enforced_count) + " of " + str(total_admins) +
+                    " admin account(s) do not have 2-Step Verification enforced: " +
+                    ", ".join(not_enforced_admins[:10])
+                )
+            recommendations.append(
+                "Enforce 2-Step Verification for all administrator accounts in the Google Workspace Admin Console under Security > 2-Step Verification > Enforcement"
+            )
+            recommendations.append(
+                "Set enforcement to 'On' specifically for the Admins organizational unit to ensure all privileged accounts require 2SV"
+            )
+
+        if len(not_enrolled_admins) > 0:
+            additional_findings.append(
+                str(len(not_enrolled_admins)) + " admin(s) are not yet enrolled in 2SV: " +
+                ", ".join(not_enrolled_admins[:10])
+            )
+
+        extra_fields = {
+            "totalAdminUsers": total_admins,
+            "enforcedCount": enforced_count,
+            "notEnforcedCount": not_enforced_count,
+            "notEnforcedAdmins": not_enforced_admins,
+            "notEnrolledAdmins": not_enrolled_admins
+        }
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalAdminUsers": total_admins, "enforcedCount": enforced_count}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/iam/google/isMFALoggingEnabled.py
+++ b/safeguards/iam/google/isMFALoggingEnabled.py
@@ -1,0 +1,164 @@
+"""
+Transformation: isMFALoggingEnabled
+Vendor: Google  |  Category: IAM
+Evaluates: Check if MFA/login audit logging is enabled by verifying that login activity events
+are actively being recorded in the Google Workspace Reports API login audit log.
+Passes if the items array contains recent login events, indicating audit logging is operational.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isMFALoggingEnabled", "vendor": "Google", "category": "IAM"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        items = data.get("items", [])
+        if not isinstance(items, list):
+            items = []
+
+        total_events = len(items)
+        mfa_event_count = 0
+        login_event_count = 0
+        unique_actors = []
+
+        for item in items:
+            actor = item.get("actor", {})
+            actor_email = actor.get("email", "")
+            if actor_email and actor_email not in unique_actors:
+                unique_actors.append(actor_email)
+
+            events = item.get("events", [])
+            if not isinstance(events, list):
+                events = []
+
+            for event in events:
+                event_name = event.get("name", "")
+                if event_name:
+                    login_event_count = login_event_count + 1
+                    if "2sv" in event_name.lower() or "verification" in event_name.lower() or "mfa" in event_name.lower() or "challenge" in event_name.lower():
+                        mfa_event_count = mfa_event_count + 1
+
+        logging_enabled = total_events > 0
+
+        return {
+            "isMFALoggingEnabled": logging_enabled,
+            "totalLoginEvents": total_events,
+            "totalLoginEventCount": login_event_count,
+            "mfaRelatedEventCount": mfa_event_count,
+            "uniqueActorCount": len(unique_actors)
+        }
+    except Exception as e:
+        return {"isMFALoggingEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isMFALoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        total_login_events = eval_result.get("totalLoginEvents", 0)
+        total_login_event_count = eval_result.get("totalLoginEventCount", 0)
+        mfa_related_event_count = eval_result.get("mfaRelatedEventCount", 0)
+        unique_actor_count = eval_result.get("uniqueActorCount", 0)
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append(
+                "Login audit logging is operational: " + str(total_login_events) +
+                " login activity record(s) found in the Google Workspace Reports API"
+            )
+            pass_reasons.append(
+                "Audit events captured for " + str(unique_actor_count) + " unique actor(s)"
+            )
+        else:
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            else:
+                fail_reasons.append(
+                    "No login activity events found in the Google Workspace Reports API audit log"
+                )
+            recommendations.append(
+                "Verify that the Google Workspace Reports API (Admin SDK) is enabled and that the service account has the required audit.readonly scope authorized via Domain-Wide Delegation"
+            )
+            recommendations.append(
+                "Ensure login audit logging is turned on under Admin Console > Reports > Audit > Login"
+            )
+
+        if mfa_related_event_count > 0:
+            additional_findings.append(
+                str(mfa_related_event_count) + " MFA/2SV related login event(s) detected in the audit log"
+            )
+
+        extra_fields = {
+            "totalLoginEvents": total_login_events,
+            "totalLoginEventCount": total_login_event_count,
+            "mfaRelatedEventCount": mfa_related_event_count,
+            "uniqueActorCount": unique_actor_count
+        }
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalLoginEvents": total_login_events, "uniqueActorCount": unique_actor_count}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Adds 3 **Google** (iam) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Google API responses against Spektrum safeguard criteria to determine whether the organization's Google configuration meets security posture requirements.

**Context:** Google is being onboarded as a new iam vendor integration. These scripts cover the `safeguards/iam/google` namespace.

## What each transformation does

### `isMFAEnabled.py` (Validated)
Check if MFA (2-Step Verification) is enabled in the Google Workspace domain

- **API fields consumed:** `users`
- Graceful fallback on missing keys and empty responses

### `isMFALoggingEnabled.py` (Validated)
Check if MFA/login audit logging is enabled by verifying that login activity events

- **API fields consumed:** `items`
- Graceful fallback on missing keys and empty responses

### `isMFAEnforcedForAdminAccess.py` (Validated)
Verify that MFA (2-Step Verification) is enforced for all administrator accounts

- **API fields consumed:** `users`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline