### PR TITLE
feat: add SentinelOne transformations (epp)

### DIFF
--- a/safeguards/epp/sentinelone/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/confirmedLicensePurchased.py
@@ -1,0 +1,177 @@
+"""Transformation: confirmedLicensePurchased — SentinelOne getAccounts"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+    total_accounts = len(accounts)
+
+    if total_accounts == 0:
+        return create_response(
+            result={
+                "confirmedLicensePurchased": False,
+                "totalAccounts": 0,
+                "activeAccountsWithLicense": 0,
+            },
+            validation=validation,
+            pass_reasons=[],
+            fail_reasons=["No accounts returned by the API — unable to confirm a purchased license."],
+            recommendations=["Verify that the API token has permission to read account data and that at least one account exists."],
+            input_summary={"totalAccounts": 0},
+            metadata={
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            },
+        )
+
+    active_accounts_with_license = []
+    findings = []
+
+    for account in accounts:
+        account_name = account.get("name") or account.get("id") or "unknown"
+        state = account.get("state") or ""
+        account_type = account.get("accountType") or ""
+        billing_mode = account.get("billingMode") or ""
+        total_licenses = account.get("totalLicenses")
+        unlimited_expiration = account.get("unlimitedExpiration") or False
+        expiration = account.get("expiration")
+
+        licenses = account.get("licenses") or {}
+        bundles = licenses.get("bundles") or []
+        skus = account.get("skus") or []
+
+        # Determine if any sku or bundle has a valid license
+        has_unlimited_sku = any(s.get("unlimited") is True for s in skus)
+        has_unlimited_licenses = (total_licenses is not None and total_licenses == -1)
+        has_paid_bundles = len(bundles) > 0
+        has_positive_licenses = (total_licenses is not None and total_licenses > 0)
+
+        license_valid = has_unlimited_sku or has_unlimited_licenses or has_positive_licenses or has_paid_bundles
+        account_active = (state.lower() == "active")
+
+        bundle_names = [b.get("displayName") or b.get("name") or "" for b in bundles]
+        sku_types = [s.get("type") or "" for s in skus]
+
+        finding = (
+            f"Account '{account_name}': state={state}, accountType={account_type}, "
+            f"billingMode={billing_mode}, totalLicenses={total_licenses}, "
+            f"bundles={bundle_names}, skus={sku_types}, "
+            f"unlimitedExpiration={unlimited_expiration}"
+        )
+        findings.append(finding)
+
+        if account_active and license_valid:
+            active_accounts_with_license.append(account_name)
+
+    confirmed = len(active_accounts_with_license) > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if confirmed:
+        pass_reasons.append(
+            f"{len(active_accounts_with_license)} of {total_accounts} account(s) "
+            f"confirmed with an active, purchased license: {active_accounts_with_license}."
+        )
+    else:
+        fail_reasons.append(
+            f"None of the {total_accounts} account(s) returned have both state='active' "
+            f"and a valid license bundle or SKU."
+        )
+        recommendations.append(
+            "Ensure the SentinelOne account is in 'active' state with at least one "
+            "purchased license bundle (e.g., 'Endpoint Security - Complete') or unlimited SKU."
+        )
+
+    return create_response(
+        result={
+            "confirmedLicensePurchased": confirmed,
+            "totalAccounts": total_accounts,
+            "activeAccountsWithLicense": len(active_accounts_with_license),
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAccounts": total_accounts,
+            "activeAccountsWithLicense": len(active_accounts_with_license),
+        },
+        additional_findings=findings,
+        metadata={
+            "transformationId": "confirmedLicensePurchased",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/isEPPConfigured.py
+++ b/safeguards/epp/sentinelone/isEPPConfigured.py
@@ -1,0 +1,198 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    items = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    total_agents = total_items
+    sample_count = len(items)
+
+    # If no agents enrolled at all, EPP is not configured
+    if total_agents == 0 and sample_count == 0:
+        return create_response(
+            result={
+                "isEPPConfigured": False,
+                "totalAgents": 0,
+                "sampleAgentsChecked": 0,
+                "agentsInProtectMode": 0,
+                "agentsInDetectMode": 0,
+                "agentsInNoneMode": 0,
+            },
+            validation=validation,
+            pass_reasons=[],
+            fail_reasons=["No enrolled agents found (totalItems=0). EPP is not configured."],
+            recommendations=["Deploy the SentinelOne agent to endpoints and set mitigationMode to 'protect' or 'detect'."],
+            input_summary={"totalAgents": 0, "sampleAgentsChecked": 0},
+            metadata={
+                "transformationId": "isEPPConfigured",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            },
+        )
+
+    # Analyse the sample page for mitigationMode, userActionsNeeded, and scanStatus
+    protect_count = 0
+    detect_count = 0
+    none_count = 0
+    needs_action_count = 0
+    scan_failed_count = 0
+
+    for agent in items:
+        mode = agent.get("mitigationMode") or ""
+        if mode == "protect":
+            protect_count = protect_count + 1
+        elif mode == "detect":
+            detect_count = detect_count + 1
+        elif mode == "none":
+            none_count = none_count + 1
+
+        actions_needed = agent.get("userActionsNeeded") or []
+        if actions_needed:
+            needs_action_count = needs_action_count + 1
+
+        scan_status = agent.get("scanStatus") or ""
+        if scan_status == "failed":
+            scan_failed_count = scan_failed_count + 1
+
+    configured_count = protect_count + detect_count
+
+    has_agents = total_agents > 0
+    no_scan_failures = scan_failed_count == 0
+
+    # If mode info is present in the sample, require at least some agents in protect/detect and none in 'none' mode
+    mode_data_present = (protect_count + detect_count + none_count) > 0
+    if mode_data_present:
+        mode_ok = configured_count > 0 and none_count == 0
+    else:
+        # No mode data surfaced in truncated sample — rely on agent existence and scan health
+        mode_ok = True
+
+    is_configured = has_agents and no_scan_failures and mode_ok
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+    additional_findings = []
+
+    if is_configured:
+        reason = f"{total_agents} agents enrolled in SentinelOne"
+        if mode_data_present:
+            reason = reason + f"; sampled {sample_count} agents: {protect_count} in 'protect' mode, {detect_count} in 'detect' mode, {none_count} in 'none' mode"
+        else:
+            reason = reason + f"; sampled {sample_count} agents all reporting healthy scan status (mitigationMode field not present in this page sample)"
+        pass_reasons.append(reason)
+        if needs_action_count > 0:
+            additional_findings.append(f"{needs_action_count} of {sample_count} sampled agents have non-empty userActionsNeeded — review those endpoints in the SentinelOne console.")
+    else:
+        if not has_agents:
+            fail_reasons.append("No enrolled agents found. EPP is not configured.")
+            recommendations.append("Deploy the SentinelOne agent to endpoints.")
+        if not no_scan_failures:
+            fail_reasons.append(f"{scan_failed_count} of {sample_count} sampled agents report scanStatus='failed', indicating EPP health check failures.")
+            recommendations.append("Investigate agents with failed scan status in the SentinelOne console and resolve any blocking issues.")
+        if mode_data_present and not mode_ok:
+            if none_count > 0:
+                fail_reasons.append(f"{none_count} of {sample_count} sampled agents have mitigationMode='none', indicating EPP protection is disabled on those agents.")
+                recommendations.append("Set mitigationMode to 'protect' or 'detect' on all agents via the SentinelOne policy settings.")
+            if configured_count == 0:
+                fail_reasons.append("No sampled agents are in 'protect' or 'detect' mode — EPP is not actively configured.")
+
+    return create_response(
+        result={
+            "isEPPConfigured": is_configured,
+            "totalAgents": total_agents,
+            "sampleAgentsChecked": sample_count,
+            "agentsInProtectMode": protect_count,
+            "agentsInDetectMode": detect_count,
+            "agentsInNoneMode": none_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        additional_findings=additional_findings,
+        input_summary={
+            "totalAgents": total_agents,
+            "sampleAgentsChecked": sample_count,
+            "agentsInProtectMode": protect_count,
+            "agentsInDetectMode": detect_count,
+            "agentsInNoneMode": none_count,
+        },
+        metadata={
+            "transformationId": "isEPPConfigured",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/isEPPEnabled.py
+++ b/safeguards/epp/sentinelone/isEPPEnabled.py
@@ -1,0 +1,118 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems")
+
+    # Fall back to counting items in the data list if pagination is absent
+    items = data.get("data") or []
+    if total_items is None:
+        total_items = len(items)
+
+    total_items = int(total_items) if total_items is not None else 0
+    is_epp_enabled = total_items > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_epp_enabled:
+        pass_reasons.append(
+            f"SentinelOne EPP agents are deployed on endpoints: pagination.totalItems reports {total_items} enrolled agents across the fleet."
+        )
+    else:
+        fail_reasons.append(
+            "No SentinelOne EPP agents were found: pagination.totalItems returned 0, indicating no agents are enrolled on endpoints."
+        )
+        recommendations.append(
+            "Deploy SentinelOne agents on endpoints to enable EPP protection. Install agents via the SentinelOne management console under Sentinels > Endpoints."
+        )
+
+    return create_response(
+        result={
+            "isEPPEnabled": is_epp_enabled,
+            "totalAgents": total_items,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAgents": total_items,
+        },
+        metadata={
+            "transformationId": "isEPPEnabled",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/isEPPLoggingEnabled.py
+++ b/safeguards/epp/sentinelone/isEPPLoggingEnabled.py
@@ -1,0 +1,158 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    agents = data.get("data") or []
+    pagination = data.get("pagination") or {}
+    total_items = pagination.get("totalItems") or 0
+
+    total_agents = len(agents)
+    agents_with_edr = 0
+    agents_without_edr = 0
+    sample_without_edr = []
+
+    for agent in agents:
+        active_protection = agent.get("activeProtection") or []
+        if "edr" in active_protection:
+            agents_with_edr = agents_with_edr + 1
+        else:
+            agents_without_edr = agents_without_edr + 1
+            computer_name = agent.get("computerName") or agent.get("id") or "unknown"
+            if len(sample_without_edr) < 5:
+                sample_without_edr.append(computer_name)
+
+    logging_enabled = agents_with_edr > 0 and agents_without_edr == 0
+
+    if total_agents == 0:
+        return create_response(
+            result={
+                "isEPPLoggingEnabled": False,
+                "totalAgents": 0,
+                "agentsWithEDRLogging": 0,
+                "agentsWithoutEDRLogging": 0,
+            },
+            validation=validation,
+            pass_reasons=[],
+            fail_reasons=["No agent records were returned; cannot confirm EDR logging is enabled."],
+            recommendations=["Ensure SentinelOne agents are enrolled and the API token has permission to list agents."],
+            input_summary={"totalAgents": 0, "totalItemsInFleet": total_items},
+            metadata={
+                "transformationId": "isEPPLoggingEnabled",
+                "vendor": "SentinelOne",
+                "category": "epp",
+            },
+        )
+
+    if logging_enabled:
+        pass_reasons = [
+            f"All {agents_with_edr} of {total_agents} sampled agents (fleet total: {total_items}) "
+            f"have 'edr' present in their activeProtection array, confirming EDR telemetry/logging is active."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"{agents_without_edr} of {total_agents} sampled agents are missing 'edr' in their "
+            f"activeProtection array, indicating EDR logging is not fully active across the fleet."
+        ]
+        if sample_without_edr:
+            sample_str = ", ".join(sample_without_edr)
+            fail_reasons.append(f"Sample agents without EDR logging: {sample_str}")
+        recommendations = [
+            "Review and update the SentinelOne policy for affected agents to enable EDR telemetry "
+            "(ensure the agent policy has 'Deep Visibility' or EDR logging activated)."
+        ]
+
+    return create_response(
+        result={
+            "isEPPLoggingEnabled": logging_enabled,
+            "totalAgents": total_agents,
+            "agentsWithEDRLogging": agents_with_edr,
+            "agentsWithoutEDRLogging": agents_without_edr,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalAgentsSampled": total_agents,
+            "totalItemsInFleet": total_items,
+            "agentsWithEDR": agents_with_edr,
+            "agentsWithoutEDR": agents_without_edr,
+        },
+        metadata={
+            "transformationId": "isEPPLoggingEnabled",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/requiredCoveragePercentage.py
@@ -1,0 +1,156 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+
+    # countAgents returns {"data": {"total": N, "decommissioned": N, "online": N, ...}}
+    # extract_input leaves the raw envelope intact (does not unwrap "data")
+    data = data if isinstance(data, dict) else {}
+
+    counts = data.get("data") or {}
+    if not isinstance(counts, dict):
+        counts = {}
+
+    total = counts.get("total") or 0
+    decommissioned = counts.get("decommissioned") or 0
+    online = counts.get("online") or 0
+
+    # Active (non-decommissioned) agents have Endpoint Security installed
+    active_agents = max(0, total - decommissioned)
+
+    if total <= 0:
+        coverage_pct = 0.0
+        pass_reasons = []
+        fail_reasons = [
+            "No agents found in SentinelOne (data.total=0). "
+            "Coverage percentage cannot be computed."
+        ]
+        recommendations = [
+            "Enroll endpoints into SentinelOne to establish Endpoint Security coverage."
+        ]
+    else:
+        coverage_pct = round((active_agents / float(total)) * 100.0, 2)
+        if decommissioned == 0:
+            pass_reasons = [
+                f"All {total} enrolled agents are active (none decommissioned), "
+                f"yielding {coverage_pct}% Endpoint Security coverage. "
+                f"{online} of those agents are currently online."
+            ]
+            fail_reasons = []
+            recommendations = []
+        elif coverage_pct >= 90.0:
+            pass_reasons = [
+                f"{active_agents} of {total} enrolled agents are active "
+                f"(data.total={total}, data.decommissioned={decommissioned}), "
+                f"yielding {coverage_pct}% Endpoint Security coverage."
+            ]
+            fail_reasons = []
+            recommendations = [
+                f"Review the {decommissioned} decommissioned agent record(s) and remove "
+                "stale entries to keep coverage metrics accurate."
+            ]
+        else:
+            pass_reasons = []
+            fail_reasons = [
+                f"Only {active_agents} of {total} enrolled agents are active "
+                f"(data.total={total}, data.decommissioned={decommissioned}), "
+                f"yielding {coverage_pct}% Endpoint Security coverage. "
+                f"{decommissioned} agents are decommissioned and no longer protected."
+            ]
+            recommendations = [
+                f"Investigate the {decommissioned} decommissioned agent(s): re-enroll "
+                "active endpoints that lost coverage, or remove stale records.",
+                "Ensure all managed endpoints have the SentinelOne agent installed and active."
+            ]
+
+    return create_response(
+        result={
+            "requiredCoveragePercentage": coverage_pct,
+            "totalAgents": total,
+            "activeAgents": active_agents,
+            "decommissionedAgents": decommissioned,
+            "onlineAgents": online,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "total": total,
+            "activeAgents": active_agents,
+            "decommissioned": decommissioned,
+            "online": online,
+        },
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "SentinelOne",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/sentinelone/schemas/__init__.py
+++ b/safeguards/epp/sentinelone/schemas/__init__.py
@@ -1,0 +1,15 @@
+"""Schema registry for this vendor's transformations."""
+
+from .confirmedLicensePurchased import ConfirmedLicensePurchasedInput
+from .isEPPConfigured import IsEPPConfiguredInput
+from .isEPPEnabled import IsEPPEnabledInput
+from .isEPPLoggingEnabled import IsEPPLoggingEnabledInput
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
+__all__ = [
+    "ConfirmedLicensePurchasedInput",
+    "IsEPPConfiguredInput",
+    "IsEPPEnabledInput",
+    "IsEPPLoggingEnabledInput",
+    "RequiredCoveragePercentageInput",
+]

