### PR TITLE
feat: add Cato Networks transformations (firewall)

### DIFF
--- a/safeguards/firewall/cato-networks/EndUserDeviceFirewallEnabled.py
+++ b/safeguards/firewall/cato-networks/EndUserDeviceFirewallEnabled.py
@@ -1,0 +1,142 @@
+"""
+Transformation: EndUserDeviceFirewallEnabled
+Vendor: Cato Networks  |  Category: Firewall
+Evaluates: Whether the Internet Firewall policy is enabled in Cato Networks.
+The Internet Firewall protects end-user device traffic to and from the internet.
+Returns true if internetFirewall.policy.enabled is true.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "EndUserDeviceFirewallEnabled", "vendor": "Cato Networks", "category": "Firewall"}
+        }
+    }
+
+
+def count_active_rules(rules):
+    """Count rules where enabled is true."""
+    if not rules:
+        return 0
+    count = 0
+    for item in rules:
+        rule = item.get("rule", {})
+        if rule.get("enabled", False):
+            count = count + 1
+    return count
+
+
+def evaluate(data):
+    """Core evaluation logic for EndUserDeviceFirewallEnabled."""
+    try:
+        # The returnSpec for getInternetFirewallPolicy resolves to data.policy.internetFirewall.policy
+        # Shape: { "enabled": bool, "rules": [ { "rule": { ... } } ] }
+        # Handle case where data is the full policy wrapper containing internetFirewall key
+        policy = data
+        if "internetFirewall" in data:
+            inet_fw = data.get("internetFirewall", {})
+            policy = inet_fw.get("policy", {})
+
+        inet_enabled = policy.get("enabled", False)
+        rules_raw = policy.get("rules", [])
+        active_rule_count = count_active_rules(rules_raw)
+        total_rule_count = len(rules_raw) if rules_raw else 0
+
+        return {
+            "EndUserDeviceFirewallEnabled": inet_enabled,
+            "internetFirewallEnabled": inet_enabled,
+            "totalRules": total_rule_count,
+            "activeRules": active_rule_count
+        }
+    except Exception as e:
+        return {"EndUserDeviceFirewallEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "EndUserDeviceFirewallEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        active_rules = eval_result.get("activeRules", 0)
+        total_rules = eval_result.get("totalRules", 0)
+
+        if result_value:
+            pass_reasons.append("Internet Firewall policy is enabled in Cato Networks")
+            pass_reasons.append("End-user device internet traffic is protected by the firewall policy")
+            pass_reasons.append("Active rules: " + str(active_rules) + " of " + str(total_rules) + " total")
+        else:
+            if "error" in eval_result:
+                fail_reasons.append("Transformation error: " + eval_result["error"])
+            else:
+                fail_reasons.append("Internet Firewall policy is not enabled in Cato Networks")
+            recommendations.append("Enable the Internet Firewall policy in Cato Networks to protect end-user device internet traffic")
+            recommendations.append("Navigate to Security > Internet Firewall in the Cato Management Application and set the policy to enabled")
+            recommendations.append("Define ALLOW and BLOCK rules appropriate for your user population and acceptable-use policy")
+
+        additional_findings.append("Total Internet Firewall rules defined: " + str(total_rules))
+        additional_findings.append("Active Internet Firewall rules: " + str(active_rules))
+
+        return create_response(
+            result={
+                criteriaKey: result_value,
+                "internetFirewallEnabled": eval_result.get("internetFirewallEnabled", False),
+                "totalRules": total_rules,
+                "activeRules": active_rules
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"internetFirewallEnabled": result_value, "totalRules": total_rules},
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/firewall/cato-networks/NetworkConfigurationSecure.py
+++ b/safeguards/firewall/cato-networks/NetworkConfigurationSecure.py
@@ -1,0 +1,199 @@
+"""
+Transformation: NetworkConfigurationSecure
+Vendor: Cato Networks  |  Category: Firewall
+Evaluates: Overall security configuration of both internetFirewall and wanFirewall policies.
+Checks that both policies are enabled, that active rules are defined, and that event
+tracking is configured on at least one rule in each policy.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "NetworkConfigurationSecure", "vendor": "Cato Networks", "category": "Firewall"}
+        }
+    }
+
+
+def check_rules_have_tracking(rules):
+    """Return True if at least one enabled rule has event tracking enabled."""
+    if not rules:
+        return False
+    for item in rules:
+        rule = item.get("rule", {})
+        if not rule.get("enabled", False):
+            continue
+        tracking = rule.get("tracking", {})
+        event = tracking.get("event", {})
+        if event.get("enabled", False):
+            return True
+    return False
+
+
+def count_active_rules(rules):
+    """Count rules where enabled is true."""
+    if not rules:
+        return 0
+    count = 0
+    for item in rules:
+        rule = item.get("rule", {})
+        if rule.get("enabled", False):
+            count = count + 1
+    return count
+
+
+def evaluate(data):
+    """Core evaluation logic for NetworkConfigurationSecure."""
+    try:
+        fail_details = []
+
+        # Extract internetFirewall policy
+        inet_fw = data.get("internetFirewall", {})
+        inet_policy = inet_fw.get("policy", {})
+        inet_enabled = inet_policy.get("enabled", False)
+        inet_rules_raw = inet_policy.get("rules", [])
+        inet_active_count = count_active_rules(inet_rules_raw)
+        inet_tracking = check_rules_have_tracking(inet_rules_raw)
+
+        # Extract wanFirewall policy
+        wan_fw = data.get("wanFirewall", {})
+        wan_policy = wan_fw.get("policy", {})
+        wan_enabled = wan_policy.get("enabled", False)
+        wan_rules_raw = wan_policy.get("rules", [])
+        wan_active_count = count_active_rules(wan_rules_raw)
+        wan_tracking = check_rules_have_tracking(wan_rules_raw)
+
+        # Evaluate conditions
+        if not inet_enabled:
+            fail_details.append("Internet Firewall policy is not enabled")
+        if not wan_enabled:
+            fail_details.append("WAN Firewall policy is not enabled")
+        if inet_active_count == 0:
+            fail_details.append("No active rules found in Internet Firewall policy")
+        if wan_active_count == 0:
+            fail_details.append("No active rules found in WAN Firewall policy")
+        if not inet_tracking and not wan_tracking:
+            fail_details.append("Event tracking is not enabled on any active rule in either policy")
+
+        is_secure = (
+            inet_enabled and
+            wan_enabled and
+            inet_active_count > 0 and
+            wan_active_count > 0 and
+            (inet_tracking or wan_tracking)
+        )
+
+        return {
+            "NetworkConfigurationSecure": is_secure,
+            "internetFirewallEnabled": inet_enabled,
+            "wanFirewallEnabled": wan_enabled,
+            "internetFirewallActiveRules": inet_active_count,
+            "wanFirewallActiveRules": wan_active_count,
+            "internetFirewallEventTrackingEnabled": inet_tracking,
+            "wanFirewallEventTrackingEnabled": wan_tracking,
+            "failDetails": fail_details
+        }
+    except Exception as e:
+        return {"NetworkConfigurationSecure": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "NetworkConfigurationSecure"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        fail_details = eval_result.get("failDetails", [])
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Both Internet Firewall and WAN Firewall policies are enabled")
+            pass_reasons.append("Active rules are defined in both policies")
+            pass_reasons.append("Event tracking is configured on at least one active rule")
+        else:
+            if "error" in eval_result:
+                fail_reasons.append("Transformation error: " + eval_result["error"])
+            else:
+                for detail in fail_details:
+                    fail_reasons.append(detail)
+            recommendations.append("Enable both Internet Firewall and WAN Firewall policies in Cato Networks")
+            recommendations.append("Define active ALLOW and BLOCK rules for both firewall policies")
+            recommendations.append("Enable event tracking on at least one active rule to ensure audit visibility")
+
+        additional_findings.append("Internet Firewall enabled: " + str(eval_result.get("internetFirewallEnabled", False)))
+        additional_findings.append("WAN Firewall enabled: " + str(eval_result.get("wanFirewallEnabled", False)))
+        additional_findings.append("Internet Firewall active rules: " + str(eval_result.get("internetFirewallActiveRules", 0)))
+        additional_findings.append("WAN Firewall active rules: " + str(eval_result.get("wanFirewallActiveRules", 0)))
+        additional_findings.append("Internet Firewall event tracking: " + str(eval_result.get("internetFirewallEventTrackingEnabled", False)))
+        additional_findings.append("WAN Firewall event tracking: " + str(eval_result.get("wanFirewallEventTrackingEnabled", False)))
+
+        input_summary = {
+            "internetFirewallEnabled": eval_result.get("internetFirewallEnabled", False),
+            "wanFirewallEnabled": eval_result.get("wanFirewallEnabled", False),
+            "internetFirewallActiveRules": eval_result.get("internetFirewallActiveRules", 0),
+            "wanFirewallActiveRules": eval_result.get("wanFirewallActiveRules", 0)
+        }
+
+        return create_response(
+            result={
+                criteriaKey: result_value,
+                "internetFirewallEnabled": eval_result.get("internetFirewallEnabled", False),
+                "wanFirewallEnabled": eval_result.get("wanFirewallEnabled", False),
+                "internetFirewallActiveRules": eval_result.get("internetFirewallActiveRules", 0),
+                "wanFirewallActiveRules": eval_result.get("wanFirewallActiveRules", 0),
+                "internetFirewallEventTrackingEnabled": eval_result.get("internetFirewallEventTrackingEnabled", False),
+                "wanFirewallEventTrackingEnabled": eval_result.get("wanFirewallEventTrackingEnabled", False)
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_summary,
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/firewall/cato-networks/NetworkSegmentation.py
+++ b/safeguards/firewall/cato-networks/NetworkSegmentation.py
@@ -1,0 +1,152 @@
+"""
+Transformation: NetworkSegmentation
+Vendor: Cato Networks  |  Category: Firewall
+Evaluates: Network segmentation by querying entityLookup for networkInterface entities.
+Checks that two or more distinct network interfaces/segments are defined, indicating
+that the network is divided into separate zones or VLANs rather than a flat topology.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "NetworkSegmentation", "vendor": "Cato Networks", "category": "Firewall"}
+        }
+    }
+
+
+def collect_segment_names(items):
+    """Collect unique segment names from entityLookup items."""
+    seen = {}
+    names = []
+    for item in items:
+        entity = item.get("entity", {})
+        entity_id = entity.get("id", "")
+        entity_name = entity.get("name", "")
+        if entity_id and entity_id not in seen:
+            seen[entity_id] = True
+            names.append(entity_name)
+    return names
+
+
+def evaluate(data):
+    """Core evaluation logic for NetworkSegmentation."""
+    try:
+        # returnSpec for getSiteNetworkRanges resolves to data.entityLookup.items
+        # Shape: list of { "entity": { "id": str, "name": str, "type": str }, "description": str }
+        items = data
+
+        if isinstance(data, dict):
+            if "entityLookup" in data:
+                lookup = data.get("entityLookup", {})
+                items = lookup.get("items", [])
+            elif "items" in data:
+                items = data.get("items", [])
+
+        if not isinstance(items, list):
+            items = []
+
+        segment_names = collect_segment_names(items)
+        segment_count = len(segment_names)
+
+        # Network segmentation requires at least 2 distinct interfaces/segments
+        is_segmented = segment_count >= 2
+
+        return {
+            "NetworkSegmentation": is_segmented,
+            "totalNetworkSegments": segment_count,
+            "segmentNames": segment_names
+        }
+    except Exception as e:
+        return {"NetworkSegmentation": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "NetworkSegmentation"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        segment_count = eval_result.get("totalNetworkSegments", 0)
+        segment_names = eval_result.get("segmentNames", [])
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        if result_value:
+            pass_reasons.append("Network segmentation is in place with " + str(segment_count) + " distinct network interface segments")
+            pass_reasons.append("Multiple network zones reduce lateral movement risk within the environment")
+        else:
+            if "error" in eval_result:
+                fail_reasons.append("Transformation error: " + eval_result["error"])
+            else:
+                if segment_count == 0:
+                    fail_reasons.append("No network interface segments found in Cato Networks account")
+                else:
+                    fail_reasons.append("Only " + str(segment_count) + " network interface segment found; at least 2 are required for segmentation")
+            recommendations.append("Configure multiple network interfaces or VLANs in Cato Networks to segment your network")
+            recommendations.append("Separate at minimum corporate LAN, DMZ, and guest/IoT zones into distinct network ranges")
+            recommendations.append("Apply WAN Firewall policies between segments to control inter-zone traffic")
+
+        for name in segment_names:
+            additional_findings.append("Segment found: " + name)
+
+        additional_findings.append("Total distinct segments: " + str(segment_count))
+
+        return create_response(
+            result={
+                criteriaKey: result_value,
+                "totalNetworkSegments": segment_count,
+                "segmentNames": segment_names
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"totalNetworkSegments": segment_count, "segmented": result_value},
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )

--- a/safeguards/firewall/cato-networks/ServerFirewallEnabled.py
+++ b/safeguards/firewall/cato-networks/ServerFirewallEnabled.py
@@ -1,0 +1,140 @@
+"""
+Transformation: ServerFirewallEnabled
+Vendor: Cato Networks  |  Category: Firewall
+Evaluates: Whether the WAN Firewall policy is enabled in Cato Networks.
+The WAN Firewall controls access to WAN resources and server-to-server traffic.
+Returns true if wanFirewall.policy.enabled is true.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
+            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
+            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "ServerFirewallEnabled", "vendor": "Cato Networks", "category": "Firewall"}
+        }
+    }
+
+
+def count_active_rules(rules):
+    """Count rules where enabled is true."""
+    if not rules:
+        return 0
+    count = 0
+    for item in rules:
+        rule = item.get("rule", {})
+        if rule.get("enabled", False):
+            count = count + 1
+    return count
+
+
+def evaluate(data):
+    """Core evaluation logic for ServerFirewallEnabled."""
+    try:
+        # The returnSpec for getWanFirewallPolicy resolves to data.policy.wanFirewall.policy
+        # Shape: { "enabled": bool, "rules": [ { "rule": { ... } } ] }
+        # Handle case where data is the full policy wrapper containing wanFirewall key
+        policy = data
+        if "wanFirewall" in data:
+            wan_fw = data.get("wanFirewall", {})
+            policy = wan_fw.get("policy", {})
+
+        wan_enabled = policy.get("enabled", False)
+        rules_raw = policy.get("rules", [])
+        active_rule_count = count_active_rules(rules_raw)
+        total_rule_count = len(rules_raw) if rules_raw else 0
+
+        return {
+            "ServerFirewallEnabled": wan_enabled,
+            "wanFirewallEnabled": wan_enabled,
+            "totalRules": total_rule_count,
+            "activeRules": active_rule_count
+        }
+    except Exception as e:
+        return {"ServerFirewallEnabled": False, "error": str(e)}
+
+
+def transform(input):
+    criteriaKey = "ServerFirewallEnabled"
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, validation = extract_input(input)
+        if validation.get("status") == "failed":
+            return create_response(result={criteriaKey: False}, validation=validation,
+                                   fail_reasons=["Input validation failed"])
+        eval_result = evaluate(data)
+        result_value = eval_result.get(criteriaKey, False)
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        active_rules = eval_result.get("activeRules", 0)
+        total_rules = eval_result.get("totalRules", 0)
+
+        if result_value:
+            pass_reasons.append("WAN Firewall policy is enabled in Cato Networks")
+            pass_reasons.append("Active rules: " + str(active_rules) + " of " + str(total_rules) + " total")
+        else:
+            if "error" in eval_result:
+                fail_reasons.append("Transformation error: " + eval_result["error"])
+            else:
+                fail_reasons.append("WAN Firewall policy is not enabled in Cato Networks")
+            recommendations.append("Enable the WAN Firewall policy in Cato Networks to protect server-to-server and WAN resource traffic")
+            recommendations.append("Navigate to Security > WAN Firewall in the Cato Management Application and set the policy to enabled")
+
+        additional_findings.append("Total WAN Firewall rules defined: " + str(total_rules))
+        additional_findings.append("Active WAN Firewall rules: " + str(active_rules))
+
+        return create_response(
+            result={
+                criteriaKey: result_value,
+                "wanFirewallEnabled": eval_result.get("wanFirewallEnabled", False),
+                "totalRules": total_rules,
+                "activeRules": active_rules
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"wanFirewallEnabled": result_value, "totalRules": total_rules},
+            additional_findings=additional_findings
+        )
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: " + str(e)]
+        )


