### PR TITLE
feat: add SentinelOne transformations (epp)

### DIFF
--- a/safeguards/epp/sentinelone/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/confirmedLicensePurchased.py
@@ -1,0 +1,196 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+
+    if not accounts:
+        return create_response(
+            result={
+                "confirmedLicensePurchased": False,
+                "totalAccounts": 0,
+                "activeAccounts": 0,
+                "paidAccounts": 0,
+                "licensedBundles": [],
+            },
+            validation=validation,
+            pass_reasons=[],
+            fail_reasons=["No account records returned from the API. Unable to confirm a valid license exists."],
+            recommendations=[
+                "Verify the API token has sufficient permissions to read account information, "
+                "and that at least one account exists."
+            ],
+            input_summary={"totalAccounts": 0, "activeAccounts": 0},
+            metadata={
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            }
+        )
+
+    license_confirmed = False
+    active_accounts = 0
+    paid_accounts = 0
+    unlimited_accounts = 0
+    licensed_bundle_names = []
+
+    for account in accounts:
+        state = account.get("state") or ""
+        account_type = account.get("accountType") or ""
+        total_licenses = account.get("totalLicenses")
+        unlimited_complete = account.get("unlimitedComplete") or False
+        unlimited_control = account.get("unlimitedControl") or False
+        unlimited_core = account.get("unlimitedCore") or False
+        skus = account.get("skus") or []
+        licenses_obj = account.get("licenses") or {}
+        bundles = licenses_obj.get("bundles") or []
+
+        if state == "active":
+            active_accounts = active_accounts + 1
+
+        if account_type == "Paid":
+            paid_accounts = paid_accounts + 1
+
+        has_unlimited = unlimited_complete or unlimited_control or unlimited_core
+        if not has_unlimited:
+            for sku in skus:
+                if sku.get("unlimited"):
+                    has_unlimited = True
+                    break
+
+        # totalLicenses == -1 means unlimited in the SentinelOne API
+        has_licenses = has_unlimited or (total_licenses is not None and total_licenses != 0)
+
+        if has_unlimited:
+            unlimited_accounts = unlimited_accounts + 1
+
+        for bundle in bundles:
+            bundle_name = bundle.get("displayName") or bundle.get("name") or ""
+            if bundle_name and bundle_name not in licensed_bundle_names:
+                licensed_bundle_names.append(bundle_name)
+
+        if state == "active" and has_licenses:
+            license_confirmed = True
+
+    total_accounts = len(accounts)
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if license_confirmed:
+        reason_parts = []
+        if paid_accounts > 0:
+            reason_parts.append(f"{paid_accounts} account(s) with accountType='Paid'")
+        if unlimited_accounts > 0:
+            reason_parts.append(f"{unlimited_accounts} account(s) with unlimited license entitlement")
+        if licensed_bundle_names:
+            bundle_str = ", ".join(licensed_bundle_names)
+            reason_parts.append(f"licensed bundle(s): {bundle_str}")
+        summary = "; ".join(reason_parts) if reason_parts else "active state with valid license entitlement"
+        pass_reasons.append(
+            f"Valid license confirmed across {active_accounts} active account(s) "
+            f"(of {total_accounts} total): {summary}."
+        )
+    else:
+        fail_reasons.append(
+            f"No active accounts with valid license entitlement found across {total_accounts} account(s) examined "
+            f"(active={active_accounts}, paid={paid_accounts}, unlimited={unlimited_accounts})."
+        )
+        recommendations.append(
+            "Ensure at least one SentinelOne account is in 'active' state with a purchased license "
+            "(totalLicenses > 0, totalLicenses = -1 for unlimited, or skus[*].unlimited = true)."
+        )
+
+    return create_response(
+        result={
+            "confirmedLicensePurchased": license_confirmed,
+            "totalAccounts": total_accounts,
+            "activeAccounts": active_accounts,
+            "paidAccounts": paid_accounts,
+            "licensedBundles": licensed_bundle_names,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAccounts": total_accounts,
+            "activeAccounts": active_accounts,
+        },
+        metadata={
+            "transformationId": "confirmedLicensePurchased",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        }
+    )

