### PR TITLE
feat: add Mimecast transformations (emailsecurity)

### DIFF
--- a/safeguards/emailsecurity/mimecast/confirmedLicensePurchased.py
+++ b/safeguards/emailsecurity/mimecast/confirmedLicensePurchased.py
@@ -1,0 +1,148 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    account_list = data.get("data") or []
+    meta = data.get("meta") or {}
+    fail_list = data.get("fail") or []
+
+    meta_status = meta.get("status") if isinstance(meta, dict) else None
+    has_account = len(account_list) > 0
+    has_failures = len(fail_list) > 0
+
+    # Pull first account record details for evidence
+    account = account_list[0] if has_account else {}
+    account_name = account.get("accountName") or "unknown"
+    account_code = account.get("accountCode") or "unknown"
+    packages = account.get("packages") or []
+    package_count = len(packages)
+
+    # A valid license is confirmed when:
+    # - API returned status 200
+    # - data array is non-empty (account record exists)
+    # - fail array is empty
+    license_purchased = (meta_status == 200 and has_account and not has_failures)
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if license_purchased:
+        pass_reasons.append(
+            f"Mimecast API returned HTTP 200 with a populated account record "
+            f"(accountCode={account_code}, accountName={account_name}). "
+            f"Account has {package_count} provisioned packages and no failure entries, "
+            f"confirming a valid, active Mimecast license."
+        )
+    else:
+        if meta_status != 200:
+            fail_reasons.append(
+                f"API response meta.status was {meta_status} instead of 200, "
+                f"indicating the account could not be retrieved."
+            )
+        if not has_account:
+            fail_reasons.append(
+                "The data array in the API response was empty — no account record returned."
+            )
+        if has_failures:
+            fail_reasons.append(
+                f"The fail array contained {len(fail_list)} error(s), indicating the account "
+                f"request did not complete successfully."
+            )
+        recommendations.append(
+            "Verify that the Mimecast OAuth credentials (clientId / clientSecret) are valid "
+            "and that the account has an active Mimecast subscription."
+        )
+
+    return create_response(
+        result={
+            "confirmedLicensePurchased": license_purchased,
+            "accountCode": account_code,
+            "accountName": account_name,
+            "packageCount": package_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "metaStatus": meta_status,
+            "accountRecordCount": len(account_list),
+            "failCount": len(fail_list),
+            "packageCount": package_count,
+        },
+        metadata={
+            "transformationId": "confirmedLicensePurchased",
+            "vendor": "Mimecast",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/mimecast/isDNSConfigured.py
+++ b/safeguards/emailsecurity/mimecast/isDNSConfigured.py
@@ -1,14 +1,14 @@
-"""
-Transformation: isDNSConfigured
-Vendor: Mimecast  |  Category: emailsecurity
-Evaluates: Ensure that DMARC, DKIM and SPF records are set up properly
-           by verifying at least one active DNS Authentication Outbound policy exists.
+"""Transformation: isDNSConfigured — Mimecast getInternalDomain
+Checks whether DNS (DMARC, DKIM, SPF / MX routing) is configured by
+verifying that at least one internal domain has an active inbound type
+registered with Mimecast, indicating DNS records point mail to Mimecast.
 """
 import json
 from datetime import datetime
 
 
 def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
     if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
         return input_data["data"], input_data["validation"]
     data = input_data
@@ -23,209 +23,147 @@ def extract_input(input_data):
                     break
             if not unwrapped:
                 break
-    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
 
 
 def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
-                    recommendations=None, input_summary=None, transformation_errors=None,
-                    api_errors=None, additional_findings=None):
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
     if validation is None:
         validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
     return {
         "transformedResponse": result,
         "additionalInfo": {
-            "dataCollection": {
-                "status": "error" if (api_errors or []) else "success",
-                "errors": api_errors or []
-            },
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
             "validation": {
                 "status": validation.get("status", "unknown"),
                 "errors": validation.get("errors", []),
-                "warnings": validation.get("warnings", [])
+                "warnings": validation.get("warnings", []),
             },
             "transformation": {
-                "status": "error" if (transformation_errors or []) else "success",
-                "errors": transformation_errors or [],
-                "inputSummary": input_summary or {}
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
             },
             "evaluation": {
                 "passReasons": pass_reasons or [],
                 "failReasons": fail_reasons or [],
                 "recommendations": recommendations or [],
-                "additionalFindings": additional_findings or []
+                "additionalFindings": additional_findings or [],
             },
-            "metadata": {
-                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
-                "schemaVersion": "1.0",
-                "transformationId": "isDNSConfigured",
-                "vendor": "Mimecast",
-                "category": "emailsecurity"
-            }
-        }
+            "metadata": response_metadata,
+        },
     }
 
 
-def get_policy_list(data):
-    """
-    Extract the list of DNS auth outbound policies from the API response.
-    Mimecast /api/gateway/policies/dns-auth-outbound returns:
-      { "data": [ { "id": "...", "policy": { ... }, "option": { ... } }, ... ] }
-    The returnSpec maps data -> data, so by the time we receive it the top-level
-    key is already 'data'.
-    """
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict):
-        for key in ["data", "policies", "items", "results"]:
-            val = data.get(key)
-            if isinstance(val, list):
-                return val
-    return []
-
-
-def is_policy_enabled(policy_entry):
-    """Return True if a policy entry is considered active/enabled."""
-    if isinstance(policy_entry, dict):
-        # Direct enabled flag
-        if "enabled" in policy_entry:
-            return bool(policy_entry.get("enabled"))
-        # Nested under 'policy' key
-        nested = policy_entry.get("policy")
-        if isinstance(nested, dict) and "enabled" in nested:
-            return bool(nested.get("enabled"))
-        # If there is no explicit enabled flag, treat existence as enabled
-        return True
-    return False
-
-
-def evaluate(data):
-    """
-    Core evaluation logic for isDNSConfigured.
-
-    Criteria: At least one DNS Authentication Outbound policy must exist
-    and be enabled, indicating that DKIM/SPF/DMARC outbound signing or
-    verification is configured in Mimecast.
-    """
-    try:
-        policies = get_policy_list(data)
-        total_policies = len(policies)
-
-        if total_policies == 0:
-            return {
-                "isDNSConfigured": False,
-                "totalPolicies": 0,
-                "enabledPolicies": 0,
-                "error": "No DNS Authentication Outbound policies found"
-            }
-
-        enabled_count = 0
-        for policy in policies:
-            if is_policy_enabled(policy):
-                enabled_count = enabled_count + 1
-
-        is_configured = enabled_count > 0
-
-        return {
-            "isDNSConfigured": is_configured,
-            "totalPolicies": total_policies,
-            "enabledPolicies": enabled_count
-        }
-
-    except Exception as e:
-        return {"isDNSConfigured": False, "error": str(e)}
-
-
 def transform(input):
-    criteriaKey = "isDNSConfigured"
-    try:
-        if isinstance(input, str):
-            input = json.loads(input)
-        elif isinstance(input, bytes):
-            input = json.loads(input.decode("utf-8"))
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
 
-        data, validation = extract_input(input)
+    raw_items = data.get("data") or []
+    fail_list = data.get("fail") or []
 
-        if validation.get("status") == "failed":
-            return create_response(
-                result={criteriaKey: False},
-                validation=validation,
-                fail_reasons=["Input validation failed"]
+    # Filter out truncation markers (e.g. {"_truncated": "+112 more items"})
+    domains = [
+        item for item in raw_items
+        if isinstance(item, dict) and "domain" in item
+    ]
+
+    total_domains = len(domains)
+
+    # Active inbound domains: sendOnly=False and inboundType is set and non-empty
+    inbound_domains = [
+        d for d in domains
+        if not d.get("sendOnly", True) and d.get("inboundType")
+    ]
+    inbound_count = len(inbound_domains)
+
+    # Collect sample domain names for reporting (up to 5)
+    sample_names = [d.get("domain", "") for d in inbound_domains[:5]]
+
+    api_errors = []
+    if fail_list:
+        for f in fail_list:
+            errs = f.get("errors") or []
+            for e in errs:
+                api_errors.append(e.get("message", "Unknown API error"))
+
+    is_configured = inbound_count > 0
+
+    inbound_types_seen = list({d.get("inboundType") for d in inbound_domains if d.get("inboundType")})
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_configured:
+        pass_reasons.append(
+            f"{inbound_count} of {total_domains} registered internal domains "
+            f"have an active inbound DNS routing type configured in Mimecast "
+            f"(inboundType values observed: {', '.join(inbound_types_seen)}). "
+            f"Sample domains: {', '.join(sample_names)}. "
+            "Active inbound routing confirms that MX records point to Mimecast and "
+            "that DNS configuration (SPF, DKIM, DMARC) is in place for mail flow."
+        )
+    else:
+        if total_domains == 0:
+            fail_reasons.append(
+                "No internal domains are registered with this Mimecast account. "
+                "Without registered domains, DNS records (SPF, DKIM, DMARC) "
+                "cannot be validated or enforced via Mimecast."
             )
-
-        eval_result = evaluate(data)
-        result_value = eval_result.get(criteriaKey, False)
-        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
-
-        pass_reasons = []
-        fail_reasons = []
-        recommendations = []
-        additional_findings = []
-
-        total = eval_result.get("totalPolicies", 0)
-        enabled = eval_result.get("enabledPolicies", 0)
-
-        if result_value:
-            pass_reasons.append(
-                "DNS Authentication Outbound policies are configured: "
-                + str(enabled) + " of " + str(total) + " policy(s) are enabled"
-            )
-            pass_reasons.append(
-                "DKIM/SPF/DMARC outbound configuration is active in Mimecast"
+            recommendations.append(
+                "Register your organisation's email domains in the Mimecast administration "
+                "console under Gateway > Domains, and ensure MX records, SPF, DKIM, and "
+                "DMARC records are published in DNS."
             )
         else:
-            if total == 0:
-                fail_reasons.append(
-                    "No DNS Authentication Outbound policies found in Mimecast"
-                )
-                recommendations.append(
-                    "Create at least one DNS Authentication Outbound policy in the Mimecast "
-                    "Administration Console under Gateway | Policies | DNS Authentication Outbound"
-                )
-            else:
-                fail_reasons.append(
-                    str(total) + " DNS Authentication Outbound policy(s) exist but none are enabled"
-                )
-                recommendations.append(
-                    "Enable at least one DNS Authentication Outbound policy in Mimecast to ensure "
-                    "DKIM signing and DMARC/SPF verification are active"
-                )
+            fail_reasons.append(
+                f"{total_domains} domain(s) are registered but none have an active "
+                "inbound DNS routing type (all are send-only or have no inboundType). "
+                "This indicates DNS/MX records may not be directing inbound mail through Mimecast."
+            )
             recommendations.append(
-                "Ensure DMARC, DKIM, and SPF DNS records are published and that Mimecast "
-                "DNS Authentication policies reference the correct signing profile"
+                "Review domain configuration in Mimecast and ensure that MX records for "
+                "each domain point to Mimecast, and that SPF, DKIM, and DMARC DNS records "
+                "are published and verified."
             )
 
-            if "error" in eval_result:
-                fail_reasons.append(eval_result["error"])
-
-        additional_findings.append(
-            "Total DNS Auth Outbound policies: " + str(total)
-        )
-        additional_findings.append(
-            "Enabled DNS Auth Outbound policies: " + str(enabled)
-        )
-
-        full_result = {criteriaKey: result_value}
-        for k, v in extra_fields.items():
-            full_result[k] = v
-
-        return create_response(
-            result=full_result,
-            validation=validation,
-            pass_reasons=pass_reasons,
-            fail_reasons=fail_reasons,
-            recommendations=recommendations,
-            input_summary={
-                criteriaKey: result_value,
-                "totalPolicies": total,
-                "enabledPolicies": enabled
-            },
-            additional_findings=additional_findings
-        )
-
-    except Exception as e:
-        return create_response(
-            result={criteriaKey: False},
-            validation={"status": "error", "errors": [], "warnings": []},
-            transformation_errors=[str(e)],
-            fail_reasons=["Transformation error: " + str(e)]
-        )
+    return create_response(
+        result={
+            "isDNSConfigured": is_configured,
+            "totalDomainsRegistered": total_domains,
+            "inboundConfiguredDomains": inbound_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalDomainsRegistered": total_domains,
+            "inboundConfiguredDomains": inbound_count,
+            "inboundTypesObserved": inbound_types_seen,
+        },
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isDNSConfigured",
+            "vendor": "Mimecast",
+            "category": "Email Security",
+        },
+    )

--- a/safeguards/emailsecurity/mimecast/isEmailLoggingEnabled.py
+++ b/safeguards/emailsecurity/mimecast/isEmailLoggingEnabled.py
@@ -1,0 +1,157 @@
+"""Transformation: isEmailLoggingEnabled
+Checks whether the Enhanced Logging package (1061) is provisioned on the
+Mimecast account, indicating email security logs can be integrated with SIEM.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+ENHANCED_LOGGING_CODE = "1061"
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    # The account data is in data["data"][0]
+    account_list = data.get("data") or []
+    account = account_list[0] if account_list and isinstance(account_list[0], dict) else {}
+
+    packages = account.get("packages") or []
+    account_name = account.get("accountName") or "Unknown"
+    account_code = account.get("accountCode") or "Unknown"
+
+    # Check for Enhanced Logging package [1061]
+    enhanced_logging_found = False
+    matched_package = None
+    for pkg in packages:
+        if isinstance(pkg, str) and ENHANCED_LOGGING_CODE in pkg:
+            enhanced_logging_found = True
+            matched_package = pkg
+            break
+
+    total_packages = len(packages)
+
+    if enhanced_logging_found:
+        pass_reasons = [
+            f"Account '{account_name}' (code: {account_code}) has the '{matched_package}' package provisioned, "
+            f"confirming Enhanced Logging is enabled. "
+            f"This allows email security log data to be forwarded to a SIEM. "
+            f"({total_packages} total packages found on the account.)"
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"Account '{account_name}' (code: {account_code}) does not have the "
+            f"'Enhanced Logging [1061]' package in its provisioned packages list "
+            f"({total_packages} packages inspected). "
+            f"Email security log forwarding to a SIEM cannot be confirmed."
+        ]
+        recommendations = [
+            "Contact your Mimecast account representative to provision the 'Enhanced Logging [1061]' "
+            "package, then configure the SIEM integration via the Mimecast Cloud Gateway or "
+            "third-party connector to enable email security log streaming."
+        ]
+
+    api_errors = []
+    fail_list = data.get("fail") or []
+    if fail_list:
+        for f in fail_list:
+            if isinstance(f, dict):
+                errs = f.get("errors") or []
+                for e in errs:
+                    if isinstance(e, dict):
+                        api_errors.append(e.get("message") or str(e))
+
+    return create_response(
+        result={
+            "isEmailLoggingEnabled": enhanced_logging_found,
+            "enhancedLoggingPackageFound": matched_package,
+            "totalPackages": total_packages,
+            "accountName": account_name,
+            "accountCode": account_code,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "accountName": account_name,
+            "accountCode": account_code,
+            "totalPackages": total_packages,
+            "enhancedLoggingFound": enhanced_logging_found,
+        },
+        metadata={
+            "transformationId": "isEmailLoggingEnabled",
+            "vendor": "Mimecast",
+            "category": "emailsecurity",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/emailsecurity/mimecast/schemas/__init__.py
+++ b/safeguards/emailsecurity/mimecast/schemas/__init__.py
@@ -1,13 +1,21 @@
-"""Pydantic schemas for transformation inputs."""
+"""Schema registry for this vendor's transformations."""
 
+from .confirmedLicensePurchased import ConfirmedLicensePurchasedInput
 from .confirmedlicensepurchased import ConfirmedlicensepurchasedInput
-from .isantiphishingenabled import IsantiphishingenabledInput
+from
+from .isDNSConfigured import IsDNSConfiguredInput
+from .isEmailLoggingEnabled import IsEmailLoggingEnabledInput
 from .isdnsconfigured import IsdnsconfiguredInput
-from .isemailloggingenabled import IsemailloggingenabledInput
+from
 from .isurlrewriteenabled import IsurlrewriteenabledInput
 
+__all__
+
 __all__ = [
+    "ConfirmedLicensePurchasedInput",
     "ConfirmedlicensepurchasedInput",
+    "IsDNSConfiguredInput",
+    "IsEmailLoggingEnabledInput",
     "IsantiphishingenabledInput",
     "IsdnsconfiguredInput",
     "IsemailloggingenabledInput",

--- a/safeguards/emailsecurity/mimecast/schemas/confirmedLicensePurchased.py
+++ b/safeguards/emailsecurity/mimecast/schemas/confirmedLicensePurchased.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class ConfirmedLicensePurchasedInput(BaseModel):
+    """Input schema for the confirmedLicensePurchased transformation.
+
+    Expects the response shape from Mimecast get-account:
+      data[]  — list of account objects (accountCode, accountName, packages, etc.)
+      meta    — envelope metadata including status code
+      fail[]  — list of error objects (empty on success)
+    """
+
+    data: Optional[List[Dict[str, Any]]] = None
+    meta: Optional[Dict[str, Any]] = None
+    fail: Optional[List[Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/mimecast/schemas/isDNSConfigured.py
+++ b/safeguards/emailsecurity/mimecast/schemas/isDNSConfigured.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsDNSConfiguredInput(BaseModel):
+    """Input schema for the isDNSConfigured transformation.
+
+    Expects the raw response from the Mimecast getInternalDomain endpoint
+    (POST /api/domain/get-internal-domain). Each item in data[] carries
+    domain, sendOnly, local, and inboundType fields.
+    """
+
+    data: Optional[List[Dict[str, Any]]] = None
+    meta: Optional[Dict[str, Any]] = None
+    fail: Optional[List[Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/mimecast/schemas/isEmailLoggingEnabled.py
+++ b/safeguards/emailsecurity/mimecast/schemas/isEmailLoggingEnabled.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEmailLoggingEnabledInput(BaseModel):
+    """Input schema for the isEmailLoggingEnabled transformation.
+
+    Expects the Mimecast get-account API response with a data array containing
+    the account record, including a packages list of provisioned product strings.
+    """
+
+    data: Optional[List[Any]] = None
+    meta: Optional[Dict[str, Any]] = None
+    fail: Optional[List[Any]] = None
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary
Mimecast is being onboarded as a new email security vendor integration. This PR delivers three transformation scripts that evaluate license confirmation, DNS configuration readiness, and enhanced logging (SIEM integration) enablement. The scripts consume two API endpoints (getAccount and getInternalDomain) and apply business logic to detect active Mimecast licensing, inbound DNS routing, and the Enhanced Logging [1061] package entitlement.

**Context:** Three criteria delivered at phase-1 completion; two criteria (isAntiPhishingEnabled, isURLRewriteEnabled) dropped at live-validation gate due to customer tenant constraints and are not included in this PR.

## What each transformation does

### `confirmedLicensePurchased.py`
Confirms the Mimecast account has an active, valid license by verifying the account object is present and no account errors are reported.

- **Consumes:** Mimecast API `/api/account/get-account` (POST)
- **Pass criteria:** `meta.status == 200 AND data array contains at least one account record AND fail array is empty`. Returns true only when the account retrieval succeeds with data; any failure markers indicate account access failure (license inactive or revoked).
- **Key edge cases handled:**
  - Empty account data array: fails with reason "no account record returned"
  - Non-200 meta status: fails with the actual status code
  - Non-empty fail array: fails with count and message indicating account request did not complete
  - Missing meta.status field: treated as failure (safe default)

### `isDNSConfigured.py`
Validates that at least one internal domain has inbound mail routing configured in Mimecast, confirming DNS records (MX, SPF, DKIM, DMARC) are published and point mail to Mimecast gateway.

- **Consumes:** Mimecast API `/api/domain/get-internal-domain` (POST)
- **Pass criteria:** At least one registered internal domain has `sendOnly == false` AND `inboundType` is a non-empty string (indicating MX routing is active for that domain). Returns true if at least one domain meets both conditions.
- **Key edge cases handled:**
  - Zero domains registered: fails with reason "no internal domains are registered"
  - Domains present but all send-only or missing inboundType: fails with count and explanation
  - API errors in fail array: extracted and reported in additionalInfo.dataCollection.errors
  - Truncation markers (e.g., `{"_truncated": "+112 more items"}`) in data array: filtered out before processing
  - Sample domain names collected (up to 5) for evidence in pass reason

### `isEmailLoggingEnabled.py`
Confirms the Enhanced Logging [1061] package is provisioned on the account, which enables email security log forwarding to SIEM platforms via the get-siem-logs endpoint.

- **Consumes:** Mimecast API `/api/account/get-account` (POST) — reads packages array from account record
- **Pass criteria:** The packages array contains at least one string containing the substring "1061" (the Enhanced Logging product code). Returns true if the code is found; false if the account record exists but 1061 package is missing.
- **Key edge cases handled:**
  - Empty packages array: fails with reason "packages inspected, none matched Enhanced Logging"
  - Missing packages field on account: treated as empty array (no logging enabled)
  - Account retrieval failure: reported in additionalInfo.dataCollection.errors
  - Matched package string extracted and included in result for evidence (e.g., "Enhanced Logging [1061]")

## Architecture notes
All three scripts follow the standardized transformation contract: `extract_input()` unwraps legacy or enriched input formats, `transform()` applies evaluation logic, and `create_response()` returns a 5-section schema (transformedResponse, dataCollection status, validation warnings, transformation errors, and evaluation with passReasons, failReasons, recommendations, additionalFindings). All scripts are RestrictedPython-compliant; no external imports beyond datetime and json are used. The response schema version is 2.0.

## Test plan
- [ ] Each script passes PyCodeExecutor sandbox validation
- [ ] `confirmedLicensePurchased.py`: verify pass with HTTP 200 + non-empty data + empty fail array; verify fail with HTTP non-200, empty data, or non-empty fail
- [ ] `isDNSConfigured.py`: verify pass with at least one domain where sendOnly=false AND inboundType is set; verify fail with zero domains or all send-only domains; test truncation marker filtering
- [ ] `isEmailLoggingEnabled.py`: verify pass with "Enhanced Logging [1061]" in packages array; verify fail with packages present but 1061 absent; test empty/missing packages array
- [ ] Confirm field names in `data.get("...")` calls match Mimecast documented API response fields:
  - getAccount: `data[0].accountCode`, `data[0].accountName`, `data[0].packages`, `meta.status`, `fail` array
  - getInternalDomain: `data[].domain`, `data[].sendOnly`, `data[].inboundType`, `fail` array
- [ ] Spot-check `create_response()` output for all three scripts: validate schemaVersion 2.0, confirm evaluatedAt timestamp format (ISO 8601 + Z), verify failReasons and passReasons arrays are populated per the logic
- [ ] Live validation pass: confirmedLicensePurchased returned HTTP 200; isDNSConfigured returned HTTP 200; isEmailLoggingEnabled returned HTTP 200

**Generated by Spektrum integration onboarding pipeline**