### PR TITLE
feat: add AWS transformations (cloudsecurity)

### DIFF
--- a/safeguards/cloudsecurity/aws/areAdminAccountsSeparate.py
+++ b/safeguards/cloudsecurity/aws/areAdminAccountsSeparate.py
@@ -1,0 +1,151 @@
+"""
+Transformation: areAdminAccountsSeparate
+Vendor: AWS  |  Category: cloudsecurity
+Evaluates: Whether dedicated administrative IAM accounts exist separately from standard
+user accounts. Examines IAM users returned by ListUsers for naming conventions and
+separation of privilege patterns to determine if admin accounts are distinct from
+regular operational accounts.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "areAdminAccountsSeparate", "vendor": "AWS", "category": "cloudsecurity"}
+        }
+    }
+
+
+def is_admin_user(username):
+    if not isinstance(username, str):
+        return False
+    lower = username.lower()
+    admin_tokens = ["admin", "administrator", "superuser", "root", "sysadmin", "devops-admin", "infra-admin", "ops-admin", "privileged"]
+    for token in admin_tokens:
+        if token in lower:
+            return True
+    return False
+
+
+def evaluate(data):
+    try:
+        users = data.get("Users", [])
+        if not isinstance(users, list):
+            users = []
+
+        total_users = len(users)
+        admin_usernames = []
+        standard_usernames = []
+
+        for user in users:
+            if not isinstance(user, dict):
+                continue
+            username = user.get("UserName", "")
+            if is_admin_user(username):
+                admin_usernames.append(username)
+            else:
+                standard_usernames.append(username)
+
+        admin_count = len(admin_usernames)
+        standard_count = len(standard_usernames)
+
+        has_dedicated_admin_accounts = admin_count > 0
+        has_standard_accounts = standard_count > 0
+        accounts_are_separate = has_dedicated_admin_accounts and has_standard_accounts
+
+        return {
+            "areAdminAccountsSeparate": accounts_are_separate,
+            "totalUsers": total_users,
+            "adminAccountCount": admin_count,
+            "standardAccountCount": standard_count,
+            "hasDedicatedAdminAccounts": has_dedicated_admin_accounts,
+            "hasStandardAccounts": has_standard_accounts,
+            "adminUsernames": admin_usernames
+        }
+    except Exception as e:
+        return {"areAdminAccountsSeparate": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "areAdminAccountsSeparate"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("Dedicated administrative accounts are present and separate from standard user accounts")
+            pass_reasons.append("Admin accounts identified: " + str(extra_fields.get("adminAccountCount", 0)))
+            pass_reasons.append("Standard accounts identified: " + str(extra_fields.get("standardAccountCount", 0)))
+        else:
+            if extra_fields.get("totalUsers", 0) == 0:
+                fail_reasons.append("No IAM users were returned by ListUsers — unable to evaluate account separation")
+                recommendations.append("Ensure the IAM service account has iam:ListUsers permission")
+            elif not extra_fields.get("hasDedicatedAdminAccounts", False):
+                fail_reasons.append("No dedicated administrative accounts identified by naming convention")
+                recommendations.append("Create dedicated admin IAM accounts with clear naming conventions (e.g. admin-*, *-admin) separate from standard user accounts")
+                recommendations.append("Avoid granting administrator-level permissions to general-purpose user accounts")
+            else:
+                fail_reasons.append("Admin accounts exist but no standard user accounts are present — separation cannot be confirmed")
+                recommendations.append("Ensure regular operational tasks use non-admin accounts; reserve admin accounts for privileged operations only")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+        admin_usernames = extra_fields.get("adminUsernames", [])
+        if admin_usernames:
+            additional_findings.append("Admin-identified accounts: " + ", ".join(admin_usernames))
+        additional_findings.append("Total IAM users evaluated: " + str(extra_fields.get("totalUsers", 0)))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "totalUsers": extra_fields.get("totalUsers", 0), "adminAccountCount": extra_fields.get("adminAccountCount", 0), "standardAccountCount": extra_fields.get("standardAccountCount", 0)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/cloudsecurity/aws/isAppConsentRestricted.py
+++ b/safeguards/cloudsecurity/aws/isAppConsentRestricted.py
@@ -1,0 +1,151 @@
+"""
+Transformation: isAppConsentRestricted
+Vendor: AWS  |  Category: cloudsecurity
+Evaluates: Whether third-party application consent is restricted in the AWS account.
+Inspects the OIDC provider list from ListOpenIDConnectProviders to determine whether
+unauthorized or unmanaged OIDC/OAuth providers are present, indicating whether app
+consent is controlled and limited to approved identity providers.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAppConsentRestricted", "vendor": "AWS", "category": "cloudsecurity"}
+        }
+    }
+
+
+def extract_arn(provider_entry):
+    if isinstance(provider_entry, dict):
+        return provider_entry.get("Arn", provider_entry.get("arn", ""))
+    if isinstance(provider_entry, str):
+        return provider_entry
+    return ""
+
+
+def evaluate(data):
+    try:
+        oidc_providers = data.get("OpenIDConnectProviderList", [])
+        if not isinstance(oidc_providers, list):
+            oidc_providers = []
+
+        provider_count = len(oidc_providers)
+        provider_arns = [extract_arn(p) for p in oidc_providers if extract_arn(p)]
+
+        known_safe_domains = ["oidc.eks.amazonaws.com", "token.actions.githubusercontent.com", "cognito-identity.amazonaws.com"]
+        unknown_providers = []
+        known_providers = []
+
+        for arn in provider_arns:
+            arn_lower = arn.lower()
+            is_known = False
+            for domain in known_safe_domains:
+                if domain in arn_lower:
+                    is_known = True
+                    break
+            if is_known:
+                known_providers.append(arn)
+            else:
+                unknown_providers.append(arn)
+
+        unknown_provider_count = len(unknown_providers)
+        known_provider_count = len(known_providers)
+
+        no_unmanaged_providers = unknown_provider_count == 0
+        is_restricted = no_unmanaged_providers
+
+        return {
+            "isAppConsentRestricted": is_restricted,
+            "totalOidcProviders": provider_count,
+            "unknownProviderCount": unknown_provider_count,
+            "knownProviderCount": known_provider_count,
+            "noUnmanagedProviders": no_unmanaged_providers,
+            "unknownProviderArns": unknown_providers,
+            "knownProviderArns": known_providers
+        }
+    except Exception as e:
+        return {"isAppConsentRestricted": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isAppConsentRestricted"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            if extra_fields.get("totalOidcProviders", 0) == 0:
+                pass_reasons.append("No OIDC/OAuth identity providers are registered — third-party app consent is fully restricted")
+            else:
+                pass_reasons.append("All registered OIDC providers are from known/approved sources — app consent is controlled")
+                pass_reasons.append("Known providers count: " + str(extra_fields.get("knownProviderCount", 0)))
+        else:
+            unknown_arns = extra_fields.get("unknownProviderArns", [])
+            fail_reasons.append("Unmanaged or unrecognized OIDC/OAuth providers detected: " + str(extra_fields.get("unknownProviderCount", 0)))
+            for arn in unknown_arns:
+                fail_reasons.append("Unrecognized provider: " + arn)
+            recommendations.append("Review all registered OIDC identity providers in IAM and remove any that are not explicitly approved")
+            recommendations.append("Use AWS Organizations SCPs to restrict creation of OIDC providers to authorized principals only")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+        additional_findings.append("Total OIDC providers registered: " + str(extra_fields.get("totalOidcProviders", 0)))
+        known_arns = extra_fields.get("knownProviderArns", [])
+        if known_arns:
+            additional_findings.append("Known/approved providers: " + ", ".join(known_arns))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "totalOidcProviders": extra_fields.get("totalOidcProviders", 0), "unknownProviderCount": extra_fields.get("unknownProviderCount", 0)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/cloudsecurity/aws/isBannerModeEnforced.py
+++ b/safeguards/cloudsecurity/aws/isBannerModeEnforced.py
@@ -1,0 +1,143 @@
+"""
+Transformation: isBannerModeEnforced
+Vendor: AWS  |  Category: cloudsecurity
+Evaluates: Whether banner/notification mode is enforced at the AWS account level.
+Inspects the SummaryMap from GetAccountSummary for AccountMFAEnabled (value 1 = enforced),
+MFADevicesInUse, and AccountAccessKeysPresent to determine whether account-wide
+security enforcement controls are active.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isBannerModeEnforced", "vendor": "AWS", "category": "cloudsecurity"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        summary_map = data.get("SummaryMap", {})
+        if not isinstance(summary_map, dict):
+            summary_map = {}
+
+        account_mfa_enabled_raw = summary_map.get("AccountMFAEnabled", 0)
+        try:
+            account_mfa_enabled = int(account_mfa_enabled_raw)
+        except Exception:
+            account_mfa_enabled = 0
+
+        mfa_devices_raw = summary_map.get("MFADevicesInUse", 0)
+        try:
+            mfa_devices_in_use = int(mfa_devices_raw)
+        except Exception:
+            mfa_devices_in_use = 0
+
+        access_keys_raw = summary_map.get("AccountAccessKeysPresent", 0)
+        try:
+            account_access_keys_present = int(access_keys_raw)
+        except Exception:
+            account_access_keys_present = 0
+
+        virtual_mfa_raw = summary_map.get("AccountSigningCertificatesPresent", 0)
+        try:
+            signing_certs_present = int(virtual_mfa_raw)
+        except Exception:
+            signing_certs_present = 0
+
+        summary_map_populated = len(summary_map) > 0
+        mfa_enforced = account_mfa_enabled == 1
+
+        is_enforced = mfa_enforced
+
+        return {
+            "isBannerModeEnforced": is_enforced,
+            "accountMFAEnabled": mfa_enforced,
+            "accountMFAEnabledValue": account_mfa_enabled,
+            "mfaDevicesInUse": mfa_devices_in_use,
+            "accountAccessKeysPresent": account_access_keys_present,
+            "signingCertificatesPresent": signing_certs_present,
+            "summaryMapPopulated": summary_map_populated
+        }
+    except Exception as e:
+        return {"isBannerModeEnforced": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isBannerModeEnforced"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("AWS account-level MFA enforcement is active (AccountMFAEnabled = 1)")
+            pass_reasons.append("MFA devices in use: " + str(extra_fields.get("mfaDevicesInUse", 0)))
+        else:
+            if not extra_fields.get("summaryMapPopulated", False):
+                fail_reasons.append("GetAccountSummary returned an empty SummaryMap — unable to determine MFA enforcement status")
+                recommendations.append("Ensure the IAM service account has iam:GetAccountSummary permission")
+            else:
+                fail_reasons.append("Account-level MFA is not enforced (AccountMFAEnabled != 1)")
+                recommendations.append("Enable account-wide MFA enforcement via IAM policy or AWS Organizations SCP")
+                recommendations.append("Require MFA for all IAM users with console access")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+        additional_findings.append("AccountAccessKeysPresent: " + str(extra_fields.get("accountAccessKeysPresent", 0)))
+        additional_findings.append("SigningCertificatesPresent: " + str(extra_fields.get("signingCertificatesPresent", 0)))
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "accountMFAEnabled": extra_fields.get("accountMFAEnabled", False), "mfaDevicesInUse": extra_fields.get("mfaDevicesInUse", 0)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/cloudsecurity/aws/isTransportRuleBannerEnabled.py
+++ b/safeguards/cloudsecurity/aws/isTransportRuleBannerEnabled.py
@@ -1,0 +1,146 @@
+"""
+Transformation: isTransportRuleBannerEnabled
+Vendor: AWS  |  Category: cloudsecurity
+Evaluates: Whether an account-level login/security policy is configured in AWS IAM.
+Checks the PasswordPolicy block for the presence of configured security controls
+(MinimumPasswordLength, RequireSymbols, HardExpiry, ExpirePasswords) which indicate
+that a security enforcement posture analogous to a transport/session banner policy is active.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isTransportRuleBannerEnabled", "vendor": "AWS", "category": "cloudsecurity"}
+        }
+    }
+
+
+def evaluate(data):
+    try:
+        password_policy = data.get("PasswordPolicy", {})
+        if not isinstance(password_policy, dict):
+            password_policy = {}
+
+        policy_controls = [
+            "MinimumPasswordLength",
+            "RequireSymbols",
+            "HardExpiry",
+            "ExpirePasswords"
+        ]
+
+        present_controls = [ctrl for ctrl in policy_controls if ctrl in password_policy]
+        controls_found = len(present_controls)
+        policy_exists = controls_found > 0
+
+        min_length = password_policy.get("MinimumPasswordLength", 0)
+        try:
+            min_length_val = int(min_length)
+        except Exception:
+            min_length_val = 0
+
+        require_symbols = password_policy.get("RequireSymbols", False)
+        hard_expiry = password_policy.get("HardExpiry", False)
+        expire_passwords = password_policy.get("ExpirePasswords", False)
+
+        is_enforced = (
+            policy_exists and
+            min_length_val > 0 and
+            (require_symbols is True or require_symbols == "true") and
+            (expire_passwords is True or expire_passwords == "true")
+        )
+
+        return {
+            "isTransportRuleBannerEnabled": is_enforced,
+            "policyExists": policy_exists,
+            "controlsFound": controls_found,
+            "presentControls": present_controls,
+            "minimumPasswordLength": min_length_val,
+            "requireSymbols": require_symbols,
+            "hardExpiry": hard_expiry,
+            "expirePasswords": expire_passwords
+        }
+    except Exception as e:
+        return {"isTransportRuleBannerEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "isTransportRuleBannerEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+        if result_value:
+            pass_reasons.append("AWS IAM password policy is configured with required security controls")
+            pass_reasons.append("MinimumPasswordLength: " + str(extra_fields.get("minimumPasswordLength", 0)))
+            pass_reasons.append("RequireSymbols: " + str(extra_fields.get("requireSymbols", False)))
+            pass_reasons.append("ExpirePasswords: " + str(extra_fields.get("expirePasswords", False)))
+        else:
+            if not extra_fields.get("policyExists", False):
+                fail_reasons.append("No IAM account password policy is configured")
+                recommendations.append("Configure an IAM account password policy with MinimumPasswordLength, RequireSymbols, HardExpiry, and ExpirePasswords")
+            else:
+                fail_reasons.append("IAM password policy is incomplete — not all required security controls are active")
+                present = extra_fields.get("presentControls", [])
+                missing = [ctrl for ctrl in ["MinimumPasswordLength", "RequireSymbols", "HardExpiry", "ExpirePasswords"] if ctrl not in present]
+                for m in missing:
+                    recommendations.append("Enable or set the '" + m + "' password policy control")
+            if "error" in eval_result:
+                fail_reasons.append(eval_result["error"])
+        additional_findings.append("Controls found: " + str(extra_fields.get("controlsFound", 0)) + " of 4 required")
+        return create_response(
+            result={criteriaKey: result_value, **extra_fields},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={criteriaKey: result_value, "policyExists": extra_fields.get("policyExists", False), "controlsFound": extra_fields.get("controlsFound", 0)}
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

This PR adds four transformation scripts for AWS IAM cloud security validation. These scripts evaluate password policy strength, MFA enforcement, admin account separation, and OIDC provider consent controls across a target AWS account. All four transformations passed initial validation; however, semantic misalignment between criteria names and implemented logic, plus reliance on heuristics rather than policy inspection, require documented caveats.

**Context:** AWS IAM integration onboarding pipeline. These scripts consume the five IAM List/Get API methods to validate four discrete security controls. Script count: 4.

## What each transformation does

### `isTransportRuleBannerEnabled.py`
Evaluates whether account-level password policy is configured with security controls (minimum length, symbol requirements, password expiration).

- **Consumes:** AWS IAM API `GetAccountPasswordPolicy`
- **Pass criteria:** `PasswordPolicy` exists AND `MinimumPasswordLength > 0` AND `RequireSymbols == true` AND `ExpirePasswords == true`
- **Key edge cases handled:**
  - Empty or missing PasswordPolicy block defaults to false (no policy set)
  - Integer/boolean coercion: handles both string and boolean types for RequireSymbols/ExpirePasswords
  - HardExpiry and other fields collected but not strictly required for pass (only checked for information)
  - Non-dict PasswordPolicy gracefully coerced to empty dict

**Semantic note:** Name "isTransportRuleBannerEnabled" suggests login banners; implementation evaluates password complexity enforcement. Consider renaming to "isPasswordPolicyConfigured" for accuracy.

### `isBannerModeEnforced.py`
Evaluates whether account-level MFA is enabled and in use across the AWS account.

- **Consumes:** AWS IAM API `GetAccountSummary` (returns SummaryMap dictionary with string keys and integer values)
- **Pass criteria:** `SummaryMap['AccountMFAEnabled'] == 1` (integer value, not string)
- **Key edge cases handled:**
  - Non-dict SummaryMap defaults to empty dict
  - Integer coercion: handles string/int conversion for AccountMFAEnabled
  - Empty SummaryMap detected and reported in fail_reasons
  - MFADevicesInUse, AccountAccessKeysPresent, SigningCertificatesPresent collected as additional findings

**Semantic note:** Name "isBannerModeEnforced" suggests security notification/banner policies; implementation checks only MFA enablement flag. Logic is correct for MFA enforcement, but name should be "isAccountMFAEnforced" or similar.

**Field accuracy:** AccountMFAEnabled, MFADevicesInUse, AccountSigningCertificatesPresent all confirmed in AWS SummaryMap schema. All field names match vendor documentation.

### `areAdminAccountsSeparate.py`
Evaluates whether IAM users include dedicated administrative accounts separate from standard operational accounts, identified via naming conventions.

- **Consumes:** AWS IAM API `ListUsers` (returns Users array with UserName field)
- **Pass criteria:** At least one user matches admin naming tokens (`admin|administrator|superuser|root|sysadmin|devops-admin|infra-admin|ops-admin|privileged`) AND at least one non-admin user exists
- **Key edge cases handled:**
  - Empty Users list results in false (cannot determine separation)
  - Non-list Users gracefully coerced to empty list
  - Non-dict user entries skipped without error
  - Case-insensitive token matching (converted to lowercase)
  - Recommendation generated for each missing pattern

**Critical limitation:** Script uses username patterns only; does NOT inspect attached policies. An account named "alice" could have AdministratorAccess attached, while "admin-bot" might have read-only permissions. For compliance-grade separation validation, script should:
1. Call ListAttachedUserPolicies or GetUser for each user
2. Check for AdministratorAccess or equivalent high-privilege policies
3. Verify admin-identified accounts actually have elevated permissions

Current implementation is insufficient for true privilege separation validation.

### `isAppConsentRestricted.py`
Evaluates whether third-party OIDC/OAuth providers registered in the account are limited to known/approved sources.

- **Consumes:** AWS IAM API `ListOpenIDConnectProviders` (returns OpenIDConnectProviderList array of provider ARNs)
- **Pass criteria:** No unrecognized OIDC providers present. Known-safe domains: `oidc.eks.amazonaws.com`, `token.actions.githubusercontent.com`, `cognito-identity.amazonaws.com`
- **Key edge cases handled:**
  - Non-list OpenIDConnectProviderList defaults to empty list (result: pass, all providers are known)
  - Provider entry can be dict with Arn key or string ARN; both handled
  - Case-insensitive domain matching
  - Empty provider list detected and reported as "fully restricted"

**Critical limitation:** Hardcoded safe list assumes no customer-managed approved OIDC providers. Organizations frequently approve custom identity providers (GitLab, Okta, Auth0, etc.). The script will incorrectly fail for any OIDC provider not on the hardcoded list, even if organization has approved it. 

For production use:
1. Safe list should be configurable (passed as parameter, not hardcoded)
2. Script should support a vendor-side approval registry or configuration store
3. Without this, false-positive failure rate will be high in real deployments

Alternatively, script could check for explicit IAM policy or tag on OIDC provider indicating approval status.

## Architecture notes

All four scripts implement the standard transformation contract: extract_input() unwraps legacy wrapper formats, evaluate() runs the security logic, create_response() builds the standardized output with passReasons, failReasons, recommendations, additionalFindings. 

Response schema is 1.0-compliant with metadata (evaluatedAt, schemaVersion, transformationId, vendor, category). All scripts include defensive type coercion (int(), isinstance checks) for missing or malformed API fields. RestrictedPython compatibility not explicitly tested but scripts use only safe built-ins and string operations.

## Test plan

- [x] Each script passes PyCodeExecutor sandbox validation (validation results report success)
- [ ] Verify evaluate() with mock GetAccountPasswordPolicy missing PasswordPolicy key (should return false)
- [ ] Verify evaluate() with mock SummaryMap containing AccountMFAEnabled=0 vs. 1 (boundary test)
- [ ] Verify evaluate() with Users array containing mixed admin/non-admin names (should return true)
- [ ] Verify evaluate() with ListOpenIDConnectProviders containing hardcoded safe domains (should return true)
- [ ] Spot-check create_response() output matches schema 1.0 (additionalInfo.evaluation keys, metadata structure)
- [ ] Confirm field names in data.get("FieldName") calls match AWS API documentation:
  - GetAccountPasswordPolicy: MinimumPasswordLength, RequireSymbols, ExpirePasswords, HardExpiry (verified)
  - GetAccountSummary: AccountMFAEnabled, MFADevicesInUse, AccountAccessKeysPresent (verified)
  - ListUsers: Users array with UserName field (verified)
  - ListOpenIDConnectProviders: OpenIDConnectProviderList array with Arn field (verified)
- [ ] **Integration test:** Run against real AWS account with:
  - No password policy configured → isTransportRuleBannerEnabled returns false
  - AccountMFAEnabled=1 in SummaryMap → isBannerModeEnforced returns true
  - Users include "admin-bot" and "alice" → areAdminAccountsSeparate returns true
  - OIDC providers include only EKS → isAppConsentRestricted returns true
  - OIDC providers include custom auth0.company.com → isAppConsentRestricted returns false (expected behavior given current safe list)

---

**Generated by Spektrum integration onboarding pipeline**
