### PR TITLE
feat: add CrashPlan transformations (backup)

### DIFF
--- a/safeguards/backups/crashplan/isSAMLEnforced.py
+++ b/safeguards/backups/crashplan/isSAMLEnforced.py
@@ -1,0 +1,187 @@
+"""
+Transformation: isSAMLEnforced
+Vendor: CrashPlan  |  Category: Backup
+Evaluates: Check if SAML SSO is enforced for the organization by examining
+the organization security settings authentication method field.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isSAMLEnforced", "vendor": "CrashPlan", "category": "Backup"}
+        }
+    }
+
+
+def evaluate(data):
+    """
+    Evaluate SAML enforcement from CrashPlan Org API response.
+    The getOrg endpoint returns data.settings which contains authentication
+    configuration. We look for ssoAuthEnabled, ssoRequired, or similar fields.
+    """
+    try:
+        # The merged data may contain the org data directly or nested under 'data'
+        org_data = data
+        if "data" in data and isinstance(data.get("data"), dict):
+            org_data = data["data"]
+
+        # Extract settings - may be at top level or under 'settings'
+        settings = org_data.get("settings", None)
+        if settings is None:
+            settings = org_data
+
+        # CrashPlan Org settings SAML/SSO fields to check
+        saml_fields = ["ssoAuthEnabled", "ssoRequired", "samlEnabled", "samlRequired",
+                       "singleSignOnEnabled", "singleSignOnRequired", "isSamlRequired",
+                       "isSsoRequired", "isSamlEnforced", "isSsoEnforced"]
+
+        found_fields = {}
+        for field in saml_fields:
+            if field in settings:
+                found_fields[field] = settings[field]
+
+        # Also check nested security or auth sections
+        security = settings.get("security", {}) or {}
+        auth_settings = settings.get("authSettings", {}) or {}
+        sso_settings = settings.get("ssoSettings", {}) or {}
+
+        for field in saml_fields:
+            if field in security:
+                found_fields[field] = security[field]
+            if field in auth_settings:
+                found_fields[field] = auth_settings[field]
+            if field in sso_settings:
+                found_fields[field] = sso_settings[field]
+
+        # Check for authMode or loginType indicating SAML
+        auth_mode = settings.get("authMode", None) or settings.get("loginType", None) or settings.get("authType", None)
+        if auth_mode is not None:
+            found_fields["authMode"] = auth_mode
+
+        if not found_fields and auth_mode is None:
+            return {
+                "isSAMLEnforced": None,
+                "error": "required fields missing from API response: ssoAuthEnabled, ssoRequired, samlEnabled, samlRequired, authMode and related SSO/SAML settings fields"
+            }
+
+        # Determine if SAML is enforced
+        # Priority: explicit 'Required'/'Enforced' fields first
+        required_fields = ["ssoRequired", "samlRequired", "isSamlRequired", "isSsoRequired",
+                           "isSamlEnforced", "isSsoEnforced"]
+        for field in required_fields:
+            if field in found_fields:
+                val = found_fields[field]
+                if isinstance(val, bool):
+                    return {"isSAMLEnforced": val, "detectedField": field, "detectedValue": str(val)}
+                if isinstance(val, str):
+                    return {"isSAMLEnforced": val.lower() in ["true", "yes", "1", "required", "enforced"], "detectedField": field, "detectedValue": val}
+
+        # Then check enabled fields
+        enabled_fields = ["ssoAuthEnabled", "samlEnabled", "singleSignOnEnabled", "isSamlEnabled", "isSsoEnabled"]
+        for field in enabled_fields:
+            if field in found_fields:
+                val = found_fields[field]
+                if isinstance(val, bool):
+                    return {"isSAMLEnforced": val, "detectedField": field, "detectedValue": str(val)}
+                if isinstance(val, str):
+                    return {"isSAMLEnforced": val.lower() in ["true", "yes", "1", "enabled"], "detectedField": field, "detectedValue": val}
+
+        # Check authMode
+        if auth_mode is not None:
+            auth_mode_lower = str(auth_mode).lower()
+            is_saml = "saml" in auth_mode_lower or "sso" in auth_mode_lower
+            return {"isSAMLEnforced": is_saml, "detectedField": "authMode", "detectedValue": str(auth_mode)}
+
+        return {
+            "isSAMLEnforced": None,
+            "error": "required fields missing from API response: ssoAuthEnabled, ssoRequired, samlEnabled, samlRequired, authMode and related SSO/SAML settings fields"
+        }
+
+    except Exception as e:
+        return {"isSAMLEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isSAMLEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, None)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        if result_value is None:
+            fail_reasons.append(criteriaKey + " could not be determined")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            recommendations.append("Verify SAML/SSO settings are accessible via the CrashPlan Org API for " + criteriaKey)
+        elif result_value:
+            pass_reasons.append("SAML SSO is enforced for the organization")
+            for k, v in extra_fields.items():
+                pass_reasons.append(k + ": " + str(v))
+        else:
+            fail_reasons.append("SAML SSO is not enforced for the organization")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+            for k, v in extra_fields.items():
+                fail_reasons.append(k + ": " + str(v))
+            recommendations.append("Enable and enforce SAML SSO in the CrashPlan organization security settings")
+        combined_result = {criteriaKey: result_value}
+        for k, v in extra_fields.items():
+            combined_result[k] = v
+        return create_response(
+            result=combined_result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

CrashPlan backup integration includes 1 SAML enforcement validation script. This script checks whether SAML single sign-on is enforced at the organization level by querying org security settings. The criteria validates identity management posture for the backup platform.

**Context:** Onboarding CrashPlan as a backup vendor to fill coverage gap in backup compliance monitoring.

## What each transformation does

### `isSAMLEnforced.py`

Validates that SAML SSO is enforced as the mandatory authentication method for the organization.

- **Consumes:** CrashPlan Admin API `/api/v1/orgs/{orgId}` (getOrg endpoint) — returns organization metadata including security settings
- **Pass criteria:** Returns `true` if any of these fields are found and truthy:
  - **Required fields:** `ssoRequired`, `samlRequired`, `isSamlRequired`, `isSsoRequired`, `isSamlEnforced`, `isSsoEnforced`
  - **Enabled fields:** `ssoAuthEnabled`, `samlEnabled`, `singleSignOnEnabled`
  - **AuthMode fields:** if `authMode`, `loginType`, or `authType` contain "saml" or "sso" (case-insensitive)
  - Searches nested scopes: `settings`, `settings.security`, `settings.authSettings`, `settings.ssoSettings`
- **Key edge cases handled:**
  - Nested settings inspection (3-level unwrapping of wrapper keys: api_response, response, result)
  - Type coercion: accepts boolean `true` or string values "true", "yes", "1", "required", "enforced"
  - Missing fields: Returns `{isSAMLEnforced: null}` with error listing expected field names
  - API errors (if org endpoint returns error): Not explicitly handled — script would likely fail silently or return False on exception
  - Exception handling: Catches all exceptions and defaults result to `False` (conservative fail-closed behavior)

## Architecture notes

The script follows the standard transform contract: `extract_input()` unwraps nested API responses, `evaluate()` applies the pass/fail logic, `create_response()` wraps results in the v1.0 schema. Response includes: transformedResponse, additionalInfo (dataCollection, validation, transformation, evaluation), and metadata. Input validation via the initial wrapper detection is minimal; the script assumes data shape consistency.

## Test plan

- [ ] Verify script passes PyCodeExecutor sandbox validation (RestrictedPython constraints)
- [ ] Test with valid org data: org with `settings.samlRequired: true` → expect `isSAMLEnforced: true`
- [ ] Test with disabled SAML: org with `settings.samlRequired: false` → expect `isSAMLEnforced: false`
- [ ] Test with missing settings: org without any SAML fields → expect `isSAMLEnforced: null` with error
- [ ] Test with API error response: getOrg returns error status → verify graceful error message in failReasons
- [ ] **CRITICAL:** Verify actual CrashPlan API response schema for `GET /api/v1/orgs/{orgId}`
  - Confirm whether SAML enforcement fields are returned in `.settings`
  - Confirm exact field names (ssoRequired vs samlRequired vs other variants)
  - If field names differ, script will fail to detect enforcement status
- [ ] Spot-check response schema: passReasons, failReasons, recommendations, additionalFindings keys present and well-formed
- [ ] Validate TOTP auth flow if MFA is enabled on test account (per definition documentation, API accounts should be exempted from MFA)

## Findings

**Field Accuracy — NEEDS VERIFICATION:**

The script searches for 15+ potential SAML field name variations across nested settings objects. However, the exact response structure of CrashPlan's `GET /api/v1/orgs/{orgId}` endpoint is not confirmed in available vendor documentation. Key concerns:

1. **No vendor schema found:** CrashPlan's API documentation does not publicly specify which exact fields appear in the org security settings response. The script assumes fields like `samlRequired`, `ssoAuthEnabled`, etc., but these may not exist in the actual API response.

2. **SAML config location uncertainty:** CrashPlan documentation emphasizes SAML setup via Identity Management console (Administration > Integrations > Identity Management), not via org settings objects. The `/api/v1/orgs/{orgId}` endpoint may not return SAML enforcement status at all.

3. **Conservative fallback:** When expected fields are missing, the script returns `null` and lists suggested field names. This is safe but may mask integration gaps. A production test against an actual CrashPlan environment is essential.

**Recommendations:**

1. **Before merge:** Execute this script against a test CrashPlan org and capture the actual JSON response from `GET /api/v1/orgs/{orgId}`. Compare returned field names to the 15+ variants the script checks.

2. **If fields don't match:** Update the script to use the actual field names and simplify the search logic.

3. **If SAML enforcement is not in org settings:** Consider alternative endpoints (e.g., org security/authentication endpoints) or document this as a known limitation (e.g., "SAML enforcement can only be determined via console, not API").

4. **Add validation logging:** Include additional findings to report which field was detected and its exact value, for debugging mismatches in production.

**Validation Result Note:** The submitted validation shows `status: success`, but this reflects only that the transformation code is syntactically valid Python — not that the field mapping is correct.