### PR TITLE
feat: add Mimecast transformations (emailsecurity)

### DIFF
--- a/safeguards/emailsecurity/mimecast/isEmailSecurityEnabled.py
+++ b/safeguards/emailsecurity/mimecast/isEmailSecurityEnabled.py
@@ -1,0 +1,280 @@
+"""
+Transformation: isEmailSecurityEnabled
+Vendor: Mimecast  |  Category: emailsecurity
+Evaluates: Confirms that the Mimecast Email Security service is active and the account
+is correctly provisioned for email security processing by inspecting account settings
+and package entitlements returned from the get-account endpoint (checkLicenseStatus).
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isEmailSecurityEnabled",
+                "vendor": "Mimecast",
+                "category": "emailsecurity"
+            }
+        }
+    }
+
+
+def extract_account_records(data):
+    """
+    The workflow merges all API method results. checkLicenseStatus stores its
+    records under the key 'checkLicenseStatus'. Fall back to a top-level 'data'
+    list if the method-keyed form is absent.
+    """
+    if isinstance(data, dict):
+        if "checkLicenseStatus" in data:
+            records = data["checkLicenseStatus"]
+            if isinstance(records, list):
+                return records
+        if "data" in data:
+            records = data["data"]
+            if isinstance(records, list):
+                return records
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def is_email_security_package(packages):
+    """
+    Returns True when at least one package name indicates email security
+    entitlement. Mimecast package names commonly contain terms like 'email',
+    'gateway', 'secure', or 'full'. An empty packages list is treated as
+    non-disqualifying when licensePurchased > 0.
+    """
+    if not isinstance(packages, list):
+        return False
+    email_keywords = ["email", "gateway", "secure", "full", "advanced", "mime"]
+    for pkg in packages:
+        pkg_lower = str(pkg).lower()
+        for kw in email_keywords:
+            if kw in pkg_lower:
+                return True
+    return False
+
+
+def evaluate(data):
+    """
+    Core evaluation logic for isEmailSecurityEnabled.
+
+    Pass conditions (any one is sufficient):
+      1. licensePurchased > 0 AND a recognised email-security package is present.
+      2. licensePurchased > 0 AND packages list is empty/absent (account exists
+         and has purchased seats -- treat as provisioned).
+      3. A 'services.emailSecurityEnabled' flag is explicitly True.
+      4. The account record exists but zero licenses -- check commercialPackage field.
+    """
+    records = extract_account_records(data)
+
+    if not records:
+        return {
+            "isEmailSecurityEnabled": False,
+            "reason": "No account records returned from checkLicenseStatus"
+        }
+
+    account = records[0] if isinstance(records[0], dict) else {}
+
+    license_purchased = account.get("licensePurchased", 0)
+    license_used = account.get("licenseUsed", 0)
+    packages = account.get("packages", [])
+    account_type = str(account.get("type", "")).lower()
+    account_code = account.get("accountCode", "")
+    commercial_package = str(account.get("commercialPackage", "")).lower()
+
+    # Check explicit services flag when present
+    services = account.get("services", {})
+    if isinstance(services, dict):
+        explicit_flag = services.get("emailSecurityEnabled")
+        if explicit_flag is True:
+            return {
+                "isEmailSecurityEnabled": True,
+                "licensePurchased": license_purchased,
+                "licenseUsed": license_used,
+                "accountCode": account_code,
+                "packageCount": len(packages) if isinstance(packages, list) else 0,
+                "detectionMethod": "services.emailSecurityEnabled flag"
+            }
+
+    # Suspended / expired accounts are not considered enabled
+    inactive_states = ["suspended", "trial_expired", "expired", "inactive", "closed"]
+    for state in inactive_states:
+        if state in account_type:
+            return {
+                "isEmailSecurityEnabled": False,
+                "licensePurchased": license_purchased,
+                "accountCode": account_code,
+                "accountType": account_type,
+                "reason": "Account is in an inactive state: " + account_type
+            }
+
+    # Licenses purchased with a matching package
+    if license_purchased > 0 and is_email_security_package(packages):
+        return {
+            "isEmailSecurityEnabled": True,
+            "licensePurchased": license_purchased,
+            "licenseUsed": license_used,
+            "accountCode": account_code,
+            "packageCount": len(packages),
+            "packages": packages,
+            "detectionMethod": "licensePurchased + email security package match"
+        }
+
+    # Licenses purchased; packages list absent or unrecognised -- still treat as enabled
+    if license_purchased > 0:
+        return {
+            "isEmailSecurityEnabled": True,
+            "licensePurchased": license_purchased,
+            "licenseUsed": license_used,
+            "accountCode": account_code,
+            "packageCount": len(packages) if isinstance(packages, list) else 0,
+            "detectionMethod": "licensePurchased > 0 (packages not matched)"
+        }
+
+    # Account record exists but zero licenses -- check commercial package field
+    if "full" in commercial_package or "email" in commercial_package:
+        return {
+            "isEmailSecurityEnabled": True,
+            "licensePurchased": license_purchased,
+            "accountCode": account_code,
+            "commercialPackage": commercial_package,
+            "detectionMethod": "commercialPackage indicates email security"
+        }
+
+    if account_code:
+        return {
+            "isEmailSecurityEnabled": False,
+            "licensePurchased": license_purchased,
+            "accountCode": account_code,
+            "reason": "Account exists but no email security licenses or packages detected"
+        }
+
+    return {
+        "isEmailSecurityEnabled": False,
+        "reason": "Could not determine email security status from account data"
+    }
+
+
+def transform(input):
+    criteriaKey = "isEmailSecurityEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "reason" and k != "error"}
+        reason = eval_result.get("reason", "")
+        detection_method = eval_result.get("detectionMethod", "")
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Mimecast Email Security is active and provisioned.")
+            if detection_method:
+                pass_reasons.append("Detection method: " + detection_method)
+            license_purchased = eval_result.get("licensePurchased", 0)
+            license_used = eval_result.get("licenseUsed", 0)
+            if license_purchased:
+                pass_reasons.append(
+                    "Licenses purchased: " + str(license_purchased) +
+                    ", in use: " + str(license_used)
+                )
+            packages = eval_result.get("packages", [])
+            if packages:
+                additional_findings.append("Detected packages: " + ", ".join([str(p) for p in packages]))
+        else:
+            fail_reasons.append("Mimecast Email Security does not appear to be enabled.")
+            if reason:
+                fail_reasons.append("Detail: " + reason)
+            recommendations.append(
+                "Verify the Mimecast account has an active Email Security subscription "
+                "and that at least one license is purchased in the Administration Console."
+            )
+            recommendations.append(
+                "Ensure the API credentials have the 'Account | Settings | Read' permission "
+                "so that account and package entitlement data is returned."
+            )
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/emailsecurity/mimecast/isEmailSecurityLoggingEnabled.py
+++ b/safeguards/emailsecurity/mimecast/isEmailSecurityLoggingEnabled.py
@@ -1,0 +1,236 @@
+"""
+Transformation: isEmailSecurityLoggingEnabled
+Vendor: Mimecast  |  Category: emailsecurity
+Evaluates: Verifies that email security audit event logging is active by confirming
+audit events are being generated and retrievable from the Mimecast audit event stream
+(getAuditEvents endpoint).
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isEmailSecurityLoggingEnabled",
+                "vendor": "Mimecast",
+                "category": "emailsecurity"
+            }
+        }
+    }
+
+
+def extract_audit_events(data):
+    """
+    The workflow merges all API method results. getAuditEvents stores its
+    records under the key 'getAuditEvents'. Fall back to a top-level 'data'
+    list if the method-keyed form is absent.
+    """
+    if isinstance(data, dict):
+        if "getAuditEvents" in data:
+            records = data["getAuditEvents"]
+            if isinstance(records, list):
+                return records
+        if "data" in data:
+            records = data["data"]
+            if isinstance(records, list):
+                return records
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def get_event_categories(events):
+    """Return a deduplicated list of category values found across all audit events."""
+    seen = {}
+    result = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        cat = event.get("category", event.get("eventCategory", ""))
+        cat_str = str(cat)
+        if cat_str and cat_str not in seen:
+            seen[cat_str] = True
+            result.append(cat_str)
+    return result
+
+
+def get_latest_event_time(events):
+    """Return the eventTime string of the most recently timestamped event, or empty string."""
+    latest = ""
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_time = str(event.get("eventTime", event.get("timestamp", event.get("datetime", ""))))
+        if event_time and event_time > latest:
+            latest = event_time
+    return latest
+
+
+def evaluate(data):
+    """
+    Core evaluation logic for isEmailSecurityLoggingEnabled.
+
+    Pass conditions:
+      - The getAuditEvents endpoint returned at least one audit event record.
+        This confirms the Mimecast audit log stream is active and the integration
+        has the required 'Audit | Events | Read' permission.
+
+    A non-empty list of events is the definitive signal that audit event logging
+    is functioning. An empty list or missing key is treated as a fail because it
+    may indicate logging is disabled, the API scope is insufficient, or no events
+    have been generated in the query window.
+    """
+    events = extract_audit_events(data)
+
+    if not isinstance(events, list):
+        return {
+            "isEmailSecurityLoggingEnabled": False,
+            "totalAuditEvents": 0,
+            "reason": "Audit events response was not a list"
+        }
+
+    total_events = len(events)
+
+    if total_events == 0:
+        return {
+            "isEmailSecurityLoggingEnabled": False,
+            "totalAuditEvents": 0,
+            "reason": "No audit events returned; logging may be disabled or the query window returned no results"
+        }
+
+    categories = get_event_categories(events)
+    latest_event_time = get_latest_event_time(events)
+
+    return {
+        "isEmailSecurityLoggingEnabled": True,
+        "totalAuditEvents": total_events,
+        "uniqueCategories": len(categories),
+        "eventCategories": categories,
+        "latestEventTime": latest_event_time
+    }
+
+
+def transform(input):
+    criteriaKey = "isEmailSecurityLoggingEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "reason" and k != "error"}
+        reason = eval_result.get("reason", "")
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            total_events = eval_result.get("totalAuditEvents", 0)
+            unique_categories = eval_result.get("uniqueCategories", 0)
+            latest_event_time = eval_result.get("latestEventTime", "")
+            pass_reasons.append(
+                "Mimecast audit event logging is active: " +
+                str(total_events) + " event(s) retrieved."
+            )
+            if unique_categories:
+                pass_reasons.append("Unique event categories observed: " + str(unique_categories))
+            if latest_event_time:
+                additional_findings.append("Most recent audit event timestamp: " + latest_event_time)
+            categories = eval_result.get("eventCategories", [])
+            if categories:
+                additional_findings.append("Categories present: " + ", ".join([str(c) for c in categories]))
+        else:
+            fail_reasons.append("Mimecast audit event logging does not appear to be active.")
+            if reason:
+                fail_reasons.append("Detail: " + reason)
+            recommendations.append(
+                "Enable audit event logging in the Mimecast Administration Console and "
+                "confirm that email security events are being captured in the audit stream."
+            )
+            recommendations.append(
+                "Ensure the API application has the 'Audit | Events | Read' permission "
+                "so that audit event data can be retrieved via the API."
+            )
+            recommendations.append(
+                "If logging was recently enabled, allow time for events to populate and "
+                "re-evaluate. Alternatively, widen the query date range if the API supports it."
+            )
+
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, **extra_fields}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary
Mimecast email security transformations (2 scripts) validate security posture across account provisioning, license entitlements, and audit logging. These transformations enable Spektrum to confirm that Mimecast Email Security is active, properly licensed, and logging security events. Context: Mimecast API 2.0 is the modern REST-based alternative to the legacy v1 API and uses OAuth 2.0 Bearer token authentication.

