### PR TITLE
feat: add SentinelOne transformations (epp)

### DIFF
--- a/safeguards/epp/sentinelone/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/confirmedLicensePurchased.py
@@ -1,0 +1,196 @@
+"""Transformation: confirmedLicensePurchased — SentinelOne getAccounts"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+    accounts = accounts if isinstance(accounts, list) else []
+
+    if not accounts:
+        return create_response(
+            result={"confirmedLicensePurchased": False},
+            validation=validation,
+            fail_reasons=["No account records returned from getAccounts endpoint."],
+            recommendations=["Verify API credentials and account provisioning in SentinelOne."],
+            input_summary={"accountCount": 0},
+            metadata={
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            },
+        )
+
+    # Evaluate each account for a valid active license
+    paid_active_accounts = []
+    unlimited_accounts = []
+    bundle_names = []
+    sku_types = []
+    account_types = []
+    account_states = []
+
+    for account in accounts:
+        acct_type = account.get("accountType") or ""
+        state = account.get("state") or ""
+        account_types.append(acct_type)
+        account_states.append(state)
+
+        # Check skus for unlimited or positive license counts
+        skus = account.get("skus") or []
+        skus = skus if isinstance(skus, list) else []
+        for sku in skus:
+            sku_type = sku.get("type") or ""
+            if sku_type and sku_type not in sku_types:
+                sku_types.append(sku_type)
+            unlimited = sku.get("unlimited") or False
+            total_licenses = sku.get("totalLicenses") or 0
+            if unlimited or total_licenses > 0:
+                if acct_type.lower() == "paid" and state.lower() == "active":
+                    if account not in paid_active_accounts:
+                        paid_active_accounts.append(account)
+
+        # Check licenses.bundles
+        licenses_obj = account.get("licenses") or {}
+        licenses_obj = licenses_obj if isinstance(licenses_obj, dict) else {}
+        bundles = licenses_obj.get("bundles") or []
+        bundles = bundles if isinstance(bundles, list) else []
+        for bundle in bundles:
+            bname = bundle.get("displayName") or bundle.get("name") or ""
+            if bname and bname not in bundle_names:
+                bundle_names.append(bname)
+
+        # Also check unlimited flags at account level
+        unlimited_complete = account.get("unlimitedComplete") or False
+        unlimited_control = account.get("unlimitedControl") or False
+        unlimited_core = account.get("unlimitedCore") or False
+        if (unlimited_complete or unlimited_control or unlimited_core) and state.lower() == "active":
+            if account not in unlimited_accounts:
+                unlimited_accounts.append(account)
+
+    # A license is confirmed if any account is Paid + active with unlimited or purchased seats
+    confirmed = len(paid_active_accounts) > 0 or len(unlimited_accounts) > 0
+
+    total_accounts = len(accounts)
+    confirmed_count = len(paid_active_accounts) if paid_active_accounts else len(unlimited_accounts)
+
+    # Build human-readable strings without .format()
+    sku_types_str = ", ".join(sku_types) if sku_types else "N/A"
+    bundle_names_str = ", ".join(bundle_names) if bundle_names else "N/A"
+    account_types_str = ", ".join(account_types) if account_types else "N/A"
+    account_states_str = ", ".join(account_states) if account_states else "N/A"
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if confirmed:
+        pass_reasons.append(
+            str(confirmed_count) + " of " + str(total_accounts) +
+            " account(s) confirmed as Paid and active with a valid license. " +
+            "Account type(s): " + account_types_str + ". " +
+            "Account state(s): " + account_states_str + ". " +
+            "SKU type(s): " + sku_types_str + ". " +
+            "License bundle(s): " + bundle_names_str + "."
+        )
+    else:
+        fail_reasons.append(
+            "No accounts found with a Paid accountType and active state with valid license seats. " +
+            "Account type(s) found: " + account_types_str + ". " +
+            "Account state(s) found: " + account_states_str + "."
+        )
+        recommendations.append(
+            "Purchase a SentinelOne license (Complete, Control, or Core SKU) and ensure the account state is active."
+        )
+
+    return create_response(
+        result={
+            "confirmedLicensePurchased": confirmed,
+            "totalAccounts": total_accounts,
+            "confirmedAccounts": confirmed_count,
+            "skuTypes": sku_types_str,
+            "licenseBundles": bundle_names_str,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAccounts": total_accounts,
+            "confirmedAccounts": confirmed_count,
+            "skuTypes": sku_types,
+            "licenseBundles": bundle_names,
+        },
+        metadata={
+            "transformationId": "confirmedLicensePurchased",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/requiredCoveragePercentage.py
@@ -1,0 +1,186 @@
+"""Transformation: requiredCoveragePercentage — SentinelOne getAccounts
+Computes the percentage of endpoints covered by Endpoint Security agents
+relative to licensed seats. Handles unlimited-license accounts (totalLicenses=-1).
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+    accounts = accounts if isinstance(accounts, list) else []
+
+    total_active_agents = 0
+    total_licenses = 0
+    has_unlimited = False
+    account_count = len(accounts)
+
+    for account in accounts:
+        active = account.get("activeAgents") or 0
+        total_active_agents = total_active_agents + active
+
+        lic = account.get("totalLicenses")
+        # -1 signals unlimited license capacity
+        if lic is not None and lic == -1:
+            has_unlimited = True
+        elif lic is not None and lic > 0:
+            total_licenses = total_licenses + lic
+
+        # Also check per-account unlimited flags
+        if account.get("unlimitedComplete") or account.get("unlimitedControl") or account.get("unlimitedCore"):
+            has_unlimited = True
+
+        # Also check skus array for unlimited
+        skus = account.get("skus") or []
+        for sku in skus:
+            if sku.get("unlimited"):
+                has_unlimited = True
+
+    # Compute coverage percentage
+    if has_unlimited:
+        # Unlimited license capacity — all active agents are covered
+        coverage_pct = 100.0
+        license_desc = "unlimited"
+    elif total_licenses > 0:
+        raw = (float(total_active_agents) / float(total_licenses)) * 100.0
+        # Cap at 100 if over-provisioned
+        if raw > 100.0:
+            coverage_pct = 100.0
+        else:
+            coverage_pct = round(raw, 2)
+        license_desc = str(total_licenses) + " licensed seats"
+    else:
+        coverage_pct = 0.0
+        license_desc = "0 licensed seats"
+
+    input_summary = {
+        "accountCount": account_count,
+        "totalActiveAgents": total_active_agents,
+        "totalLicenses": total_licenses if not has_unlimited else -1,
+        "hasUnlimitedLicense": has_unlimited,
+    }
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if has_unlimited:
+        pass_reasons.append(
+            str(total_active_agents) + " active agents are enrolled across " +
+            str(account_count) + " account(s) with an unlimited-capacity license "
+            "(totalLicenses=-1, unlimitedComplete=true). "
+            "All enrolled endpoints are covered by Endpoint Security — coverage is 100%."
+        )
+    elif coverage_pct >= 100.0:
+        pass_reasons.append(
+            str(total_active_agents) + " active agents are enrolled against " +
+            license_desc + ". Coverage is " + str(coverage_pct) + "% (full coverage)."
+        )
+    elif coverage_pct > 0.0:
+        fail_reasons.append(
+            str(total_active_agents) + " active agents are enrolled against " +
+            license_desc + ". Coverage is " + str(coverage_pct) + "%, which is below 100%."
+        )
+        recommendations.append(
+            "Deploy Endpoint Security agents to the remaining " +
+            str(total_licenses - total_active_agents) +
+            " endpoints that have purchased licenses but are not yet enrolled."
+        )
+    else:
+        fail_reasons.append(
+            "No active agents detected (" + str(total_active_agents) +
+            ") and no valid license seats found (" + license_desc +
+            "). Endpoint Security coverage cannot be determined."
+        )
+        recommendations.append(
+            "Verify that SentinelOne agents are deployed to endpoints and that "
+            "a valid license is assigned to this account."
+        )
+
+    return create_response(
+        result={
+            "requiredCoveragePercentage": coverage_pct,
+            "totalActiveAgents": total_active_agents,
+            "totalLicenses": total_licenses if not has_unlimited else -1,
+            "hasUnlimitedLicense": has_unlimited,
+            "accountCount": account_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/schemas/__init__.py
+++ b/safeguards/epp/sentinelone/schemas/__init__.py
@@ -1,0 +1,9 @@
+"""Schema registry for this vendor's transformations."""
+
+from .confirmedLicensePurchased import ConfirmedLicensePurchasedInput
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
+__all__ = [
+    "ConfirmedLicensePurchasedInput",
+    "RequiredCoveragePercentageInput",
+]

--- a/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class ConfirmedLicensePurchasedInput(BaseModel):
+    """Input schema for the confirmedLicensePurchased transformation.
+
+    Validates the getAccounts response from SentinelOne v2.1.
+    Each account record carries accountType, state, licenses (bundles/modules/settings),
+    skus, and unlimited-seat flags that together confirm whether a paid, active
+    license is in place.
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,46 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class SkuItem(BaseModel):
+    agentsInSku: Optional[int] = None
+    totalLicenses: Optional[int] = None
+    type: Optional[str] = None
+    unlimited: Optional[bool] = None
+
+    class Config:
+        extra = "allow"
+
+
+class AccountItem(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    accountType: Optional[str] = None
+    activeAgents: Optional[int] = None
+    billingMode: Optional[str] = None
+    totalLicenses: Optional[int] = None
+    unlimitedComplete: Optional[bool] = None
+    unlimitedControl: Optional[bool] = None
+    unlimitedCore: Optional[bool] = None
+    skus: Optional[List[SkuItem]] = None
+    state: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class PaginationInfo(BaseModel):
+    nextCursor: Optional[str] = None
+    totalItems: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation."""
+    data: Optional[List[AccountItem]] = None
+    pagination: Optional[PaginationInfo] = None
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Integration Onboarding — SentinelOne (Endpoint Security)

Auto-generated **transformation modules** for **SentinelOne** (Endpoint Security), produced by the V2 onboarding pipeline.

### Run summary

| Metric | Value |
| --- | --- |
| Shipped | 2 / 6 criteria |
| Dropped at live validation | 1 |
| Unroutable (no API surface) | 3 |
| Duration | 6m 8s |

### Authentication

| Field | Value |
| --- | --- |
| Scheme | apiKey |
| Header | Authorization |
| Prefix | `ApiToken` |
| Token setting key | `apiToken` |

### Methods catalogue

| Method | Endpoint | Serves criteria |
| --- | --- | --- |
| `countAgents` | `GET` {$baseURL}/web/api/v2.1/agents/count | `isEPPEnabled`, `requiredCoveragePercentage` |
| `getAccounts` | `GET` {$baseURL}/web/api/v2.1/accounts | `confirmedLicensePurchased`, `requiredCoveragePercentage`, `isEPPEnabled` |
| `getSites` | `GET` {$baseURL}/web/api/v2.1/sites | `confirmedLicensePurchased`, `requiredCoveragePercentage` |

### Per-criterion outcome

| Criterion | Method | Live val | Outcome |
| --- | --- | --- | --- |
| `confirmedLicensePurchased` | `getAccounts` | passed (HTTP 200) | shipped |
| `isEPPEnabled` | `countAgents` | RunOutcome.FAILED_TRANSFORM (200) | dropped at live val |
| `requiredCoveragePercentage` | `getAccounts` | passed (HTTP 200) | shipped |
| `isEPPConfigured` | — | — | unroutable |
| `isEPPLoggingEnabled` | — | — | unroutable |
| `isSSOEnabled` | — | — | unroutable |

### Unroutable criteria

**`isSSOEnabled`**

> No public SentinelOne REST API v2.1 endpoint surfaces the global SSO enabled/disabled state. SSO configuration is managed exclusively through the management console UI (Settings > SSO). The user object source field (local|sso|scim) is per-user and does not represent a tenant-level SSO enforcement toggle. The SCIM endpoint and bearer token are generated inside the console but are not queryable via the management API. Searched 3 distinct query variations; no results found for any read-SSO-config endpoint. Investigated endpoints all returned either 404, empty responses, or unrelated data.

**`isEPPConfigured`**

> Catalogue probe: method 'getAgents' ({$baseURL}/web/api/v2.1/agents) returned DEAD on this tenant. No live alternative method serves this criterion.

**`isEPPLoggingEnabled`**

> Catalogue probe: method 'getAgents' ({$baseURL}/web/api/v2.1/agents) returned DEAD on this tenant. No live alternative method serves this criterion.

### Audit

**Receipt ID:** `7dd75c71-190f-4fb1-bb7e-4d22b28ae260`  
**Phase-1 web searches:** 4  
**Tokens (in/out):** 32,716 / 35,380

---
*Auto-generated by Token Service V2 onboarding pipeline.*