### PR DESCRIPTION
## Summary

Adds 4 **Cato Networks** (firewall) transformation scripts as part of the integration onboarding pipeline. These transformations evaluate Cato Networks API responses against Spektrum safeguard criteria to determine whether the organization's Cato Networks configuration meets security posture requirements.

**Context:** Cato Networks is being onboarded as a new firewall vendor integration. These scripts cover the `safeguards/firewall/cato-networks` namespace.

## What each transformation does

### `NetworkConfigurationSecure.py` (Validated)
Overall security configuration of both internetFirewall and wanFirewall policies.

- **API fields consumed:** `internetFirewall`, `wanFirewall`
- Graceful fallback on missing keys and empty responses

### `ServerFirewallEnabled.py` (Validated)
Whether the WAN Firewall policy is enabled in Cato Networks.

- **API fields consumed:** `wanFirewall`
- Graceful fallback on missing keys and empty responses

### `NetworkSegmentation.py` (Validated)
Network segmentation by querying entityLookup for networkInterface entities.

- **API fields consumed:** `entityLookup`, `items`
- Graceful fallback on missing keys and empty responses

### `EndUserDeviceFirewallEnabled.py` (Validated)
Whether the Internet Firewall policy is enabled in Cato Networks.

- **API fields consumed:** `internetFirewall`
- Graceful fallback on missing keys and empty responses

## Architecture notes

All scripts follow the standard transformation contract:
1. `extract_input()` — unwraps nested API response wrappers (up to 3 levels)
2. `evaluate()` — pure evaluation logic, returns structured result dict
3. `transform()` — orchestrates input parsing, evaluation, and response formatting via `create_response()`

Response schema includes `passReasons`, `failReasons`, `recommendations`, and `additionalFindings` for downstream consumption by the safeguard scoring pipeline. Scripts are RestrictedPython-compliant (no underscore-prefixed names, no map/filter/reduce, only `json` and `datetime` imports).

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()` returns correct result for: valid data, missing fields, API error responses
- [ ] Confirm `extract_input()` handles both new `{data, validation}` format and legacy wrapped formats
- [ ] Spot-check `create_response()` output matches expected schema version 1.0

🤖 Generated by Spektrum integration onboarding pipeline