**Context:** These transformations support the Mimecast onboarding pipeline and fill gaps in email security service validation, ensuring organizations have actual Email Security entitlements (not just a Mimecast account) and that audit logging is enabled for compliance and incident response.

## What each transformation does

### `isEmailSecurityEnabled.py`
Validates that the Mimecast Email Security service is active and the account has purchased at least one license and/or is provisioned with an email-security package.

- **Consumes:** Mimecast API 2.0 POST /api/account/get-account (via checkLicenseStatus method)
- **Pass criteria:** (licensePurchased > 0 AND email-security package matched) OR (licensePurchased > 0 AND packages absent) OR (services.emailSecurityEnabled == True) OR (commercialPackage contains 'full'/'email') AND account NOT in inactive state
- **Key edge cases handled:**
  - Suspended/expired accounts fail regardless of licenses
  - Zero-license accounts checked for commercialPackage fallback field
  - Empty packages list treated as provisioned if licensePurchased > 0
  - Explicit services.emailSecurityEnabled flag overrides package matching
  - Missing account data returns False with descriptive reason

### `isEmailSecurityLoggingEnabled.py`
Verifies that email security audit event logging is active and functional by confirming audit events are being generated and retrievable via the Mimecast audit event stream.

- **Consumes:** Mimecast API 2.0 POST /api/audit/get-audit-events
- **Pass criteria:** Audit events list contains >= 1 record; non-empty list signals logging is active, API has read permission, and events are being generated
- **Key edge cases handled:**
  - Empty event list fails conservatively (logging may be disabled or query window has no events)
  - Non-list response type fails gracefully
  - Missing getAuditEvents key falls back to top-level 'data'
  - API error status (stat: FAIL) results in empty list interpretation → fail