--- a/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
+++ b/safeguards/epp/sentinelone/schemas/confirmedLicensePurchased.py
@@ -1,0 +1,87 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class LicenseSurface(BaseModel):
+    count: Optional[int] = None
+    name: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class LicenseBundle(BaseModel):
+    displayName: Optional[str] = None
+    majorVersion: Optional[int] = None
+    minorVersion: Optional[int] = None
+    name: Optional[str] = None
+    surfaces: Optional[List[LicenseSurface]] = None
+    totalSurfaces: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class LicenseModule(BaseModel):
+    displayName: Optional[str] = None
+    majorVersion: Optional[int] = None
+    name: Optional[str] = None
+
+    class Config:
+        extra = "allow"
+
+
+class Licenses(BaseModel):
+    bundles: Optional[List[LicenseBundle]] = None
+    modules: Optional[List[LicenseModule]] = None
+    settings: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        extra = "allow"
+
+
+class SkuEntry(BaseModel):
+    agentsInSku: Optional[int] = None
+    totalLicenses: Optional[int] = None
+    type: Optional[str] = None
+    unlimited: Optional[bool] = None
+
+    class Config:
+        extra = "allow"
+
+
+class AccountItem(BaseModel):
+    id: Optional[str] = None
+    name: Optional[str] = None
+    accountType: Optional[str] = None
+    activeAgents: Optional[int] = None
+    billingMode: Optional[str] = None
+    licenses: Optional[Licenses] = None
+    skus: Optional[List[SkuEntry]] = None
+    expiration: Optional[str] = None
+    state: Optional[str] = None
+    totalLicenses: Optional[int] = None
+    unlimitedComplete: Optional[bool] = None
+    unlimitedControl: Optional[bool] = None
+    unlimitedCore: Optional[bool] = None
+    unlimitedExpiration: Optional[bool] = None
+
+    class Config:
+        extra = "allow"
+
+
+class Pagination(BaseModel):
+    nextCursor: Optional[str] = None
+    totalItems: Optional[int] = None
+
+    class Config:
+        extra = "allow"
+
+
+class ConfirmedLicensePurchasedInput(BaseModel):
+    """Input schema for the confirmedLicensePurchased transformation."""
+    data: Optional[List[AccountItem]] = None
+    pagination: Optional[Pagination] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPConfigured.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPConfigured.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPConfiguredInput(BaseModel):
+    """Input schema for the isEPPConfigured transformation.
+
+    Expects a SentinelOne getAgents response envelope with:
+      - data: list of agent records (each may contain mitigationMode, scanStatus, userActionsNeeded)
+      - pagination: object with totalItems integer
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPEnabled.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPEnabled.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPEnabledInput(BaseModel):
+    """Input schema for the isEPPEnabled transformation.
+
+    Expects the raw SentinelOne GET /web/api/v2.1/agents response shape,
+    with a top-level 'data' list of agent records and a 'pagination' object
+    containing 'totalItems' (fleet-wide enrolled agent count).
+    """
+
+    data: Optional[List[Dict[str, Any]]] = None
+    pagination: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/isEPPLoggingEnabled.py
+++ b/safeguards/epp/sentinelone/schemas/isEPPLoggingEnabled.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEPPLoggingEnabledInput(BaseModel):
+    """Input schema for the isEPPLoggingEnabled transformation.
+
+    Expects the SentinelOne getAgents response shape:
+      - data: list of agent records, each with an activeProtection array
+      - pagination: object with totalItems (fleet size) and optional nextCursor
+    """
+
+    data: Optional[List[Dict[str, Any]]] = None
+    pagination: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation.
+
+    Represents the response shape from SentinelOne GET /web/api/v2.1/agents/count.
+    The 'data' object contains aggregate agent count scalars.
+    """
+
+    class CountData(BaseModel):
+        total: Optional[int] = None
+        upToDate: Optional[int] = None
+        outOfDate: Optional[int] = None
+        online: Optional[int] = None
+        infected: Optional[int] = None
+        decommissioned: Optional[int] = None
+
+        class Config:
+            extra = "allow"
+
+    data: Optional[CountData] = None
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary

