### PR TITLE
feat: add Halcyon transformations (epp)

### DIFF
--- a/safeguards/epp/halcyon/confirmLicensePurchased.py
+++ b/safeguards/epp/halcyon/confirmLicensePurchased.py
@@ -1,0 +1,205 @@
+"""
+Transformation: confirmLicensePurchased
+Vendor: Halcyon  |  Category: epp
+Evaluates: Ensures a valid license response is returned and the licensePurchased field is truthy,
+confirming an active Halcyon subscription.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "confirmLicensePurchased", "vendor": "Halcyon", "category": "epp"}
+        }
+    }
+
+
+def parse_expiry_date(expiry_str):
+    if not expiry_str or not isinstance(expiry_str, str):
+        return None
+    try:
+        parts = expiry_str[:10].split("-")
+        if len(parts) == 3:
+            year = int(parts[0])
+            month = int(parts[1])
+            day = int(parts[2])
+            return datetime(year, month, day)
+    except Exception:
+        pass
+    try:
+        parts = expiry_str[:10].split("/")
+        if len(parts) == 3:
+            month = int(parts[0])
+            day = int(parts[1])
+            year = int(parts[2])
+            return datetime(year, month, day)
+    except Exception:
+        pass
+    return None
+
+
+def evaluate(data):
+    try:
+        license_data = data.get("data", data)
+        if not isinstance(license_data, dict):
+            return {
+                "confirmLicensePurchased": False,
+                "licensePurchased": False,
+                "error": "License data is not a valid object"
+            }
+
+        if len(license_data) == 0:
+            return {
+                "confirmLicensePurchased": False,
+                "licensePurchased": False,
+                "error": "Empty license response returned from API"
+            }
+
+        license_purchased = license_data.get("licensePurchased", None)
+        if license_purchased is None:
+            license_purchased = license_data.get("license_purchased", None)
+        if license_purchased is None:
+            license_purchased = license_data.get("purchased", None)
+        if license_purchased is None:
+            license_purchased = license_data.get("active", None)
+
+        purchased_bool = False
+        if license_purchased is True:
+            purchased_bool = True
+        elif isinstance(license_purchased, str) and license_purchased.lower() in ["true", "yes", "active", "1"]:
+            purchased_bool = True
+        elif isinstance(license_purchased, int) and license_purchased == 1:
+            purchased_bool = True
+
+        if license_purchased is None:
+            status_val = license_data.get("status", "") or license_data.get("licenseStatus", "") or license_data.get("license_status", "")
+            if isinstance(status_val, str) and status_val.lower() in ["active", "valid", "purchased", "enabled"]:
+                purchased_bool = True
+
+        license_status = license_data.get("status", "") or license_data.get("licenseStatus", "")
+        expiry_date_raw = license_data.get("expiryDate", "") or license_data.get("expiry_date", "") or license_data.get("expiry", "") or license_data.get("validUntil", "") or license_data.get("valid_until", "")
+        licensed_seats = license_data.get("seats", None) or license_data.get("licensedSeats", None) or license_data.get("licensed_seats", None)
+        license_type = license_data.get("type", "") or license_data.get("licenseType", "") or license_data.get("license_type", "")
+
+        expiry_warning = None
+        if expiry_date_raw:
+            expiry_dt = parse_expiry_date(str(expiry_date_raw))
+            if expiry_dt is not None:
+                now = datetime.utcnow()
+                days_remaining = (expiry_dt - now).days
+                if days_remaining < 0:
+                    purchased_bool = False
+                    expiry_warning = "License has expired (expiry: " + str(expiry_date_raw) + ")"
+                elif days_remaining < 30:
+                    expiry_warning = "License expires in " + str(days_remaining) + " days (expiry: " + str(expiry_date_raw) + ")"
+
+        result = {
+            "confirmLicensePurchased": purchased_bool,
+            "licensePurchased": purchased_bool
+        }
+        if license_status:
+            result["licenseStatus"] = str(license_status)
+        if expiry_date_raw:
+            result["expiryDate"] = str(expiry_date_raw)
+        if licensed_seats is not None:
+            result["licensedSeats"] = licensed_seats
+        if license_type:
+            result["licenseType"] = str(license_type)
+        if expiry_warning:
+            result["expiryWarning"] = expiry_warning
+        return result
+    except Exception as e:
+        return {"confirmLicensePurchased": False, "licensePurchased": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "confirmLicensePurchased"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        license_status = eval_result.get("licenseStatus", "")
+        expiry_date = eval_result.get("expiryDate", "")
+        licensed_seats = eval_result.get("licensedSeats", None)
+        license_type = eval_result.get("licenseType", "")
+        expiry_warning = eval_result.get("expiryWarning", "")
+        if result_value:
+            pass_reasons.append("A valid Halcyon license has been purchased and is active")
+            if license_status:
+                pass_reasons.append("License status: " + str(license_status))
+            if expiry_date:
+                pass_reasons.append("License expiry: " + str(expiry_date))
+            if licensed_seats is not None:
+                pass_reasons.append("Licensed seats: " + str(licensed_seats))
+            if license_type:
+                pass_reasons.append("License type: " + str(license_type))
+            if expiry_warning:
+                additional_findings.append(expiry_warning)
+        else:
+            fail_reasons.append("No valid active Halcyon license confirmed")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            if expiry_warning:
+                fail_reasons.append(expiry_warning)
+            if license_status:
+                additional_findings.append("Reported license status: " + str(license_status))
+            recommendations.append("Ensure a valid Halcyon subscription license has been purchased and is currently active")
+            recommendations.append("Contact Halcyon support or your account representative to resolve any licensing issues")
+            if expiry_warning:
+                recommendations.append("Renew the Halcyon license before it expires to avoid loss of protection coverage")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"licensePurchased": eval_result.get("licensePurchased", False), "licenseStatus": license_status, "expiryDate": expiry_date}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/epp/halcyon/isEPPConfiguredToVendorGuidance.py
+++ b/safeguards/epp/halcyon/isEPPConfiguredToVendorGuidance.py
@@ -1,0 +1,219 @@
+"""
+Transformation: isEPPConfiguredToVendorGuidance
+Vendor: Halcyon  |  Category: epp
+Evaluates: Validates that Halcyon policy groups are configured in line with vendor-recommended
+settings, including blocking mode enabled and prevention engines active, rather than left in
+default learning or passive modes.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPConfiguredToVendorGuidance", "vendor": "Halcyon", "category": "epp"}
+        }
+    }
+
+
+NON_COMPLIANT_MODES = ["learning", "audit", "passive", "monitor", "observe", "detection", "detect"]
+COMPLIANT_MODES = ["blocking", "block", "prevent", "prevention", "protect", "active", "enforce"]
+
+
+def get_policy_mode(policy):
+    mode = policy.get("mode", "") or policy.get("protection_mode", "") or policy.get("protectionMode", "") or policy.get("enforcement_mode", "") or policy.get("enforcementMode", "")
+    if isinstance(mode, str):
+        return mode.lower()
+    return ""
+
+
+def is_policy_active(policy):
+    status = policy.get("status", "") or policy.get("state", "")
+    if isinstance(status, str) and status.lower() in ["active", "enabled", "on"]:
+        return True
+    enabled = policy.get("enabled", None)
+    if enabled is True:
+        return True
+    return False
+
+
+def prevention_engines_active(policy):
+    engines = policy.get("prevention_engines", None) or policy.get("preventionEngines", None)
+    if engines is None:
+        return None
+    if isinstance(engines, bool):
+        return engines
+    if isinstance(engines, dict):
+        values = [engines[k] for k in engines]
+        true_count = len([v for v in values if v is True or v == "enabled" or v == "active"])
+        return true_count > 0
+    if isinstance(engines, list):
+        active = [e for e in engines if e.get("enabled", False) is True or e.get("status", "") in ["active", "enabled"]]
+        return len(active) > 0
+    return None
+
+
+def check_policy_compliant(policy):
+    mode = get_policy_mode(policy)
+    mode_compliant = True
+    mode_finding = ""
+    if mode in NON_COMPLIANT_MODES:
+        mode_compliant = False
+        mode_finding = "policy mode is '" + mode + "' (non-compliant)"
+    elif mode in COMPLIANT_MODES:
+        mode_compliant = True
+    elif mode == "":
+        mode_compliant = True
+
+    engines_result = prevention_engines_active(policy)
+    engines_compliant = True
+    engines_finding = ""
+    if engines_result is False:
+        engines_compliant = False
+        engines_finding = "prevention engines are disabled"
+
+    compliant = mode_compliant and engines_compliant
+    findings = []
+    if mode_finding:
+        findings.append(mode_finding)
+    if engines_finding:
+        findings.append(engines_finding)
+    return compliant, findings
+
+
+def evaluate(data):
+    try:
+        policies_raw = data.get("data", [])
+        if not isinstance(policies_raw, list):
+            policies_raw = []
+
+        if len(policies_raw) == 0:
+            return {
+                "isEPPConfiguredToVendorGuidance": False,
+                "totalPolicies": 0,
+                "activePolicies": 0,
+                "compliantPolicies": 0,
+                "nonCompliantPolicies": 0,
+                "scoreInPercentage": 0,
+                "error": "No policy data returned from API"
+            }
+
+        active_policies = [p for p in policies_raw if is_policy_active(p)]
+        total_active = len(active_policies)
+
+        if total_active == 0:
+            return {
+                "isEPPConfiguredToVendorGuidance": False,
+                "totalPolicies": len(policies_raw),
+                "activePolicies": 0,
+                "compliantPolicies": 0,
+                "nonCompliantPolicies": 0,
+                "scoreInPercentage": 0,
+                "error": "No active policies found"
+            }
+
+        compliant_count = 0
+        non_compliant_details = []
+        for policy in active_policies:
+            compliant, findings = check_policy_compliant(policy)
+            if compliant:
+                compliant_count = compliant_count + 1
+            else:
+                policy_name = policy.get("name", policy.get("id", "unknown"))
+                non_compliant_details.append(str(policy_name) + ": " + "; ".join(findings))
+
+        score = (compliant_count * 100) / total_active
+        passed = score >= 90
+
+        result = {
+            "isEPPConfiguredToVendorGuidance": passed,
+            "totalPolicies": len(policies_raw),
+            "activePolicies": total_active,
+            "compliantPolicies": compliant_count,
+            "nonCompliantPolicies": total_active - compliant_count,
+            "scoreInPercentage": score
+        }
+        if non_compliant_details:
+            result["nonCompliantPolicyDetails"] = non_compliant_details
+        return result
+    except Exception as e:
+        return {"isEPPConfiguredToVendorGuidance": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPConfiguredToVendorGuidance"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        score = eval_result.get("scoreInPercentage", 0)
+        compliant_count = eval_result.get("compliantPolicies", 0)
+        active_count = eval_result.get("activePolicies", 0)
+        non_compliant_details = eval_result.get("nonCompliantPolicyDetails", [])
+        if result_value:
+            pass_reasons.append("Halcyon policies are configured in line with vendor guidance (" + str(compliant_count) + "/" + str(active_count) + " active policies compliant)")
+            pass_reasons.append("Compliance score: " + str(round(score, 1)) + "%")
+        else:
+            fail_reasons.append("One or more Halcyon policies deviate from vendor-recommended configuration (" + str(compliant_count) + "/" + str(active_count) + " compliant, score: " + str(round(score, 1)) + "%)")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            for detail in non_compliant_details:
+                additional_findings.append("Non-compliant policy: " + str(detail))
+            recommendations.append("Enable blocking/prevention mode on all active Halcyon policies; avoid leaving policies in learning, audit, or passive modes")
+            recommendations.append("Ensure prevention engines are active across all policy groups as recommended by Halcyon vendor guidance")
+            recommendations.append("Review each non-compliant policy and update settings to align with Halcyon hardening recommendations")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalPolicies": eval_result.get("totalPolicies", 0), "activePolicies": active_count, "compliantPolicies": compliant_count, "scoreInPercentage": score}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/epp/halcyon/isEPPEnabledForCriticalSystems.py
+++ b/safeguards/epp/halcyon/isEPPEnabledForCriticalSystems.py
@@ -1,0 +1,205 @@
+"""
+Transformation: isEPPEnabledForCriticalSystems
+Vendor: Halcyon  |  Category: epp
+Evaluates: Checks that Halcyon EPP agents are actively deployed and enabled on systems tagged or
+classified as critical, ensuring prioritised ransomware protection for high-value assets.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isEPPEnabledForCriticalSystems", "vendor": "Halcyon", "category": "epp"}
+        }
+    }
+
+
+CRITICAL_TAGS = ["critical", "Critical", "CRITICAL", "high-value", "high_value", "tier1", "tier-1", "Tier1", "Tier 1"]
+ACTIVE_STATUSES = ["active", "Active", "ACTIVE", "online", "Online", "ONLINE", "connected", "Connected", "enabled", "Enabled"]
+
+
+def is_critical_agent(agent):
+    tags = agent.get("tags", [])
+    if isinstance(tags, list):
+        for tag in tags:
+            tag_val = tag if isinstance(tag, str) else str(tag)
+            tag_lower = tag_val.lower()
+            if "critical" in tag_lower or "high-value" in tag_lower or "tier1" in tag_lower or "tier 1" in tag_lower:
+                return True
+    if isinstance(tags, str):
+        tag_lower = tags.lower()
+        if "critical" in tag_lower or "high-value" in tag_lower:
+            return True
+    labels = agent.get("labels", {})
+    if isinstance(labels, dict):
+        for lk in labels:
+            lv = labels[lk]
+            combined = (str(lk) + " " + str(lv)).lower()
+            if "critical" in combined or "high-value" in combined:
+                return True
+    criticality = agent.get("criticality", "")
+    if isinstance(criticality, str) and criticality.lower() in ["critical", "high"]:
+        return True
+    group = agent.get("group", "") or agent.get("group_name", "") or agent.get("groupName", "")
+    if isinstance(group, str) and ("critical" in group.lower() or "high-value" in group.lower()):
+        return True
+    return False
+
+
+def is_agent_active(agent):
+    status = agent.get("status", "") or agent.get("agentStatus", "") or agent.get("agent_status", "")
+    if isinstance(status, str) and status in ACTIVE_STATUSES:
+        return True
+    enabled = agent.get("enabled", None)
+    if enabled is True:
+        return True
+    protection = agent.get("protection_state", "") or agent.get("protectionState", "")
+    if isinstance(protection, str) and protection.lower() in ["active", "enabled", "protected"]:
+        return True
+    return False
+
+
+def evaluate(data):
+    try:
+        agents_raw = data.get("data", [])
+        if not isinstance(agents_raw, list):
+            agents_raw = []
+
+        if len(agents_raw) == 0:
+            return {
+                "isEPPEnabledForCriticalSystems": False,
+                "totalAgents": 0,
+                "criticalAgentsTotal": 0,
+                "criticalAgentsActive": 0,
+                "scoreInPercentage": 0,
+                "error": "No agent data returned from API"
+            }
+
+        critical_agents = [a for a in agents_raw if is_critical_agent(a)]
+        total_critical = len(critical_agents)
+
+        if total_critical == 0:
+            total = len(agents_raw)
+            active_count = len([a for a in agents_raw if is_agent_active(a)])
+            score = 0
+            if total > 0:
+                score = (active_count * 100) / total
+            passed = score >= 90
+            return {
+                "isEPPEnabledForCriticalSystems": passed,
+                "totalAgents": total,
+                "criticalAgentsTotal": 0,
+                "criticalAgentsActive": active_count,
+                "scoreInPercentage": score,
+                "note": "No agents tagged as critical found; evaluated across all agents"
+            }
+
+        active_critical = [a for a in critical_agents if is_agent_active(a)]
+        active_critical_count = len(active_critical)
+        score = (active_critical_count * 100) / total_critical
+        passed = score >= 90
+
+        inactive_hostnames = [
+            a.get("hostname", a.get("name", a.get("id", "unknown")))
+            for a in critical_agents
+            if not is_agent_active(a)
+        ]
+
+        result = {
+            "isEPPEnabledForCriticalSystems": passed,
+            "totalAgents": len(agents_raw),
+            "criticalAgentsTotal": total_critical,
+            "criticalAgentsActive": active_critical_count,
+            "criticalAgentsInactive": total_critical - active_critical_count,
+            "scoreInPercentage": score
+        }
+        if inactive_hostnames:
+            result["inactiveCriticalHosts"] = inactive_hostnames
+        return result
+    except Exception as e:
+        return {"isEPPEnabledForCriticalSystems": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isEPPEnabledForCriticalSystems"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        score = eval_result.get("scoreInPercentage", 0)
+        total_critical = eval_result.get("criticalAgentsTotal", 0)
+        active_critical = eval_result.get("criticalAgentsActive", 0)
+        note = eval_result.get("note", "")
+        if result_value:
+            pass_reasons.append("Halcyon EPP agents are active on critical systems (" + str(active_critical) + "/" + str(total_critical) + " critical agents enabled)")
+            pass_reasons.append("Coverage score: " + str(round(score, 1)) + "%")
+            if note:
+                additional_findings.append(note)
+        else:
+            fail_reasons.append("EPP coverage on critical systems is insufficient (" + str(active_critical) + "/" + str(total_critical) + " critical agents active, score: " + str(round(score, 1)) + "%)")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            if note:
+                additional_findings.append(note)
+            inactive_hosts = eval_result.get("inactiveCriticalHosts", [])
+            if inactive_hosts:
+                additional_findings.append("Inactive critical hosts: " + ", ".join([str(h) for h in inactive_hosts]))
+            recommendations.append("Ensure Halcyon EPP agents are installed and active on all systems classified as critical")
+            recommendations.append("Review agent tags and group assignments to ensure critical systems are correctly identified")
+            recommendations.append("Investigate inactive agents on critical hosts and remediate connectivity or configuration issues")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={"totalAgents": eval_result.get("totalAgents", 0), "criticalAgentsTotal": total_critical, "criticalAgentsActive": active_critical, "scoreInPercentage": score}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Halcyon anti-ransomware EPP integration adds three transformation scripts covering license validation, critical system protection verification, and policy configuration compliance. These scripts validate that Halcyon agents are deployed to high-value systems, configured per vendor hardening guidance, and backed by an active license.

**Context:** Halcyon onboarding fills gap in ransomware-specific endpoint protection assessment, enabling security teams to verify deployment coverage and policy enforcement across their infrastructure.

## What each transformation does

### `confirmLicensePurchased.py`
Validates that an active Halcyon subscription license exists and has not expired.

- **Consumes:** Halcyon Admin API `/v1/account/license`
- **Pass criteria:** `licensePurchased` field is truthy (boolean `true`, string "true"/"active"/"yes", or integer 1) AND license has not expired based on `expiryDate` comparison to current UTC time
- **Key edge cases handled:**
  - Fallback field names: checks `licensePurchased`, `license_purchased`, `purchased`, `active` in sequence
  - Expiry parsing: handles both YYYY-MM-DD and MM/DD/YYYY date formats
  - Expired licenses: automatically set `purchased_bool = False` if expiry date is in past
  - Expiry warning: alerts if license expires within 30 days but does not yet fail
  - Empty response: returns `False` with error message if response is empty dict

### `isEPPEnabledForCriticalSystems.py`
Evaluates whether Halcyon EPP agents are actively deployed on systems tagged or classified as critical/high-value.

- **Consumes:** Halcyon Admin API `/v1/agents`
- **Pass criteria:** >= 90% of agents tagged as "critical", "high-value", "tier1", or "Tier 1" (checked in tags, labels, criticality field, and group name) are in an active status ("active", "online", "connected", "enabled") OR if no agents are tagged critical, >= 90% of all agents are active
- **Key edge cases handled:**
  - No critical agents found: falls back to evaluating all agents and notes "No agents tagged as critical found"
  - Tag format flexibility: supports tags as list of strings or single string, label checks as key-value pairs
  - Multiple status field names: checks `status`, `agentStatus`, `agent_status` sequentially
  - Missing data: defaults to empty list if data.data is not a list; returns `False` with error if agents list is empty
  - Returns list of inactive critical hostnames in `inactiveCriticalHosts` field for remediation

### `isEPPConfiguredToVendorGuidance.py`
Validates that Halcyon policy groups are configured in blocking/prevention mode (not learning/passive) and have prevention engines enabled.

- **Consumes:** Halcyon Admin API `/v1/policies`
- **Pass criteria:** >= 90% of active policies have mode in ["blocking", "block", "prevent", "prevention", "protect", "active", "enforce"] AND `prevention_engines` field is truthy (boolean `true` or dict/list with >= 1 enabled entry)
- **Key edge cases handled:**
  - Non-compliant modes: fails if mode is in ["learning", "audit", "passive", "monitor", "observe", "detection", "detect"]
  - Missing mode field: treated as compliant (assumes default is safe)
  - Prevention engines field variations: checks bool, dict (counts enabled values), or list of engine objects
  - Inactive policies excluded: only evaluates policies with status in ["active", "enabled", "on"] or `enabled == True`
  - Detailed findings: returns list of non-compliant policy names with reason (mode or engine disabled) in `nonCompliantPolicyDetails`

## Architecture notes

All three scripts follow standard Spektrum transformation contract: `extract_input()` unwraps nested API response wrappers (api_response, response, result, apiResponse), `evaluate()` applies business logic and returns dict with criteria key plus metadata, `transform()` orchestrates execution and builds response schema version 1.0. Response includes `additionalInfo` with `dataCollection`, `validation`, `transformation`, and `evaluation` sections. Scripts are RestrictedPython compatible (no dangerous imports, safe data access patterns).

## Test plan

- [ ] Each script passes PyCodeExecutor sandbox validation (no unsafe imports/functions)
- [ ] `confirmLicensePurchased`:
  - [ ] Valid license response with `licensePurchased: true` and future expiry → pass
  - [ ] Empty license response dict {} → fail with "Empty license response" error
  - [ ] License with `active: "true"` (string) → pass
  - [ ] License with expiry 5 days in past → fail with "License has expired"
  - [ ] License with expiry 15 days in future → pass with warning "expires in 15 days"
- [ ] `isEPPEnabledForCriticalSystems`:
  - [ ] 100 agents, 10 tagged "critical", 9 active → pass (90%)
  - [ ] 100 agents, 10 tagged "critical", 8 active → fail (80%)
  - [ ] 100 agents, 0 tagged critical, 95 active → pass with note "No agents tagged as critical"
  - [ ] Empty agents list → fail with "No agent data returned"
  - [ ] Tags as string vs array handling: both formats pass
- [ ] `isEPPConfiguredToVendorGuidance`:
  - [ ] 10 active policies, 9 in "blocking" mode with prevention_engines: true → pass (90%)
  - [ ] 10 active policies, 5 in "learning" mode → fail
  - [ ] 10 active policies, 8 active, 2 inactive (only active counted): 8 in blocking → pass
  - [ ] Empty policies list → fail with "No policy data returned"
  - [ ] Mode field missing but engines enabled → pass (mode defaults safe)
- [ ] Confirm field names match Halcyon `/v1/agents` and `/v1/policies` actual response schemas
- [ ] Spot-check create_response() output includes all expected keys: transformedResponse, additionalInfo.evaluation.passReasons/failReasons/recommendations/additionalFindings, metadata.schemaVersion = "1.0"

Generated by Spektrum integration onboarding pipeline