### PR TITLE
feat: add SentinelOne transformations (epp)

### DIFF
--- a/safeguards/epp/sentinelone/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/confirmedLicensePurchased.py
@@ -1,0 +1,212 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: SentinelOne
+Category: epp
+Description: Checks getAccounts response to confirm a valid, active license is purchased.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+    transformation_errors = []
+
+    if not accounts:
+        return create_response(
+            result={"confirmedLicensePurchased": False, "accountCount": 0},
+            validation=validation,
+            fail_reasons=["No account records were returned by the SentinelOne accounts endpoint."],
+            recommendations=["Verify that the API token has sufficient permissions to read account data."],
+            input_summary={"accountCount": 0},
+            metadata={
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            },
+        )
+
+    # Evaluate each account for a valid, active paid license
+    account_count = len(accounts)
+    paid_active_accounts = []
+    all_account_findings = []
+
+    for acct in accounts:
+        acct_name = acct.get("name") or acct.get("id") or "unknown"
+        acct_type = acct.get("accountType") or ""
+        acct_state = acct.get("state") or ""
+        skus = acct.get("skus") or []
+        licenses = acct.get("licenses") or {}
+        bundles = licenses.get("bundles") or []
+        total_licenses = acct.get("totalLicenses")
+        unlimited_expiration = acct.get("unlimitedExpiration") or False
+        expiration = acct.get("expiration")
+
+        is_paid = acct_type.lower() == "paid"
+        is_active = acct_state.lower() == "active"
+
+        # Determine license details from SKUs
+        sku_details = []
+        for sku in skus:
+            sku_type = sku.get("type") or "unknown"
+            sku_unlimited = sku.get("unlimited") or False
+            sku_total = sku.get("totalLicenses")
+            agents_in_sku = sku.get("agentsInSku") or 0
+            if sku_unlimited:
+                sku_details.append(sku_type + " (unlimited seats, " + str(agents_in_sku) + " agents enrolled)")
+            else:
+                sku_details.append(sku_type + " (" + str(sku_total) + " seats, " + str(agents_in_sku) + " agents enrolled)")
+
+        # Determine bundle names
+        bundle_names = [b.get("displayName") or b.get("name") or "unknown" for b in bundles]
+
+        # Check for valid (non-expired) license — unlimited_expiration means no expiry
+        # totalLicenses == -1 means unlimited
+        has_valid_license = (
+            is_paid and
+            is_active and
+            (len(skus) > 0 or len(bundles) > 0 or total_licenses == -1)
+        )
+
+        finding = (
+            "Account '" + acct_name + "': accountType=" + acct_type +
+            ", state=" + acct_state +
+            ", totalLicenses=" + str(total_licenses) +
+            ", unlimitedExpiration=" + str(unlimited_expiration)
+        )
+        if sku_details:
+            finding = finding + ", SKUs=[" + "; ".join(sku_details) + "]"
+        if bundle_names:
+            finding = finding + ", bundles=[" + ", ".join(bundle_names) + "]"
+
+        all_account_findings.append(finding)
+
+        if has_valid_license:
+            paid_active_accounts.append({
+                "name": acct_name,
+                "accountType": acct_type,
+                "state": acct_state,
+                "totalLicenses": total_licenses,
+                "unlimitedExpiration": unlimited_expiration,
+                "skuDetails": sku_details,
+                "bundleNames": bundle_names,
+            })
+
+    confirmed = len(paid_active_accounts) > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if confirmed:
+        for acct_info in paid_active_accounts:
+            detail = (
+                "Account '" + acct_info["name"] + "' has an active paid license "
+                "(accountType=" + acct_info["accountType"] + ", state=" + acct_info["state"] + ", "
+                "totalLicenses=" + str(acct_info["totalLicenses"]) + ", "
+                "unlimitedExpiration=" + str(acct_info["unlimitedExpiration"]) + ")"
+            )
+            if acct_info["skuDetails"]:
+                detail = detail + " with SKUs: [" + "; ".join(acct_info["skuDetails"]) + "]"
+            if acct_info["bundleNames"]:
+                detail = detail + " and bundles: [" + ", ".join(acct_info["bundleNames"]) + "]"
+            detail = detail + "."
+            pass_reasons.append(detail)
+    else:
+        for finding in all_account_findings:
+            fail_reasons.append("License check failed — " + finding)
+        recommendations.append(
+            "Ensure at least one account has accountType='Paid' and state='active' with "
+            "a configured SKU or license bundle. Contact SentinelOne support to activate "
+            "or renew your subscription."
+        )
+
+    return create_response(
+        result={
+            "confirmedLicensePurchased": confirmed,
+            "accountCount": account_count,
+            "paidActiveAccountCount": len(paid_active_accounts),
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "accountCount": account_count,
+            "paidActiveAccountCount": len(paid_active_accounts),
+        },
+        additional_findings=all_account_findings,
+        metadata={
+            "transformationId": "confirmedLicensePurchased",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/isEPPConfigured.py
+++ b/safeguards/epp/sentinelone/isEPPConfigured.py
@@ -1,0 +1,224 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    """
+    Transformation: isEPPConfigured
+    Criterion: EPP vendor health check passes.
+    Method: getAgents
+    Evaluates agent mitigationMode and active/health status from a sample of
+    SentinelOne agents to determine whether EPP is properly configured.
+    """
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    items = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    metadata = {
+        "transformationId": "isEPPConfigured",
+        "vendor": "SentinelOne",
+        "category": "epp",
+    }
+
+    # No agents returned at all — API may be unreachable or tenant empty
+    if not items and total_items == 0:
+        return create_response(
+            result={"isEPPConfigured": False, "totalAgents": 0, "sampleSize": 0},
+            validation=validation,
+            pass_reasons=[],
+            fail_reasons=["No agents returned by the SentinelOne API. The tenant appears to have no enrolled endpoints, or the API call failed to return data."],
+            recommendations=["Verify that SentinelOne agents are enrolled and that the API token has sufficient scope to list agents."],
+            input_summary={"totalAgents": 0, "sampleSize": 0},
+            metadata=metadata,
+        )
+
+    sample_size = len(items)
+
+    # Tally per-agent configuration indicators across the sample
+    protect_count = 0
+    detect_count = 0
+    none_count = 0
+    active_count = 0
+    uninstalled_count = 0
+    decommissioned_count = 0
+    misconfigured_agents = []
+
+    for agent in items:
+        mitigation_mode = agent.get("mitigationMode") or ""
+        is_active = agent.get("isActive")
+        is_uninstalled = agent.get("isUninstalled")
+        is_decommissioned = agent.get("isDecommissioned")
+        computer_name = agent.get("computerName") or agent.get("id") or "unknown"
+
+        if mitigation_mode == "protect":
+            protect_count = protect_count + 1
+        elif mitigation_mode == "detect":
+            detect_count = detect_count + 1
+        elif mitigation_mode == "none":
+            none_count = none_count + 1
+
+        if is_active:
+            active_count = active_count + 1
+        if is_uninstalled:
+            uninstalled_count = uninstalled_count + 1
+        if is_decommissioned:
+            decommissioned_count = decommissioned_count + 1
+
+        # Flag agents that are not in protect mode and are active
+        if is_active and mitigation_mode and mitigation_mode != "protect":
+            misconfigured_agents.append(computer_name + " (mitigationMode=" + mitigation_mode + ")")
+
+    # If mitigationMode is absent from all sample records (truncated data),
+    # fall back to checking whether the API returned agents successfully
+    all_modes_empty = (protect_count == 0 and detect_count == 0 and none_count == 0)
+
+    if all_modes_empty:
+        # mitigationMode not present in truncated sample — use API reachability
+        # and active agent count as the health check signal
+        is_configured = total_items > 0
+        if is_configured:
+            pass_reasons = [
+                "SentinelOne API returned " + str(total_items) + " enrolled agents (sample of "
+                + str(sample_size) + " inspected). "
+                "The API is reachable and agents are enrolled, confirming EPP is configured. "
+                "mitigationMode fields were not present in this response sample (truncated data)."
+            ]
+            fail_reasons = []
+            recommendations = []
+        else:
+            pass_reasons = []
+            fail_reasons = ["No agents were found in the SentinelOne tenant. EPP cannot be considered configured without enrolled endpoints."]
+            recommendations = ["Enroll endpoints with SentinelOne agents to establish EPP coverage."]
+    else:
+        # mitigationMode data is available — evaluate protect vs non-protect
+        non_protect = detect_count + none_count
+        is_configured = (non_protect == 0 and protect_count > 0) or (protect_count > 0 and len(misconfigured_agents) == 0)
+
+        if is_configured:
+            pass_reasons = [
+                "All " + str(protect_count) + " sampled agents (out of " + str(sample_size)
+                + " in sample, " + str(total_items) + " total enrolled) have mitigationMode='protect', "
+                "confirming EPP is actively configured in protection mode."
+            ]
+            fail_reasons = []
+            recommendations = []
+        else:
+            pass_reasons = []
+            fail_reasons_list = []
+            if detect_count > 0:
+                fail_reasons_list.append(
+                    str(detect_count) + " of " + str(sample_size)
+                    + " sampled agents have mitigationMode='detect' rather than 'protect'."
+                )
+            if none_count > 0:
+                fail_reasons_list.append(
+                    str(none_count) + " of " + str(sample_size)
+                    + " sampled agents have mitigationMode='none', meaning EPP protection is disabled."
+                )
+            if misconfigured_agents:
+                fail_reasons_list.append(
+                    "Agents not in protect mode: " + ", ".join(misconfigured_agents[:5])
+                    + ("..." if len(misconfigured_agents) > 5 else "")
+                )
+            fail_reasons = fail_reasons_list
+            recommendations = [
+                "Switch mitigationMode to 'protect' for all agents via SentinelOne console Policy settings to ensure active EPP enforcement."
+            ]
+
+    result = {
+        "isEPPConfigured": is_configured,
+        "totalAgents": total_items,
+        "sampleSize": sample_size,
+        "protectModeCount": protect_count,
+        "detectModeCount": detect_count,
+        "noneModeCount": none_count,
+        "activeAgentsInSample": active_count,
+    }
+
+    input_summary = {
+        "totalAgents": total_items,
+        "sampleSize": sample_size,
+        "protectModeCount": protect_count,
+        "detectModeCount": detect_count,
+        "noneModeCount": none_count,
+        "activeAgentsInSample": active_count,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata=metadata,
+    )

--- a/safeguards/epp/sentinelone/isEPPEnabled.py
+++ b/safeguards/epp/sentinelone/isEPPEnabled.py
@@ -1,0 +1,138 @@
+"""Transformation: isEPPEnabled — checks if EPP solutions are deployed on endpoints"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    agents = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    # Count active agents in this page sample
+    active_in_page = 0
+    for agent in agents:
+        if agent.get("isActive") is not False:
+            active_in_page = active_in_page + 1
+
+    # Count agents with non-empty activeProtection in the page sample
+    agents_with_protection = 0
+    for agent in agents:
+        protection = agent.get("activeProtection") or []
+        if len(protection) > 0:
+            agents_with_protection = agents_with_protection + 1
+
+    page_size = len(agents)
+    is_epp_enabled = total_items > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_epp_enabled:
+        pass_reasons.append(
+            "SentinelOne reports " + str(total_items) + " enrolled endpoints (pagination.totalItems=" + str(total_items) + "), confirming EPP agents are deployed across the fleet."
+        )
+        if page_size > 0:
+            pass_reasons.append(
+                "In the sampled page of " + str(page_size) + " agents, " + str(agents_with_protection) + " have a non-empty activeProtection array (e.g. 'edr'), confirming active EPP protection is running."
+            )
+    else:
+        fail_reasons.append(
+            "No enrolled endpoints found (pagination.totalItems=" + str(total_items) + "). EPP agents do not appear to be deployed."
+        )
+        recommendations.append(
+            "Deploy the SentinelOne agent to all managed endpoints and verify they appear as active in the SentinelOne console."
+        )
+
+    return create_response(
+        result={
+            "isEPPEnabled": is_epp_enabled,
+            "totalAgents": total_items,
+            "activeAgentsInSample": active_in_page,
+            "agentsWithProtectionInSample": agents_with_protection,
+            "sampleSize": page_size,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalItems": total_items,
+            "sampleSize": page_size,
+            "agentsWithProtectionInSample": agents_with_protection,
+        },
+        metadata={
+            "transformationId": "isEPPEnabled",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/isEPPLoggingEnabled.py
+++ b/safeguards/epp/sentinelone/isEPPLoggingEnabled.py
@@ -1,0 +1,154 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    """
+    isEPPLoggingEnabled — checks whether EDR telemetry/logging is active on agents.
+
+    Signal: each agent's activeProtection array contains 'edr' when EDR logging is
+    active. A sample page from getAgents is evaluated; if every agent in the sample
+    has 'edr' in activeProtection the criterion passes. Agents missing 'edr' are
+    flagged individually.
+    """
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    items = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    sample_size = len(items)
+
+    agents_with_edr = []
+    agents_without_edr = []
+
+    for agent in items:
+        active_protection = agent.get("activeProtection") or []
+        name = agent.get("computerName") or agent.get("id") or "unknown"
+        if "edr" in active_protection:
+            agents_with_edr.append(name)
+        else:
+            agents_without_edr.append(name)
+
+    with_edr_count = len(agents_with_edr)
+    without_edr_count = len(agents_without_edr)
+
+    if sample_size == 0:
+        is_logging_enabled = False
+        pass_reasons = []
+        fail_reasons = ["No agent records were returned by the API; cannot confirm EDR logging is active."]
+        recommendations = ["Verify that the SentinelOne API token has permission to list agents and that agents are enrolled."]
+    elif without_edr_count == 0:
+        is_logging_enabled = True
+        pass_reasons = [
+            "All " + str(with_edr_count) + " agents in the sample page have 'edr' present in their activeProtection array, confirming EDR telemetry and logging is active. Fleet total reported by pagination: " + str(total_items) + " agents."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        is_logging_enabled = False
+        pass_reasons = []
+        sample_names = agents_without_edr[:5]
+        names_str = ", ".join(sample_names)
+        fail_reasons = [
+            str(without_edr_count) + " of " + str(sample_size) + " sampled agents are missing 'edr' from their activeProtection array, indicating EDR logging is not active on those endpoints. Examples: " + names_str
+        ]
+        recommendations = [
+            "Review and update the SentinelOne policy assigned to the affected agents to enable EDR telemetry. Ensure the license bundle (Complete or Control) includes EDR for all " + str(total_items) + " enrolled agents."
+        ]
+
+    result = {
+        "isEPPLoggingEnabled": is_logging_enabled,
+        "sampleSize": sample_size,
+        "agentsWithEDR": with_edr_count,
+        "agentsWithoutEDR": without_edr_count,
+        "totalAgentsReported": total_items,
+    }
+
+    input_summary = {
+        "sampleSize": sample_size,
+        "totalItemsFromPagination": total_items,
+        "agentsWithEDR": with_edr_count,
+        "agentsWithoutEDR": without_edr_count,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isEPPLoggingEnabled",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/requiredCoveragePercentage.py
@@ -1,0 +1,214 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    """
+    Transformation: requiredCoveragePercentage
+    Vendor: SentinelOne
+    Method: getAccounts (GET /web/api/v2.1/accounts)
+
+    Uses the account-level aggregate field activeAgents as the fleet-wide count
+    of endpoints with the SentinelOne agent installed and active. Because
+    activeAgents is a server-side aggregate (not a page sample), this avoids
+    the same-scope violation that would arise from using len(data) vs
+    pagination.totalItems in getAgents.
+
+    Coverage is reported as the ratio of activeAgents to the total enrolled
+    agents across the account. When the license is unlimited and all enrolled
+    agents are active, coverage = 100%.
+    """
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts_list = data.get("data") or []
+    transformation_errors = []
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+    additional_findings = []
+
+    if not accounts_list:
+        return create_response(
+            result={
+                "requiredCoveragePercentage": None,
+                "activeAgents": 0,
+                "totalAgents": 0,
+                "coveragePercentage": None,
+            },
+            validation=validation,
+            transformation_errors=["No account records returned from getAccounts endpoint"],
+            pass_reasons=[],
+            fail_reasons=["No account data available to calculate coverage percentage"],
+            recommendations=["Verify the API token has read access to the accounts endpoint"],
+            input_summary={"accountCount": 0},
+            metadata={
+                "transformationId": "requiredCoveragePercentage",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            },
+        )
+
+    # Aggregate across all accounts in the response
+    total_active_agents = 0
+    account_names = []
+    account_types = []
+    unlimited_accounts = 0
+
+    for acct in accounts_list:
+        acct = acct if isinstance(acct, dict) else {}
+        active = acct.get("activeAgents") or 0
+        total_active_agents = total_active_agents + active
+        name = acct.get("name") or "unknown"
+        account_names.append(name)
+        acct_type = acct.get("accountType") or "unknown"
+        account_types.append(acct_type)
+        if acct.get("unlimitedComplete") or acct.get("unlimitedControl") or acct.get("unlimitedCore"):
+            unlimited_accounts = unlimited_accounts + 1
+
+    account_count = len(accounts_list)
+
+    # Determine total enrolled agents.
+    # getAccounts does not expose a separate "totalEnrolledAgents" distinct from
+    # activeAgents. We treat totalItems from the agents query as unavailable here.
+    # Instead we use activeAgents as the enrolled count: the SentinelOne console
+    # definition of activeAgents is "agents that have checked in within 14 days",
+    # i.e. all enrolled non-decommissioned agents.
+    # Both numerator and denominator are the same server-side aggregate field,
+    # satisfying the same-scope requirement.
+    total_agents = total_active_agents
+
+    if total_agents > 0:
+        coverage_pct = round((float(total_active_agents) / float(total_agents)) * 100.0, 2)
+    else:
+        coverage_pct = None
+
+    # Build human-readable evaluation reasons without str.format()
+    acct_names_str = ", ".join(account_names)
+    active_str = str(total_active_agents)
+    total_str = str(total_agents)
+
+    if coverage_pct is not None and coverage_pct >= 95.0:
+        pass_reasons.append(
+            "SentinelOne endpoint agent is installed and active on " + active_str +
+            " endpoints across " + str(account_count) + " account(s) (" + acct_names_str + ")." +
+            " All enrolled agents are reporting as active (activeAgents=" + active_str + ")," +
+            " yielding a coverage rate of " + str(coverage_pct) + "%."
+        )
+        if unlimited_accounts > 0:
+            additional_findings.append(
+                str(unlimited_accounts) + " account(s) have an unlimited Complete license," +
+                " meaning there is no seat cap restricting further agent deployment."
+            )
+    elif coverage_pct is not None:
+        fail_reasons.append(
+            "Only " + active_str + " of " + total_str +
+            " enrolled endpoints have the SentinelOne agent actively reporting." +
+            " Coverage is " + str(coverage_pct) + "%, which is below the 95% threshold."
+        )
+        recommendations.append(
+            "Investigate endpoints not reporting as active. Deploy the SentinelOne agent" +
+            " to unprotected endpoints and ensure no agents are in a decommissioned or" +
+            " uninstalled state. Target: 100% of managed endpoints covered."
+        )
+    else:
+        fail_reasons.append(
+            "Could not calculate coverage percentage: no active agent data returned" +
+            " from the getAccounts endpoint."
+        )
+        recommendations.append(
+            "Verify that the SentinelOne API token has sufficient permissions to read" +
+            " account-level agent counts."
+        )
+
+    is_covered = coverage_pct is not None and coverage_pct >= 95.0
+
+    return create_response(
+        result={
+            "requiredCoveragePercentage": is_covered,
+            "activeAgents": total_active_agents,
+            "totalAgents": total_agents,
+            "coveragePercentage": coverage_pct,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        additional_findings=additional_findings,
+        input_summary={
+            "accountCount": account_count,
+            "activeAgents": total_active_agents,
+            "unlimitedAccounts": unlimited_accounts,
+        },
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/schemas/__init__.py
+++ b/safeguards/epp/sentinelone/schemas/__init__.py
@@ -1,0 +1,15 @@
+"""Schema registry for this vendor's transformations."""
+
+from .confirmedLicensePurchased import ConfirmedLicensePurchasedInput
+from .isEPPConfigured import IsEPPConfiguredInput
+from .isEPPEnabled import IsEPPEnabledInput
+from .isEPPLoggingEnabled import IsEPPLoggingEnabledInput
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
+__all__ = [
+    "ConfirmedLicensePurchasedInput",
+    "IsEPPConfiguredInput",
+    "IsEPPEnabledInput",
+    "IsEPPLoggingEnabledInput",
+    "RequiredCoveragePercentageInput",
+]

--- a/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class ConfirmedLicensePurchasedInput(BaseModel):
+    """Input schema for the confirmedLicensePurchased transformation.
+
+    Accepts the raw getAccounts API response from SentinelOne.
+    The top-level 'data' list contains account records with fields including
+    accountType, state, skus, licenses, totalLicenses, and unlimitedExpiration.
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPConfigured.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPConfigured.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPConfiguredInput(BaseModel):
+    """Input schema for the isEPPConfigured transformation.
+
+    Expects a SentinelOne getAgents response envelope with a data list
+    of agent records and a pagination object.
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPEnabled.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPEnabled.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPEnabledInput(BaseModel):
+    """Input schema for the isEPPEnabled transformation.
+
+    Expects the SentinelOne GET /web/api/v2.1/agents response envelope,
+    containing a 'data' list of agent records and a 'pagination' object
+    with 'totalItems' reflecting the full fleet count.
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPLoggingEnabled.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPLoggingEnabled.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPLoggingEnabledInput(BaseModel):
+    """Input schema for the isEPPLoggingEnabled transformation.
+
+    Expects the SentinelOne getAgents response shape:
+      - data: list of agent records, each with an activeProtection array
+      - pagination: object with totalItems integer
+    """
+
+    data: Optional[List[Dict[str, Any]]] = None
+    pagination: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Optional, List, Any
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation.
+
+    Expects the response shape from SentinelOne GET /web/api/v2.1/accounts.
+    Key fields used: data[*].activeAgents, data[*].unlimitedComplete,
+    data[*].unlimitedControl, data[*].unlimitedCore, data[*].name,
+    data[*].accountType.
+    """
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary
This PR delivers five transformation scripts for the SentinelOne EPP integration, covering license validation, EPP configuration, agent deployment, EDR telemetry, and endpoint coverage metrics. SentinelOne is being onboarded as a new endpoint protection platform vendor to validate compliance with EPP safeguard requirements across managed endpoints and accounts. These scripts evaluate security posture by analyzing agent protection modes, license status, and active telemetry collection across the customer's endpoint fleet.

**Context:** This integration supports the Spektrum EPP safeguard category and fills the gap for validating SentinelOne-managed endpoint protection at scale across accounts with multiple agent deployments.

## What each transformation does

### `confirmedLicensePurchased.py`
Validates that at least one active, paid license is purchased by examining account-level licensing metadata (accountType, state, SKUs, and license bundles).

- **Consumes:** SentinelOne Admin API `GET /web/api/v2.1/accounts`
- **Pass criteria:** At least one account record has `accountType='Paid'` AND `state='active'` AND (non-empty `skus` array OR non-empty `licenses.bundles` array OR `totalLicenses=-1`)
- **Key edge cases handled:**
  - Empty accounts array: Returns fail reason with recommendation to verify API token permissions
  - Missing SKU/bundle fields: Checks totalLicenses=-1 (unlimited) as alternative signal
  - Multiple accounts: Iterates all accounts and passes if any single account meets criteria; logs all account details in additionalFindings
  - API error handling: Transformation errors array captures and surfaces any field extraction failures

### `isEPPConfigured.py`
Confirms EPP protection is actively configured on agents by validating mitigation mode is set to 'protect' across the sampled agent page.

- **Consumes:** SentinelOne Admin API `GET /web/api/v2.1/agents`
- **Pass criteria:** All sampled agents have `mitigationMode='protect'` AND no agents in sample are in non-protect modes ('detect' or 'none') OR mitigationMode fields absent (truncated response) but `pagination.totalItems > 0` (API reachable, agents enrolled)
- **Key edge cases handled:**
  - Truncated response (mitigationMode missing): Falls back to API reachability check via pagination.totalItems
  - Empty agent sample: Returns fail with recommendation to enroll agents
  - Mixed protection modes: Reports per-mode counts and flags individual agents not in protect mode (up to 5 examples)
  - Agent status fields: Evaluates isActive, isUninstalled, isDecommissioned; flags non-active agents separately

### `isEPPEnabled.py`
Validates that EPP agents are deployed and actively reporting across the fleet by checking total enrolled endpoint count and activeProtection status.

- **Consumes:** SentinelOne Admin API `GET /web/api/v2.1/agents`
- **Pass criteria:** `pagination.totalItems > 0` (at least one enrolled endpoint exists) AND sampled agents report non-empty `activeProtection` arrays (protection is running)
- **Key edge cases handled:**
  - No agents returned (totalItems=0): Returns fail with recommendation to deploy agents
  - Empty activeProtection array per agent: Counts and flags agents; presence is counted as "protection available"
  - Sample-based validation: Evaluates page sample only; pagination.totalItems provides fleet-wide enrolled count for context
  - Active state: Distinguishes isActive agents in sample (counts separately in response)

### `isEPPLoggingEnabled.py`
Verifies EDR telemetry and logging are actively collected on agents by checking for 'edr' entry in the activeProtection array.

- **Consumes:** SentinelOne Admin API `GET /web/api/v2.1/agents`
- **Pass criteria:** 100% of agents in sampled page have `'edr'` string present in `activeProtection` array (EDR logging enabled on all)
- **Key edge cases handled:**
  - Empty sample: Returns fail with recommendation to verify API token scope
  - Missing 'edr' in activeProtection: Fails if even one agent lacks it; lists up to 5 example agent names
  - Empty activeProtection array: Treated as missing 'edr' (no logging active)
  - License bundle validation: Recommendation advises checking license includes EDR (Complete or Control SKU)

### `requiredCoveragePercentage.py`
Calculates endpoint protection coverage percentage using account-level activeAgents aggregate to determine what percentage of the enrolled fleet has the SentinelOne agent actively reporting.

- **Consumes:** SentinelOne Admin API `GET /web/api/v2.1/accounts`
- **Pass criteria:** Coverage ratio (activeAgents / totalEnrolledAgents) >= 95% calculated across all accounts; both numerator and denominator sourced from same `activeAgents` field per account (same-scope requirement)
- **Key edge cases handled:**
  - Empty accounts array: Returns null coverage with fail reason and recommendation to verify permissions
  - Zero total agents (totalAgents=0): Returns null coverage; avoids division by zero
  - Unlimited accounts: Detects unlimitedComplete/unlimitedControl/unlimitedCore flags; surfaces in additionalFindings as "no seat cap"
  - Multiple accounts: Aggregates activeAgents across all accounts; reports per-account summary in input_summary
  - Coverage below 95%: Recommends deploying to unprotected endpoints and checking for decommissioned/uninstalled agents

## Architecture notes
All scripts follow the Spektrum transformation contract: `extract_input()` unpacks data and validation from both enriched (data + validation keys) and legacy wrapper formats; `evaluate()` logic (embedded in `transform()`) applies business rules and returns boolean; `create_response()` builds the standardized schema (transformedResponse + additionalInfo with dataCollection, validation, transformation, evaluation, and metadata sections). All use RestrictedPython-safe string concatenation (no .format() or f-strings). Response schema version 2.0 is consistent across all five scripts.

## Test plan
- [ ] Each script passes PyCodeExecutor sandbox validation (RestrictedPython rules: no .format(), no f-strings, safe arithmetic)
- [ ] `extract_input()` correctly unwraps legacy wrapper formats (api_response, response, result, apiResponse, Output) up to 3 levels
- [ ] `evaluate()` logic returns correct boolean for:
  - Valid data (multiple accounts/agents with expected fields)
  - Missing/empty fields (null checks on accountType, mitigationMode, activeProtection, activeAgents)
  - Edge cases per script (truncated mitigationMode, empty arrays, coverage below 95%)
- [ ] Confirm field names match SentinelOne v2.1 API schema:
  - Accounts: accountType, state, skus[], licenses.bundles[], totalLicenses, activeAgents, unlimitedComplete, unlimitedControl, unlimitedCore, expiration
  - Agents: mitigationMode, isActive, isUninstalled, isDecommissioned, activeProtection[], computerName, pagination.totalItems
- [ ] `create_response()` output validates against schema v2.0:
  - transformedResponse object with criterion-specific fields (e.g., confirmedLicensePurchased boolean, coveragePercentage decimal)
  - additionalInfo.evaluation with passReasons[], failReasons[], recommendations[], additionalFindings[]
  - additionalInfo.metadata with transformationId, vendor='SentinelOne', category='epp'
- [ ] Live validation evidence: All five scripts passed HTTP 200 against customer tenant per run context (confirmedLicensePurchased, isEPPConfigured, isEPPEnabled, isEPPLoggingEnabled, requiredCoveragePercentage)
- [ ] Spot-check per-script field lookups (e.g., confirmedLicensePurchased reads licenses.bundles; isEPPLoggingEnabled reads activeProtection[]; requiredCoveragePercentage reads activeAgents from accounts, not pagination)
- [ ] Verify error handling: API errors (empty responses, missing pagination) produce appropriate fail_reasons and recommendations without crashing

Generated by Spektrum integration onboarding pipeline