This PR delivers 5 transformation scripts for the new SentinelOne Endpoint Protection Platform (EPP) integration, enabling automated evaluation of license purchases, EPP deployment configuration, agent enablement, EDR logging activation, and endpoint coverage percentage. These scripts assess SentinelOne tenant security posture across the epp safeguard category and validate EPP operational readiness.

**Context:** SentinelOne is being onboarded as a new EPP vendor integration as part of the integration onboarding pipeline. All 5 scripts passed live validation (HTTP 200) against a customer SentinelOne tenant during phase-1.

## What each transformation does

### `confirmedLicensePurchased.py`
Validates that a SentinelOne account has an active, purchased EPP license bundle (Endpoint Security or equivalent) by inspecting account state and license entitlements.

- **Consumes:** SentinelOne Admin API GET /web/api/v2.1/accounts
- **Pass criteria:** At least one account exists with state='active' AND at least one of: (bundles array with length > 0) OR (totalLicenses > 0) OR (unlimited SKU with unlimited=true)
- **Key edge cases handled:**
  - Empty accounts list (no accounts returned) — fails with recommendation to verify API token permissions
  - Multiple accounts — passes if ANY active account has a valid license; flags all active accounts with licenses in pass_reasons
  - Zero totalLicenses with empty bundles and no unlimited SKUs — correctly classified as no valid license
  - Expired accounts (state != 'active') — excluded from confirmation even if bundles present

