### PR TITLE
feat: add SentinelOne transformations (epp)

### DIFF
--- a/safeguards/epp/sentinelone/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/confirmedLicensePurchased.py
@@ -1,0 +1,203 @@
+"""Transformation: confirmedLicensePurchased — checks that a valid SentinelOne license is purchased and active."""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+
+    if not accounts:
+        return create_response(
+            result={"confirmedLicensePurchased": False, "totalAccounts": 0, "activePaidAccounts": 0},
+            validation=validation,
+            fail_reasons=["No accounts found in the SentinelOne API response. Cannot confirm a valid license is purchased."],
+            recommendations=["Verify that the API token has sufficient permissions to read account data and that the account is properly set up in SentinelOne."],
+            input_summary={"totalAccounts": 0, "activePaidAccounts": 0},
+            metadata={"transformationId": "confirmedLicensePurchased", "vendor": "SentinelOne", "category": "epp"},
+        )
+
+    total_accounts = len(accounts)
+    active_paid_accounts = []
+    all_findings = []
+
+    for account in accounts:
+        account_name = account.get("name") or "Unknown"
+        account_state = account.get("state") or ""
+        account_type = account.get("accountType") or ""
+        billing_mode = account.get("billingMode") or ""
+        total_licenses = account.get("totalLicenses")
+        active_agents = account.get("activeAgents") or 0
+
+        skus = account.get("skus") or []
+        licenses = account.get("licenses") or {}
+        bundles = licenses.get("bundles") or []
+
+        is_active = account_state.lower() == "active"
+        is_paid = account_type.lower() == "paid"
+
+        has_unlimited_sku = False
+        has_nonzero_sku = False
+        sku_details = []
+        for sku in skus:
+            sku_type = sku.get("type") or "Unknown"
+            sku_unlimited = sku.get("unlimited") or False
+            sku_total = sku.get("totalLicenses") or 0
+            if sku_unlimited:
+                has_unlimited_sku = True
+            if sku_total > 0:
+                has_nonzero_sku = True
+            sku_details.append(sku_type + "(unlimited=" + str(sku_unlimited) + ", totalLicenses=" + str(sku_total) + ")")
+
+        bundle_names = [b.get("displayName") or b.get("name") or "Unknown" for b in bundles]
+
+        # totalLicenses=-1 means unlimited; unlimited SKU or positive seat count also valid
+        has_license = (
+            (total_licenses is not None and total_licenses != 0)
+            or has_unlimited_sku
+            or has_nonzero_sku
+        )
+
+        finding = (
+            "Account '" + account_name + "': state=" + account_state
+            + ", accountType=" + account_type
+            + ", billingMode=" + billing_mode
+            + ", totalLicenses=" + str(total_licenses)
+            + ", activeAgents=" + str(active_agents)
+        )
+        if bundle_names:
+            finding = finding + ", bundles=[" + ", ".join(bundle_names) + "]"
+        if sku_details:
+            finding = finding + ", skus=[" + ", ".join(sku_details) + "]"
+        all_findings.append(finding)
+
+        if is_active and is_paid and has_license:
+            active_paid_accounts.append({
+                "name": account_name,
+                "state": account_state,
+                "accountType": account_type,
+                "billingMode": billing_mode,
+                "totalLicenses": total_licenses,
+                "bundleNames": bundle_names,
+                "skuDetails": sku_details,
+                "activeAgents": active_agents,
+            })
+
+    confirmed = len(active_paid_accounts) > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if confirmed:
+        for acc in active_paid_accounts:
+            parts = [
+                "Account '" + acc["name"] + "' has a valid paid license",
+                "state=" + acc["state"],
+                "accountType=" + acc["accountType"],
+                "billingMode=" + acc["billingMode"],
+                "totalLicenses=" + str(acc["totalLicenses"]),
+                "activeAgents=" + str(acc["activeAgents"]),
+            ]
+            if acc["bundleNames"]:
+                parts.append("bundles=[" + ", ".join(acc["bundleNames"]) + "]")
+            if acc["skuDetails"]:
+                parts.append("skus=[" + ", ".join(acc["skuDetails"]) + "]")
+            pass_reasons.append(", ".join(parts))
+    else:
+        for finding in all_findings:
+            fail_reasons.append("No valid paid active license found. " + finding)
+        recommendations.append(
+            "Ensure the SentinelOne account has an active paid subscription. "
+            "Check that account state='active', accountType='Paid', and at least one SKU "
+            "has unlimited=true or totalLicenses > 0."
+        )
+
+    return create_response(
+        result={
+            "confirmedLicensePurchased": confirmed,
+            "totalAccounts": total_accounts,
+            "activePaidAccounts": len(active_paid_accounts),
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAccounts": total_accounts,
+            "activePaidAccounts": len(active_paid_accounts),
+        },
+        additional_findings=all_findings,
+        metadata={
+            "transformationId": "confirmedLicensePurchased",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/isEPPConfigured.py
+++ b/safeguards/epp/sentinelone/isEPPConfigured.py
@@ -1,0 +1,168 @@
+"""Transformation: isEPPConfigured — checks EPP protection policy configuration via agent mitigationMode and active status."""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    agents = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    if total_items == 0 and len(agents) == 0:
+        return create_response(
+            result={"isEPPConfigured": False, "totalAgents": 0, "sampledAgents": 0, "configuredAgents": 0, "misconfiguredAgents": 0},
+            validation=validation,
+            fail_reasons=["No agents found in the SentinelOne fleet. EPP cannot be considered configured with zero enrolled endpoints."],
+            recommendations=["Enroll endpoints with the SentinelOne agent to establish EPP coverage."],
+            input_summary={"totalAgents": 0, "sampledAgents": 0},
+            metadata={"transformationId": "isEPPConfigured", "vendor": "SentinelOne", "category": "epp"},
+        )
+
+    sampled = len(agents)
+    configured_count = 0
+    misconfigured_count = 0
+    misconfigured_examples = []
+
+    for agent in agents:
+        agent = agent if isinstance(agent, dict) else {}
+        mitigation_mode = agent.get("mitigationMode") or ""
+        is_active = agent.get("isActive")
+        is_decommissioned = agent.get("isDecommissioned") or False
+        computer_name = agent.get("computerName") or agent.get("id") or "unknown"
+
+        if mitigation_mode:
+            if mitigation_mode in ("protect", "detect"):
+                configured_count = configured_count + 1
+            else:
+                misconfigured_count = misconfigured_count + 1
+                if len(misconfigured_examples) < 3:
+                    misconfigured_examples.append(
+                        computer_name + " (mitigationMode=" + str(mitigation_mode) + ")"
+                    )
+        else:
+            if is_active is not False and not is_decommissioned:
+                configured_count = configured_count + 1
+            else:
+                misconfigured_count = misconfigured_count + 1
+                if len(misconfigured_examples) < 3:
+                    misconfigured_examples.append(
+                        computer_name + " (inactive or decommissioned)"
+                    )
+
+    is_configured = total_items > 0 and misconfigured_count == 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_configured:
+        pass_reasons.append(
+            str(total_items) + " agents are enrolled in SentinelOne. "
+            "All " + str(sampled) + " sampled agents show EPP protection configured "
+            "(mitigationMode=protect/detect or active non-decommissioned agent state). "
+            "EPP health check passes."
+        )
+    else:
+        if total_items == 0:
+            fail_reasons.append(
+                "No agents enrolled in SentinelOne; EPP health check cannot pass with zero endpoints."
+            )
+            recommendations.append("Enroll endpoints with the SentinelOne agent.")
+        if misconfigured_count > 0:
+            example_str = ", ".join(misconfigured_examples) if misconfigured_examples else "none captured"
+            fail_reasons.append(
+                str(misconfigured_count) + " of " + str(sampled) + " sampled agents have EPP misconfigured "
+                "(mitigationMode=none or agent inactive/decommissioned). "
+                "Examples: " + example_str + "."
+            )
+            recommendations.append(
+                "Review and update the SentinelOne policy for affected agents to set mitigationMode to 'protect'."
+            )
+
+    return create_response(
+        result={
+            "isEPPConfigured": is_configured,
+            "totalAgents": total_items,
+            "sampledAgents": sampled,
+            "configuredAgents": configured_count,
+            "misconfiguredAgents": misconfigured_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAgents": total_items,
+            "sampledAgents": sampled,
+            "configuredAgents": configured_count,
+            "misconfiguredAgents": misconfigured_count,
+        },
+        metadata={"transformationId": "isEPPConfigured", "vendor": "SentinelOne", "category": "epp"},
+    )

--- a/safeguards/epp/sentinelone/isEPPEnabled.py
+++ b/safeguards/epp/sentinelone/isEPPEnabled.py
@@ -1,0 +1,156 @@
+"""Transformation: isEPPEnabled — checks if EPP agents are deployed on endpoints."""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    agents = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    active_count = 0
+    inactive_count = 0
+    decommissioned_count = 0
+    uninstalled_count = 0
+
+    for agent in agents:
+        if not isinstance(agent, dict):
+            continue
+        is_active = agent.get("isActive")
+        is_decommissioned = agent.get("isDecommissioned")
+        is_uninstalled = agent.get("isUninstalled")
+        is_pending_uninstall = agent.get("isPendingUninstall")
+
+        if is_decommissioned:
+            decommissioned_count = decommissioned_count + 1
+        elif is_uninstalled or is_pending_uninstall:
+            uninstalled_count = uninstalled_count + 1
+        elif is_active:
+            active_count = active_count + 1
+        else:
+            inactive_count = inactive_count + 1
+
+    page_size = len(agents)
+
+    is_epp_enabled = total_items > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_epp_enabled:
+        pass_reasons.append(
+            "SentinelOne EPP agents are deployed across the fleet. "
+            "pagination.totalItems reports " + str(total_items) + " enrolled agents in the account."
+        )
+        if page_size > 0:
+            pass_reasons.append(
+                "Sample of " + str(page_size) + " agents inspected: " +
+                str(active_count) + " active, " +
+                str(inactive_count) + " inactive, " +
+                str(decommissioned_count) + " decommissioned, " +
+                str(uninstalled_count) + " uninstalled/pending-uninstall."
+            )
+    else:
+        fail_reasons.append(
+            "No SentinelOne EPP agents are enrolled in this account. "
+            "pagination.totalItems returned 0, indicating no endpoints have the EPP agent deployed."
+        )
+        recommendations.append(
+            "Deploy the SentinelOne EPP agent to all managed endpoints. "
+            "Use the SentinelOne management console to download and distribute the agent installer."
+        )
+
+    return create_response(
+        result={
+            "isEPPEnabled": is_epp_enabled,
+            "totalAgents": total_items,
+            "activeAgentsInSample": active_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalItems": total_items,
+            "pageSize": page_size,
+            "activeInSample": active_count,
+            "inactiveInSample": inactive_count,
+            "decommissionedInSample": decommissioned_count,
+            "uninstalledInSample": uninstalled_count,
+        },
+        metadata={
+            "transformationId": "isEPPEnabled",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/isEPPLoggingEnabled.py
+++ b/safeguards/epp/sentinelone/isEPPLoggingEnabled.py
@@ -1,0 +1,162 @@
+"""Transformation: isEPPLoggingEnabled
+Checks whether EDR telemetry/logging is active on SentinelOne agents
+by inspecting the `activeProtection` array for the 'edr' value.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    agents = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    total_agents = len(agents)
+    agents_with_edr = 0
+    agents_without_edr = []
+
+    for agent in agents:
+        active_protection = agent.get("activeProtection") or []
+        if "edr" in active_protection:
+            agents_with_edr = agents_with_edr + 1
+        else:
+            computer_name = agent.get("computerName") or agent.get("id") or "unknown"
+            agents_without_edr.append(computer_name)
+
+    # Use totalItems from pagination as the authoritative total if available
+    effective_total = total_items if total_items > 0 else total_agents
+
+    logging_enabled = (agents_with_edr == total_agents) and (total_agents > 0)
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+    additional_findings = []
+
+    if effective_total == 0:
+        fail_reasons.append(
+            "No agents were returned by the getAgents API. Cannot confirm EDR logging is active."
+        )
+        recommendations.append(
+            "Verify that agents are enrolled in SentinelOne and that the API credentials have sufficient scope to list agents."
+        )
+    elif logging_enabled:
+        pass_reasons.append(
+            "All " + str(total_agents) + " agents in the current page have 'edr' present in their activeProtection array, "
+            "confirming EDR telemetry and logging is active. The fleet total reported by pagination is " + str(effective_total) + " agents."
+        )
+        if effective_total > total_agents:
+            additional_findings.append(
+                "Only " + str(total_agents) + " agents were inspected in this page out of " + str(effective_total) + " total enrolled agents. "
+                "Full fleet coverage requires paginated evaluation."
+            )
+    else:
+        agents_missing = total_agents - agents_with_edr
+        fail_reasons.append(
+            str(agents_missing) + " out of " + str(total_agents) + " inspected agents are missing 'edr' from their activeProtection array, "
+            "indicating EDR telemetry/logging is not active on those endpoints."
+        )
+        if agents_without_edr:
+            sample = agents_without_edr[:5]
+            additional_findings.append(
+                "Sample agents without EDR active: " + ", ".join(sample)
+            )
+        recommendations.append(
+            "Review the SentinelOne policy applied to the affected agents and ensure the EDR module is enabled. "
+            "Navigate to Sentinels > Policies, select the relevant policy, and confirm EDR logging is turned on."
+        )
+
+    result = {
+        "isEPPLoggingEnabled": logging_enabled,
+        "totalAgents": effective_total,
+        "agentsInspected": total_agents,
+        "agentsWithEDRLogging": agents_with_edr,
+        "agentsWithoutEDRLogging": total_agents - agents_with_edr,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        additional_findings=additional_findings,
+        input_summary={
+            "totalItems": effective_total,
+            "agentsInspected": total_agents,
+            "agentsWithEDR": agents_with_edr,
+        },
+        metadata={
+            "transformationId": "isEPPLoggingEnabled",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/requiredCoveragePercentage.py
@@ -1,0 +1,159 @@
+"""Transformation: requiredCoveragePercentage — SentinelOne getAgents
+Computes the percentage of enrolled endpoints on which the SentinelOne EPP
+agent is actively running, using pagination.totalItems as the fleet total.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    items = data.get("data") or []
+    pagination = data.get("pagination") or {}
+
+    total_items = pagination.get("totalItems")
+    if total_items is None:
+        total_items = len(items)
+
+    total_items = int(total_items) if total_items is not None else 0
+
+    # Count active, non-decommissioned, non-uninstalled agents in the current page
+    active_count = 0
+    for agent in items:
+        is_active = agent.get("isActive")
+        is_decommissioned = agent.get("isDecommissioned")
+        is_uninstalled = agent.get("isUninstalled")
+        is_pending_uninstall = agent.get("isPendingUninstall")
+        if (is_active is True
+                and is_decommissioned is not True
+                and is_uninstalled is not True
+                and is_pending_uninstall is not True):
+            active_count = active_count + 1
+
+    page_size = len(items)
+
+    # Coverage percentage: active agents over total enrolled fleet
+    if total_items == 0:
+        coverage_percentage = None
+        passes = False
+        pass_reasons = []
+        fail_reasons = ["No agents are enrolled in SentinelOne (pagination.totalItems=0). Cannot compute coverage."]
+        recommendations = ["Ensure the SentinelOne agent is deployed to all managed endpoints."]
+    else:
+        coverage_percentage = round((active_count * 100.0) / total_items, 2)
+        passes = coverage_percentage >= 95.0
+
+        total_str = str(total_items)
+        active_str = str(active_count)
+        pct_str = str(coverage_percentage)
+
+        if passes:
+            pass_reasons = [
+                "SentinelOne reports " + total_str + " total enrolled agents (pagination.totalItems=" + total_str + "). "
+                + active_str + " agents on the current page are active, non-decommissioned, and not pending uninstall. "
+                + "Computed coverage " + pct_str + "% meets or exceeds the 95% threshold."
+            ]
+            fail_reasons = []
+            recommendations = []
+        else:
+            pass_reasons = []
+            fail_reasons = [
+                "Coverage is " + pct_str + "% (" + active_str + " active agents out of " + total_str + " total enrolled). "
+                + "This is below the required 95% threshold."
+            ]
+            recommendations = [
+                "Deploy the SentinelOne agent to all unprotected endpoints. "
+                + "Review agents with isActive=false, isDecommissioned=true, or isPendingUninstall=true and remediate."
+            ]
+
+    result = {
+        "requiredCoveragePercentage": coverage_percentage,
+        "passes": passes,
+        "totalAgents": total_items,
+        "activeAgentsInPage": active_count,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAgents": total_items,
+            "activeAgentsInPage": active_count,
+            "coveragePercentage": coverage_percentage,
+        },
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/schemas/__init__.py
+++ b/safeguards/epp/sentinelone/schemas/__init__.py
@@ -1,0 +1,15 @@
+"""Schema registry for this vendor's transformations."""
+
+from .confirmedLicensePurchased import ConfirmedLicensePurchasedInput
+from .isEPPConfigured import IsEPPConfiguredInput
+from .isEPPEnabled import IsEPPEnabledInput
+from .isEPPLoggingEnabled import IsEPPLoggingEnabledInput
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
+__all__ = [
+    "ConfirmedLicensePurchasedInput",
+    "IsEPPConfiguredInput",
+    "IsEPPEnabledInput",
+    "IsEPPLoggingEnabledInput",
+    "RequiredCoveragePercentageInput",
+]

--- a/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
@@ -1,0 +1,102 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class SkuItem(BaseModel):
+    agentsInSku: Optional[int] = None
+    totalLicenses: Optional[int] = None
+    type: Optional[str] = None
+    unlimited: Optional[bool] = None
+
+    class Config:
+        extra = "allow"
+
+
+class LicenseSurface(BaseModel):
+    count: Optional[int] = None
+    name: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class LicenseBundle(BaseModel):
+    displayName: Optional[str] = None
+    majorVersion: Optional[int] = None
+    minorVersion: Optional[int] = None
+    name: Optional[str] = None
+    surfaces: Optional[List[LicenseSurface]] = None
+    totalSurfaces: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class LicenseModule(BaseModel):
+    displayName: Optional[str] = None
+    majorVersion: Optional[int] = None
+    name: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class LicenseSetting(BaseModel):
+    displayName: Optional[str] = None
+    groupName: Optional[str] = None
+    setting: Optional[str] = None
+    settingGroup: Optional[str] = None
+    settingGroupDisplayName: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class Licenses(BaseModel):
+    bundles: Optional[List[LicenseBundle]] = None
+    modules: Optional[List[LicenseModule]] = None
+    settings: Optional[List[LicenseSetting]] = None
+
+    class Config:
+        extra = "allow"
+
+
+class AccountItem(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    accountType: Optional[str] = None
+    activeAgents: Optional[int] = None
+    billingMode: Optional[str] = None
+    createdAt: Optional[str] = None
+    expiration: Optional[str] = None
+    isDefault: Optional[bool] = None
+    licenses: Optional[Licenses] = None
+    skus: Optional[List[SkuItem]] = None
+    state: Optional[str] = None
+    totalLicenses: Optional[int] = None
+    unlimitedComplete: Optional[bool] = None
+    unlimitedControl: Optional[bool] = None
+    unlimitedCore: Optional[bool] = None
+    unlimitedExpiration: Optional[bool] = None
+    usageType: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class Pagination(BaseModel):
+    nextCursor: Optional[str] = None
+    totalItems: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class ConfirmedLicensePurchasedInput(BaseModel):
+    """Input schema for the confirmedLicensePurchased transformation.
+    Matches the GET /web/api/v2.1/accounts response shape from SentinelOne."""
+    data: Optional[List[AccountItem]] = None
+    pagination: Optional[Pagination] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPConfigured.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPConfigured.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPConfiguredInput(BaseModel):
+    """Input schema for the isEPPConfigured transformation (SentinelOne getAgents response)."""
+
+    class Config:
+        extra = "allow"
+
+    data: Optional[List[Dict[str, Any]]] = None
+    pagination: Optional[Dict[str, Any]] = None

--- a/safeguards/epp/sentinelone/schemas/isEPPEnabled.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPEnabled.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPEnabledInput(BaseModel):
+    """Input schema for the isEPPEnabled transformation (SentinelOne getAgents response)."""
+
+    data: Optional[List[Dict[str, Any]]] = None
+    pagination: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPLoggingEnabled.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPLoggingEnabled.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPLoggingEnabledInput(BaseModel):
+    """Input schema for the isEPPLoggingEnabled transformation.
+
+    Expects the getAgents API response shape with a 'data' list of agent
+    records (each containing an 'activeProtection' array) and a 'pagination'
+    object with 'totalItems'.
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class PaginationModel(BaseModel):
+    nextCursor: Optional[str] = None
+    totalItems: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class AgentItem(BaseModel):
+    id: Optional[str] = None
+    computerName: Optional[str] = None
+    isActive: Optional[bool] = None
+    isDecommissioned: Optional[bool] = None
+    isPendingUninstall: Optional[bool] = None
+    isUninstalled: Optional[bool] = None
+    isUpToDate: Optional[bool] = None
+    activeThreats: Optional[int] = None
+    mitigationMode: Optional[str] = None
+    networkStatus: Optional[str] = None
+    agentVersion: Optional[str] = None
+    osType: Optional[str] = None
+    siteName: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation.
+
+    Expects the SentinelOne getAgents response shape with a data array of
+    agent records and a pagination object containing totalItems.
+    """
+    data: Optional[List[AgentItem]] = None
+    pagination: Optional[PaginationModel] = None
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Integration Onboarding — SentinelOne (Endpoint Security)

Auto-generated **transformation modules** for **SentinelOne** (Endpoint Security), produced by the V2 onboarding pipeline.

### Run summary

| Metric | Value |
| --- | --- |
| Shipped | 5 / 6 criteria |
| Dropped at live validation | 0 |
| Unroutable (no API surface) | 1 |
| Duration | ? |

### Authentication

| Field | Value |
| --- | --- |
| Scheme | AuthScheme.API_KEY |
| Header | Authorization |
| Prefix | `ApiToken` |
| Token setting key | `apiToken` |

### Methods catalogue

| Method | Endpoint | Serves criteria |
| --- | --- | --- |
| `getAgents` | `HttpMethod.GET` {$baseURL}/web/api/v2.1/agents | `isEPPEnabled`, `isEPPConfigured`, `isEPPLoggingEnabled`, `requiredCoveragePercentage` |
| `countAgents` | `HttpMethod.GET` {$baseURL}/web/api/v2.1/agents/count | `requiredCoveragePercentage`, `isEPPEnabled` |
| `getAccounts` | `HttpMethod.GET` {$baseURL}/web/api/v2.1/accounts | `confirmedLicensePurchased`, `requiredCoveragePercentage` |
| `getSites` | `HttpMethod.GET` {$baseURL}/web/api/v2.1/sites | `confirmedLicensePurchased`, `requiredCoveragePercentage` |

### Per-criterion outcome

| Criterion | Method | Live val | Outcome |
| --- | --- | --- | --- |
| `confirmedLicensePurchased` | `getAccounts` | passed (HTTP 200) | shipped |
| `isEPPConfigured` | `getAgents` | passed (HTTP 200) | shipped |
| `isEPPEnabled` | `getAgents` | passed (HTTP 200) | shipped |
| `isEPPLoggingEnabled` | `getAgents` | passed (HTTP 200) | shipped |
| `requiredCoveragePercentage` | `getAgents` | passed (HTTP 200) | shipped |
| `isSSOEnabled` | — | — | unroutable |

### Unroutable criteria

**`isSSOEnabled`**

> SentinelOne SSO (SAML) is exclusively configured through the management console UI under Settings > SSO. The v2.1 REST API does not expose any GET endpoint that returns SSO configuration state (enabled/disabled, IdP details, or SSO enforcement policy). Investigated the following approaches: (1) Searched for /sso-settings, /settings/sso, /auth/sso — none documented in v2.1 API; (2) GET /users returns a `source` field (local|sso|scim) per user, but this reflects per-user login method, not whether SSO is enforced as an account policy; (3) The SentinelOne API docs reference SSO only in the context of auth flows (Redirect to SSO, Auth by SSO) — not configuration read endpoints; (4) SCIM endpoint URL is generated inside the console under Settings > SSO and is not queryable via REST. No credible…

### Audit

**Receipt ID:** `de881fd6-e3c2-4d3e-a6b9-d319e6c4198d`  
**Phase-1 web searches:** 6  
**Tokens (in/out):** 77,673 / 45,524

---
*Auto-generated by Token Service V2 onboarding pipeline.*