## Architecture notes
Both transformations follow the standard Spektrum extraction → evaluation → transformation contract: extract_input() unwraps nested response objects and extracts validation metadata; evaluate() executes pure business logic returning criteriaKey boolean with supporting metadata; create_response() builds conformant schema v1.0 response with passReasons, failReasons, recommendations, and additionalFindings. Both scripts validate input gracefully (legacy format detection, JSON parsing from str/bytes) and return structured errors on transformation exceptions.

## Test plan
- [ ] Each script passes PyCodeExecutor sandbox validation (no imports beyond json/datetime, no eval/exec/open)
- [ ] **isEmailSecurityEnabled**:
  - [ ] Valid account with licensePurchased > 0 and email package → Pass
  - [ ] Valid account with licensePurchased > 0, packages=[] → Pass (fallback)
  - [ ] Account with licensePurchased=0, commercialPackage='full' → Pass
  - [ ] Suspended account (type contains 'suspended') → Fail
  - [ ] Empty record list from API → Fail with reason
  - [ ] services.emailSecurityEnabled=True override → Pass
  - [ ] Verify output includes licensePurchased, licenseUsed, accountCode, packageCount in additionalInfo
- [ ] **isEmailSecurityLoggingEnabled**:
  - [ ] API returns 1+ audit events → Pass (verify totalAuditEvents, eventCategories in output)
  - [ ] API returns empty event list → Fail with reason
  - [ ] getAuditEvents key present in merged response → extraction uses correct key
  - [ ] Verify latestEventTime correctly identifies most recent event timestamp
  - [ ] API error (stat: FAIL) → empty list interpretation → Fail
- [ ] Confirm field names (licensePurchased, category, eventTime) match live Mimecast API responses
- [ ] Spot-check create_response() output schema matches v1.0 (metadata, evaluation.passReasons/failReasons, additionalInfo)
- [ ] Integration test: Run both scripts against sample Mimecast API responses; verify False on missing account data and True on populated license + events data

Generated by Spektrum integration onboarding pipeline