### `isEPPConfigured.py`
Evaluates whether EPP is actively configured on enrolled agents by checking mitigation mode, scan health, and user action requirements across a sampled page of agents.

- **Consumes:** SentinelOne Admin API GET /web/api/v2.1/agents (paginated, limit=1000)
- **Pass criteria:** (totalItems > 0) AND (protect_count + detect_count > 0) AND (none_count == 0) AND (scan_failed_count == 0), OR if mode data absent in sample, (totalItems > 0) AND (scan_failed_count == 0)
- **Key edge cases handled:**
  - No enrolled agents (totalItems=0) — fails with recommendation to deploy agents
  - Agents in 'none' mode — fails per-agent if none_count > 0; recommendation to set mitigationMode to 'protect' or 'detect'
  - Scan failures (scanStatus='failed') — fails if any detected; recommendation to investigate via console
  - Missing mitigationMode in paginated sample (truncated response) — falls back to scan health check; passes if sample reports healthy scans
  - userActionsNeeded array present on agents — passes overall but raises additional_finding to alert reviewer

### `isEPPEnabled.py`
Confirms that SentinelOne EPP agents are enrolled and active on endpoints by verifying pagination.totalItems > 0.

- **Consumes:** SentinelOne Admin API GET /web/api/v2.1/agents (paginated, limit=1000)
- **Pass criteria:** pagination.totalItems > 0 (falls back to len(data) if totalItems missing)
- **Key edge cases handled:**
  - Empty data array AND totalItems=0 or absent — fails with clear directive to deploy agents
  - Fallback logic for legacy or partial pagination responses — uses len(items) if totalItems not in response
  - Returns both totalItems and computed count in result for transparency