--- a/safeguards/epp/sentinelone/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/requiredCoveragePercentage.py
@@ -1,0 +1,180 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+
+    if not accounts:
+        return create_response(
+            result={
+                "requiredCoveragePercentage": 0.0,
+                "activeAgents": 0,
+                "totalLicenses": 0,
+                "unlimitedLicense": False,
+            },
+            validation=validation,
+            fail_reasons=["No account records found in the API response. Cannot determine endpoint coverage."],
+            recommendations=["Ensure the API token has read access to account data in SentinelOne."],
+            input_summary={"accountCount": 0},
+            metadata={
+                "transformationId": "requiredCoveragePercentage",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            },
+        )
+
+    total_active_agents = 0
+    total_licenses = 0
+    is_unlimited = False
+    account_count = len(accounts)
+
+    for account in accounts:
+        active = account.get("activeAgents") or 0
+        total_active_agents = total_active_agents + active
+
+        tl = account.get("totalLicenses")
+        if tl is not None and tl == -1:
+            is_unlimited = True
+        elif tl is not None and tl > 0:
+            total_licenses = total_licenses + tl
+
+        skus = account.get("skus") or []
+        for sku in skus:
+            if sku.get("unlimited"):
+                is_unlimited = True
+
+        if account.get("unlimitedComplete") or account.get("unlimitedControl") or account.get("unlimitedCore"):
+            is_unlimited = True
+
+    if is_unlimited:
+        coverage = 100.0
+        pass_reasons = [
+            f"The account holds an unlimited license (totalLicenses=-1 and/or unlimited=true on a SKU). "
+            f"All {total_active_agents} active enrolled agents across {account_count} account(s) "
+            f"are fully covered with no seat ceiling. Coverage is reported as 100%."
+        ]
+        fail_reasons = []
+        recommendations = []
+    elif total_licenses == 0:
+        coverage = 0.0
+        fail_reasons = [
+            f"No licensed seats found (totalLicenses=0) across {account_count} account(s). "
+            f"{total_active_agents} active agents exist but no purchased license capacity could be determined."
+        ]
+        pass_reasons = []
+        recommendations = ["Purchase SentinelOne licenses to establish endpoint coverage capacity."]
+    else:
+        raw_coverage = (float(total_active_agents) / float(total_licenses)) * 100.0
+        coverage = round(min(raw_coverage, 100.0), 2)
+        if coverage >= 100.0:
+            pass_reasons = [
+                f"{total_active_agents} active agents are enrolled against {total_licenses} licensed seats "
+                f"across {account_count} account(s), yielding {coverage}% endpoint security coverage."
+            ]
+            fail_reasons = []
+            recommendations = []
+        else:
+            gap = total_licenses - total_active_agents
+            fail_reasons = [
+                f"Only {total_active_agents} of {total_licenses} licensed seats have enrolled active agents "
+                f"across {account_count} account(s), yielding {coverage}% endpoint security coverage. "
+                f"{gap} licensed endpoints remain without the SentinelOne agent."
+            ]
+            pass_reasons = []
+            recommendations = [
+                f"Deploy the SentinelOne agent to the remaining {gap} endpoints to reach full license coverage."
+            ]
+
+    return create_response(
+        result={
+            "requiredCoveragePercentage": coverage,
+            "activeAgents": total_active_agents,
+            "totalLicenses": (-1 if is_unlimited else total_licenses),
+            "unlimitedLicense": is_unlimited,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "accountCount": account_count,
+            "activeAgents": total_active_agents,
+            "totalLicenses": (-1 if is_unlimited else total_licenses),
+            "unlimitedLicense": is_unlimited,
+        },
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/schemas/__init__.py
+++ b/safeguards/epp/sentinelone/schemas/__init__.py
@@ -1,0 +1,9 @@
+"""Schema registry for this vendor's transformations."""
+
+from .confirmedLicensePurchased import ConfirmedLicensePurchasedInput
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
+__all__ = [
+    "ConfirmedLicensePurchasedInput",
+    "RequiredCoveragePercentageInput",
+]

--- a/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
@@ -1,0 +1,18 @@
+
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class ConfirmedLicensePurchasedInput(BaseModel):
+    """Input schema for the confirmedLicensePurchased transformation.
+
+    Expects the raw getAccounts API response with a top-level 'data' list
+    of account objects, each containing accountType, state, totalLicenses,
+    unlimitedComplete/Control/Core, skus, and licenses.bundles fields.
+    """
+
+    data: Optional[List[Dict[str, Any]]] = None
+    pagination: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,51 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class SkuItem(BaseModel):
+    agentsInSku: Optional[int] = None
+    totalLicenses: Optional[int] = None
+    type: Optional[str] = None
+    unlimited: Optional[bool] = None
+
+    class Config:
+        extra = "allow"
+
+
+class AccountItem(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    accountType: Optional[str] = None
+    activeAgents: Optional[int] = None
+    totalLicenses: Optional[int] = None
+    unlimitedComplete: Optional[bool] = None
+    unlimitedControl: Optional[bool] = None
+    unlimitedCore: Optional[bool] = None
+    billingMode: Optional[str] = None
+    state: Optional[str] = None
+    skus: Optional[List[SkuItem]] = None
+    licenses: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"
+
+
+class PaginationInfo(BaseModel):
+    nextCursor: Optional[str] = None
+    totalItems: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation.
+
+    Expects the getAccounts API response containing account records with
+    activeAgents counts and license information (totalLicenses, unlimited flags, skus).
+    """
+    data: Optional[List[AccountItem]] = None
+    pagination: Optional[PaginationInfo] = None
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Integration Onboarding — SentinelOne (Endpoint Security)

Auto-generated **transformation modules** for **SentinelOne** (Endpoint Security), produced by the V2 onboarding pipeline.

### Run summary

| Metric | Value |
| --- | --- |
| Shipped | 2 / 6 criteria |
| Dropped at live validation | 3 |
| Unroutable (no API surface) | 1 |
| Duration | 6m 46s |

### Authentication

| Field | Value |
| --- | --- |
| Scheme | apiKey |
| Header | Authorization |
| Prefix | `ApiToken` |
| Token setting key | `apiToken` |

### Methods catalogue

| Method | Endpoint | Serves criteria |
| --- | --- | --- |
| `getAgents` | `GET` {$baseURL}/web/api/v2.1/agents | `isEPPEnabled`, `isEPPConfigured`, `isEPPLoggingEnabled`, `requiredCoveragePercentage`, `confirmedLicensePurchased` |
| `getAccounts` | `GET` {$baseURL}/web/api/v2.1/accounts | `confirmedLicensePurchased`, `requiredCoveragePercentage` |
| `getSites` | `GET` {$baseURL}/web/api/v2.1/sites | `confirmedLicensePurchased`, `requiredCoveragePercentage` |

### Per-criterion outcome

| Criterion | Method | Live val | Outcome |
| --- | --- | --- | --- |
| `confirmedLicensePurchased` | `getAccounts` | passed (HTTP 200) | shipped |
| `isEPPConfigured` | `getAgents` | RunOutcome.FAILED_HTTP | dropped at live val |
| `isEPPEnabled` | `getAgents` | RunOutcome.FAILED_HTTP | dropped at live val |
| `isEPPLoggingEnabled` | `getAgents` | RunOutcome.FAILED_HTTP | dropped at live val |
| `requiredCoveragePercentage` | `getAccounts` | passed (HTTP 200) | shipped |
| `isSSOEnabled` | — | — | unroutable |

### Unroutable criteria

**`isSSOEnabled`**

> No public SentinelOne REST API v2.1 endpoint exposes the SSO enabled or enforced state for an account. SSO (SAML) is configured exclusively via the management console UI under Settings > SSO. The v2.1 API does contain SSO-related authentication flows (Auth by SSO, Redirect to SSO, auth-by-token) but these are login operations, not configuration-read endpoints. The user object's 'source' field (local/sso/scim) on GET /web/api/v2.1/users reflects how individual users authenticate but cannot confirm SSO enforcement policy at the account level. Investigated endpoints: GET /web/api/v2.1/system/info (no SSO field documented), GET /web/api/v2.1/users (source field only — not an enforcement signal), SSO config only surfaced in console UI / SCIM provisioning flow, not a REST-readable object.

### Audit

**Receipt ID:** `583199aa-3f37-487e-9725-2c45af726bc7`  
**Phase-1 web searches:** 6  
**Tokens (in/out):** 71,631 / 50,857

---
*Auto-generated by Token Service V2 onboarding pipeline.*