### `isEPPLoggingEnabled.py`
Verifies that EDR telemetry/logging is active on all enrolled agents by checking for 'edr' in the activeProtection array per agent.

- **Consumes:** SentinelOne Admin API GET /web/api/v2.1/agents (paginated, limit=1000)
- **Pass criteria:** (agents_with_edr > 0) AND (agents_without_edr == 0) — all sampled agents MUST have 'edr' in activeProtection
- **Key edge cases handled:**
  - No agent records returned — fails with recommendation to verify enrollment and API token scope
  - Partial EDR adoption — fails if any sampled agent lacks 'edr'; includes sample of up to 5 agent names without logging
  - agents_without_edr > 0 — flags as fail and provides actionable recommendation (enable Deep Visibility in agent policy)
  - Distinguishes between fleet total (pagination.totalItems) and sampled page — documents both in result and input_summary

### `requiredCoveragePercentage.py`
Computes Endpoint Security coverage percentage as (active_agents / total_agents) * 100 by extracting aggregate counts from the countAgents endpoint.

- **Consumes:** SentinelOne Admin API GET /web/api/v2.1/agents/count
- **Pass criteria:** coverage_pct > 0.0 (computed); response evaluated as: 100% coverage if decommissioned=0; >= 90% coverage if any decommissioned; < 90% fails with recommendation to re-enroll or remove stale records
- **Key edge cases handled:**
  - total=0 (no agents enrolled) — coverage_pct = 0.0, fails with enrollment recommendation
  - Decommissioned agents counted separately — active_agents = max(0, total - decommissioned) prevents negative counts
  - Missing or null counts — defaults to 0 per field before calculation; guards against division by zero
  - online vs active distinction — both returned in result; online agents tracked separately for fleet health context
  - Tiered pass/fail logic: 100% (no decommissioned) passes with zero recommendations; 90-99% passes with cleanup recommendation; < 90% fails with re-enrollment directive

## Architecture notes

All five scripts follow the standardized Spektrum transformation contract: `extract_input()` unwraps nested envelope (handles both enriched {data, validation} and legacy wrapper formats), `evaluate()` logic returns early with clear pass/fail branches, `transform()` orchestrates the flow and calls `create_response()` to build the standardized response schema (version 2.0). Response structure includes five sections: transformedResponse (boolean result + supporting counts), dataCollection status (API error tracking), validation metadata, transformation execution status, and evaluation details (passReasons, failReasons, recommendations, additionalFindings). All scripts handle missing fields gracefully via .get() with falsy defaults and do not raise exceptions on unexpected response shapes.

## Test plan

- [x] Each script passes PyCodeExecutor sandbox validation (no external imports, RestrictedPython compliant)
- [x] All five transformations passed live HTTP 200 validation against customer SentinelOne tenant during phase-1
- [x] **confirmedLicensePurchased**: Verified against getAccounts response with multiple accounts, bundles array, and state field
- [x] **isEPPConfigured**: Verified against paginated getAgents response with mitigationMode ('protect', 'detect', 'none'), scanStatus ('succeeded', 'failed'), and userActionsNeeded array
- [x] **isEPPEnabled**: Verified against getAgents pagination.totalItems count; confirmed fallback to len(data) logic
- [x] **isEPPLoggingEnabled**: Verified against agent records with activeProtection array containing 'edr'; confirmed failure path when 'edr' absent
- [x] **requiredCoveragePercentage**: Verified against countAgents response structure {data: {total, decommissioned, online, upToDate}}; confirmed rounding to 2 decimals and tiered logic
- [x] Confirm all field names (licenses.bundles, mitigationMode, activeProtection, pagination.totalItems, scanStatus, userActionsNeeded, computerName) match SentinelOne v2.1 API schema per official documentation
- [x] Spot-check create_response() output schema matches v2.0: transformedResponse with result object, additionalInfo with dataCollection/validation/transformation/evaluation sections, metadata with evaluatedAt and schemaVersion

---

Generated by Spektrum integration onboarding pipeline
