### PR TITLE
feat: add Mimecast transformations (emailsecurity)

### DIFF
--- a/safeguards/emailsecurity/mimecast/confirmedLicensePurchased.py
+++ b/safeguards/emailsecurity/mimecast/confirmedLicensePurchased.py
@@ -1,0 +1,153 @@
+"""Transformation: confirmedLicensePurchased — Mimecast getAccount"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    # The Mimecast getAccount response wraps account records in a top-level "data" list
+    account_list = data.get("data") or []
+    fail_list = data.get("fail") or []
+    meta = data.get("meta") or {}
+    meta_status = meta.get("status") if isinstance(meta, dict) else None
+
+    # API-level errors surfaced in the "fail" array
+    api_errors = []
+    if fail_list:
+        api_errors = [str(f) for f in fail_list]
+
+    if not account_list:
+        # No account data returned — cannot confirm license
+        return create_response(
+            result={
+                "confirmedLicensePurchased": False,
+                "packageCount": 0,
+                "accountCode": None,
+            },
+            validation=validation,
+            pass_reasons=[],
+            fail_reasons=["No account data was returned in the getAccount response. Cannot confirm a valid Mimecast license."],
+            recommendations=["Verify that the API credentials have the Accounts | Dashboard | Read scope and that the account is active."],
+            input_summary={"accountCount": 0, "metaStatus": meta_status, "failCount": len(fail_list)},
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "confirmedLicensePurchased",
+                "vendor": "Mimecast",
+                "category": "Email Security",
+            },
+        )
+
+    account = account_list[0] if isinstance(account_list[0], dict) else {}
+    account_code = account.get("accountCode") or ""
+    account_name = account.get("accountName") or ""
+    packages = account.get("packages") or []
+    package_count = len(packages)
+
+    license_purchased = package_count > 0
+
+    if license_purchased:
+        pass_reasons = [
+            f"Mimecast account '{account_name}' (code: {account_code}) returned a valid getAccount response with {package_count} licensed packages, confirming an active Mimecast license is purchased."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"Mimecast account '{account_name}' (code: {account_code}) returned a valid response but the packages array is empty, indicating no licensed products were found."
+        ]
+        recommendations = [
+            "Contact Mimecast support to verify the account's license status and ensure at least one product package is assigned."
+        ]
+
+    return create_response(
+        result={
+            "confirmedLicensePurchased": license_purchased,
+            "packageCount": package_count,
+            "accountCode": account_code,
+            "accountName": account_name,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "accountCount": len(account_list),
+            "accountCode": account_code,
+            "packageCount": package_count,
+            "metaStatus": meta_status,
+        },
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "confirmedLicensePurchased",
+            "vendor": "Mimecast",
+            "category": "Email Security",
+        },
+    )

--- a/safeguards/emailsecurity/mimecast/isAntiPhishingEnabled.py
+++ b/safeguards/emailsecurity/mimecast/isAntiPhishingEnabled.py
@@ -1,0 +1,160 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    accounts = data.get("data") or []
+
+    if not accounts:
+        return create_response(
+            result={
+                "isAntiPhishingEnabled": False,
+                "impersonationProtectionLicensed": False,
+                "urlProtectionLicensed": False,
+                "businessEmailCompromiseLicensed": False,
+                "totalPackages": 0,
+            },
+            validation=validation,
+            fail_reasons=["No account data returned from the getAccount endpoint; cannot confirm anti-phishing protection is active."],
+            recommendations=["Verify Mimecast API credentials and account access, then re-evaluate."],
+            input_summary={"accountCount": 0, "antiPhishingPackagesFound": []},
+            metadata={
+                "transformationId": "isAntiPhishingEnabled",
+                "vendor": "Mimecast",
+                "category": "emailsecurity",
+            },
+        )
+
+    account = accounts[0] if isinstance(accounts[0], dict) else {}
+    packages = account.get("packages") or []
+    account_name = account.get("accountName") or "unknown"
+
+    IMPERSONATION_PROTECTION = "Impersonation Protection [1060]"
+    URL_PROTECTION = "URL Protection (Site) [1043]"
+    BEC = "Business Email Compromise [1109]"
+
+    has_impersonation = IMPERSONATION_PROTECTION in packages
+    has_url_protection = URL_PROTECTION in packages
+    has_bec = BEC in packages
+
+    is_enabled = has_impersonation
+
+    found_packages = []
+    if has_impersonation:
+        found_packages.append(IMPERSONATION_PROTECTION)
+    if has_url_protection:
+        found_packages.append(URL_PROTECTION)
+    if has_bec:
+        found_packages.append(BEC)
+
+    if is_enabled:
+        pass_reasons = [
+            f"Account '{account_name}' has 'Impersonation Protection [1060]' in the licensed packages array, confirming TTP Impersonation Protection (anti-phishing) is active."
+        ]
+        if has_url_protection:
+            pass_reasons.append("'URL Protection (Site) [1043]' is also licensed, providing additional phishing URL blocking coverage.")
+        if has_bec:
+            pass_reasons.append("'Business Email Compromise [1109]' is also licensed, extending anti-phishing protection to BEC-style attacks.")
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"Account '{account_name}' does not include 'Impersonation Protection [1060]' in the licensed packages array. TTP Impersonation Protection (anti-phishing) is not confirmed as active."
+        ]
+        recommendations = [
+            "License and enable Impersonation Protection (package ID 1060) in Mimecast to activate anti-phishing email filtering against display-name spoofing and targeted threat dictionary attacks."
+        ]
+
+    return create_response(
+        result={
+            "isAntiPhishingEnabled": is_enabled,
+            "impersonationProtectionLicensed": has_impersonation,
+            "urlProtectionLicensed": has_url_protection,
+            "businessEmailCompromiseLicensed": has_bec,
+            "totalPackages": len(packages),
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "accountName": account_name,
+            "totalPackages": len(packages),
+            "antiPhishingPackagesFound": found_packages,
+        },
+        metadata={
+            "transformationId": "isAntiPhishingEnabled",
+            "vendor": "Mimecast",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/mimecast/isDNSConfigured.py
+++ b/safeguards/emailsecurity/mimecast/isDNSConfigured.py
@@ -1,14 +1,23 @@
 """
 Transformation: isDNSConfigured
-Vendor: Mimecast  |  Category: emailsecurity
-Evaluates: Ensure that DMARC, DKIM and SPF records are set up properly
-           by verifying at least one active DNS Authentication Outbound policy exists.
+Criterion: DNS Configuration (DMARC, DKIM, SPF)
+Vendor: Mimecast
+Method: getInternalDomain
+
+Evaluates whether DMARC, DKIM, and SPF records are set up properly for all
+internal domains registered in Mimecast. The getInternalDomain endpoint returns
+each domain along with a 'dns' nested object that surfaces per-record verification
+states. A domain is considered fully configured when all three record types
+(DKIM, DMARC, SPF) are present and verified. The overall criterion passes only
+when every domain that has DNS data returned is fully configured.
 """
+
 import json
 from datetime import datetime
 
 
 def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
     if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
         return input_data["data"], input_data["validation"]
     data = input_data
@@ -23,209 +32,245 @@ def extract_input(input_data):
                     break
             if not unwrapped:
                 break
-    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
 
 
 def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
-                    recommendations=None, input_summary=None, transformation_errors=None,
-                    api_errors=None, additional_findings=None):
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
     if validation is None:
         validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
     return {
         "transformedResponse": result,
         "additionalInfo": {
-            "dataCollection": {
-                "status": "error" if (api_errors or []) else "success",
-                "errors": api_errors or []
-            },
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
             "validation": {
                 "status": validation.get("status", "unknown"),
                 "errors": validation.get("errors", []),
-                "warnings": validation.get("warnings", [])
+                "warnings": validation.get("warnings", []),
             },
             "transformation": {
-                "status": "error" if (transformation_errors or []) else "success",
-                "errors": transformation_errors or [],
-                "inputSummary": input_summary or {}
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
             },
             "evaluation": {
                 "passReasons": pass_reasons or [],
                 "failReasons": fail_reasons or [],
                 "recommendations": recommendations or [],
-                "additionalFindings": additional_findings or []
+                "additionalFindings": additional_findings or [],
             },
-            "metadata": {
-                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
-                "schemaVersion": "1.0",
-                "transformationId": "isDNSConfigured",
-                "vendor": "Mimecast",
-                "category": "emailsecurity"
-            }
-        }
+            "metadata": response_metadata,
+        },
     }
 
 
-def get_policy_list(data):
+def check_dns_record(dns_obj, record_type):
     """
-    Extract the list of DNS auth outbound policies from the API response.
-    Mimecast /api/gateway/policies/dns-auth-outbound returns:
-      { "data": [ { "id": "...", "policy": { ... }, "option": { ... } }, ... ] }
-    The returnSpec maps data -> data, so by the time we receive it the top-level
-    key is already 'data'.
+    Check if a specific DNS record type is configured/valid within a dns object.
+    Handles various possible field shapes from Mimecast.
+    Returns True if the record appears configured, False otherwise.
     """
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict):
-        for key in ["data", "policies", "items", "results"]:
-            val = data.get(key)
-            if isinstance(val, list):
+    if not isinstance(dns_obj, dict):
+        return False
+    record_lower = record_type.lower()
+    for key in dns_obj:
+        if key.lower() == record_lower:
+            val = dns_obj[key]
+            if isinstance(val, dict):
+                valid = val.get("valid") or val.get("verified") or val.get("status") or val.get("configured")
+                if valid is True:
+                    return True
+                if isinstance(valid, str):
+                    return valid.lower() in ("verified", "valid", "ok", "pass", "configured", "true")
+                return False
+            if isinstance(val, bool):
                 return val
-    return []
-
-
-def is_policy_enabled(policy_entry):
-    """Return True if a policy entry is considered active/enabled."""
-    if isinstance(policy_entry, dict):
-        # Direct enabled flag
-        if "enabled" in policy_entry:
-            return bool(policy_entry.get("enabled"))
-        # Nested under 'policy' key
-        nested = policy_entry.get("policy")
-        if isinstance(nested, dict) and "enabled" in nested:
-            return bool(nested.get("enabled"))
-        # If there is no explicit enabled flag, treat existence as enabled
-        return True
+            if isinstance(val, str):
+                return val.lower() in ("verified", "valid", "ok", "pass", "configured", "true")
     return False
 
 
-def evaluate(data):
-    """
-    Core evaluation logic for isDNSConfigured.
-
-    Criteria: At least one DNS Authentication Outbound policy must exist
-    and be enabled, indicating that DKIM/SPF/DMARC outbound signing or
-    verification is configured in Mimecast.
-    """
-    try:
-        policies = get_policy_list(data)
-        total_policies = len(policies)
-
-        if total_policies == 0:
-            return {
-                "isDNSConfigured": False,
-                "totalPolicies": 0,
-                "enabledPolicies": 0,
-                "error": "No DNS Authentication Outbound policies found"
-            }
-
-        enabled_count = 0
-        for policy in policies:
-            if is_policy_enabled(policy):
-                enabled_count = enabled_count + 1
-
-        is_configured = enabled_count > 0
-
-        return {
-            "isDNSConfigured": is_configured,
-            "totalPolicies": total_policies,
-            "enabledPolicies": enabled_count
-        }
-
-    except Exception as e:
-        return {"isDNSConfigured": False, "error": str(e)}
-
-
 def transform(input):
-    criteriaKey = "isDNSConfigured"
-    try:
-        if isinstance(input, str):
-            input = json.loads(input)
-        elif isinstance(input, bytes):
-            input = json.loads(input.decode("utf-8"))
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
 
-        data, validation = extract_input(input)
+    items = data.get("data") or []
+    fail_field = data.get("fail") or []
 
-        if validation.get("status") == "failed":
-            return create_response(
-                result={criteriaKey: False},
-                validation=validation,
-                fail_reasons=["Input validation failed"]
-            )
+    # API-level errors
+    api_errors = []
+    if fail_field:
+        for f in fail_field:
+            if isinstance(f, dict):
+                msg = f.get("message") or f.get("msg") or str(f)
+                api_errors.append(msg)
+            else:
+                api_errors.append(str(f))
 
-        eval_result = evaluate(data)
-        result_value = eval_result.get(criteriaKey, False)
-        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
+    if not items:
+        return create_response(
+            result={
+                "isDNSConfigured": False,
+                "totalDomains": 0,
+                "domainsWithDnsData": 0,
+                "domainsWithDkim": 0,
+                "domainsWithDmarc": 0,
+                "domainsWithSpf": 0,
+                "domainsFullyConfigured": 0,
+            },
+            validation=validation,
+            fail_reasons=["No internal domains were returned by the Mimecast API. Cannot verify DMARC, DKIM, or SPF configuration."],
+            recommendations=["Register at least one internal domain in Mimecast and configure DKIM, DMARC, and SPF DNS records for it."],
+            input_summary={"totalDomains": 0, "apiErrors": api_errors},
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isDNSConfigured",
+                "vendor": "Mimecast",
+                "category": "emailsecurity",
+            }
+        )
 
+    total_domains = 0
+    domains_with_dns_data = 0
+    domains_with_dkim = 0
+    domains_with_dmarc = 0
+    domains_with_spf = 0
+    domains_fully_configured = 0
+    domain_names = []
+    missing_dns_domains = []
+    missing_record_details = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        # Skip truncation markers (e.g. {"_truncated": "+92 more items"})
+        if "_truncated" in item and len(item) == 1:
+            continue
+        domain_name = item.get("domain") or ""
+        total_domains = total_domains + 1
+        if domain_name:
+            domain_names.append(domain_name)
+
+        dns_obj = item.get("dns")
+        if not dns_obj or not isinstance(dns_obj, dict):
+            missing_dns_domains.append(domain_name)
+            continue
+
+        domains_with_dns_data = domains_with_dns_data + 1
+
+        has_dkim = check_dns_record(dns_obj, "dkim")
+        has_dmarc = check_dns_record(dns_obj, "dmarc")
+        has_spf = check_dns_record(dns_obj, "spf")
+
+        if has_dkim:
+            domains_with_dkim = domains_with_dkim + 1
+        if has_dmarc:
+            domains_with_dmarc = domains_with_dmarc + 1
+        if has_spf:
+            domains_with_spf = domains_with_spf + 1
+
+        if has_dkim and has_dmarc and has_spf:
+            domains_fully_configured = domains_fully_configured + 1
+        else:
+            missing_records = []
+            if not has_dkim:
+                missing_records.append("DKIM")
+            if not has_dmarc:
+                missing_records.append("DMARC")
+            if not has_spf:
+                missing_records.append("SPF")
+            if missing_records:
+                missing_record_details.append(
+                    f"{domain_name}: missing " + ", ".join(missing_records)
+                )
+
+    # Determine overall pass/fail
+    if domains_with_dns_data == 0:
+        # Domains exist but no DNS verification data in any response item
+        is_configured = False
         pass_reasons = []
+        sample = ", ".join(domain_names[:5]) + ("..." if len(domain_names) > 5 else "")
+        fail_reasons = [
+            f"DNS verification data (DKIM, DMARC, SPF) was not found in the response for any of the {total_domains} internal domain(s) registered in Mimecast. "
+            "The 'dns' field was absent on all returned domain records, indicating DNS records may not be configured or verified in Mimecast. "
+            f"Sample domains checked: {sample}"
+        ]
+        recommendations = [
+            "Configure DKIM, DMARC, and SPF DNS records for all internal domains in Mimecast. "
+            "Verify DNS configuration under Administration > Gateway > Policies or the Domain configuration section."
+        ]
+    elif domains_fully_configured == domains_with_dns_data and domains_fully_configured > 0:
+        is_configured = True
+        pass_reasons = [
+            f"All {domains_fully_configured} domain(s) with DNS verification data have DKIM, DMARC, and SPF records properly configured "
+            f"({domains_with_dkim} DKIM, {domains_with_dmarc} DMARC, {domains_with_spf} SPF verified out of {domains_with_dns_data} domains with DNS data)."
+        ]
         fail_reasons = []
         recommendations = []
-        additional_findings = []
-
-        total = eval_result.get("totalPolicies", 0)
-        enabled = eval_result.get("enabledPolicies", 0)
-
-        if result_value:
+        if missing_dns_domains:
             pass_reasons.append(
-                "DNS Authentication Outbound policies are configured: "
-                + str(enabled) + " of " + str(total) + " policy(s) are enabled"
+                f"Note: {len(missing_dns_domains)} domain(s) did not include DNS verification data in this response and were not evaluated."
             )
-            pass_reasons.append(
-                "DKIM/SPF/DMARC outbound configuration is active in Mimecast"
+    else:
+        is_configured = False
+        pass_reasons = []
+        fail_reasons_list = []
+        if missing_record_details:
+            detail_sample = "; ".join(missing_record_details[:5]) + ("..." if len(missing_record_details) > 5 else "")
+            fail_reasons_list.append(
+                f"{len(missing_record_details)} domain(s) are missing one or more required DNS records: {detail_sample}"
             )
-        else:
-            if total == 0:
-                fail_reasons.append(
-                    "No DNS Authentication Outbound policies found in Mimecast"
-                )
-                recommendations.append(
-                    "Create at least one DNS Authentication Outbound policy in the Mimecast "
-                    "Administration Console under Gateway | Policies | DNS Authentication Outbound"
-                )
-            else:
-                fail_reasons.append(
-                    str(total) + " DNS Authentication Outbound policy(s) exist but none are enabled"
-                )
-                recommendations.append(
-                    "Enable at least one DNS Authentication Outbound policy in Mimecast to ensure "
-                    "DKIM signing and DMARC/SPF verification are active"
-                )
-            recommendations.append(
-                "Ensure DMARC, DKIM, and SPF DNS records are published and that Mimecast "
-                "DNS Authentication policies reference the correct signing profile"
+        if missing_dns_domains:
+            domain_sample = ", ".join(missing_dns_domains[:5]) + ("..." if len(missing_dns_domains) > 5 else "")
+            fail_reasons_list.append(
+                f"{len(missing_dns_domains)} domain(s) returned no DNS verification data: {domain_sample}"
             )
+        fail_reasons = fail_reasons_list
+        recommendations = [
+            "Ensure DKIM, DMARC, and SPF DNS records are published and verified for all internal domains in Mimecast. "
+            "Review each domain listed under Administration > Gateway > Policies to confirm record configuration."
+        ]
 
-            if "error" in eval_result:
-                fail_reasons.append(eval_result["error"])
-
-        additional_findings.append(
-            "Total DNS Auth Outbound policies: " + str(total)
-        )
-        additional_findings.append(
-            "Enabled DNS Auth Outbound policies: " + str(enabled)
-        )
-
-        full_result = {criteriaKey: result_value}
-        for k, v in extra_fields.items():
-            full_result[k] = v
-
-        return create_response(
-            result=full_result,
-            validation=validation,
-            pass_reasons=pass_reasons,
-            fail_reasons=fail_reasons,
-            recommendations=recommendations,
-            input_summary={
-                criteriaKey: result_value,
-                "totalPolicies": total,
-                "enabledPolicies": enabled
-            },
-            additional_findings=additional_findings
-        )
-
-    except Exception as e:
-        return create_response(
-            result={criteriaKey: False},
-            validation={"status": "error", "errors": [], "warnings": []},
-            transformation_errors=[str(e)],
-            fail_reasons=["Transformation error: " + str(e)]
-        )
+    return create_response(
+        result={
+            "isDNSConfigured": is_configured,
+            "totalDomains": total_domains,
+            "domainsWithDnsData": domains_with_dns_data,
+            "domainsWithDkim": domains_with_dkim,
+            "domainsWithDmarc": domains_with_dmarc,
+            "domainsWithSpf": domains_with_spf,
+            "domainsFullyConfigured": domains_fully_configured,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalDomains": total_domains,
+            "domainsWithDnsData": domains_with_dns_data,
+            "domainsFullyConfigured": domains_fully_configured,
+        },
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isDNSConfigured",
+            "vendor": "Mimecast",
+            "category": "emailsecurity",
+        }
+    )

--- a/safeguards/emailsecurity/mimecast/isEmailLoggingEnabled.py
+++ b/safeguards/emailsecurity/mimecast/isEmailLoggingEnabled.py
@@ -1,0 +1,146 @@
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input_data):
+    """
+    Transformation: isEmailLoggingEnabled (Mimecast)
+
+    Checks whether the Mimecast account has the Enhanced Logging package
+    (product ID 1061) active. Enhanced Logging is Mimecast's MTA-level
+    log stream used for SIEM integration. Its presence in the account
+    packages list confirms the feature is licensed and enabled.
+    """
+    data, validation = extract_input(input_data)
+    data = data if isinstance(data, dict) else {}
+
+    # getAccount returns {"data": [...], "fail": [], "meta": {...}}
+    account_list = data.get("data") or []
+    account = account_list[0] if account_list else {}
+
+    packages = account.get("packages") or []
+    account_code = account.get("accountCode") or "unknown"
+    account_name = account.get("accountName") or "unknown"
+
+    # Enhanced Logging package string as returned by the API
+    ENHANCED_LOGGING_PACKAGE = "Enhanced Logging [1061]"
+
+    enhanced_logging_enabled = any(
+        ENHANCED_LOGGING_PACKAGE in pkg for pkg in packages
+    )
+
+    total_packages = len(packages)
+
+    if enhanced_logging_enabled:
+        pass_reasons = [
+            f"Account '{account_name}' ({account_code}) has the '{ENHANCED_LOGGING_PACKAGE}' "
+            f"package active in its licensed packages list ({total_packages} total packages). "
+            "Enhanced Logging enables MTA-level SIEM log streaming, confirming email security "
+            "logs are integrated with SIEM."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"Account '{account_name}' ({account_code}) does not have the "
+            f"'{ENHANCED_LOGGING_PACKAGE}' package in its licensed packages list "
+            f"({total_packages} packages found). Enhanced Logging must be active for "
+            "email security logs to be streamed to a SIEM."
+        ]
+        recommendations = [
+            "Enable Enhanced Logging under Account Settings in the Mimecast Administration Console "
+            "and configure a SIEM connector to receive MTA log data. Contact your Mimecast "
+            "account representative if the Enhanced Logging package is not included in your subscription."
+        ]
+
+    return create_response(
+        result={
+            "isEmailLoggingEnabled": enhanced_logging_enabled,
+            "enhancedLoggingPackageFound": enhanced_logging_enabled,
+            "totalPackages": total_packages,
+            "accountCode": account_code,
+            "accountName": account_name,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "accountCode": account_code,
+            "accountName": account_name,
+            "totalPackages": total_packages,
+            "enhancedLoggingPackageFound": enhanced_logging_enabled,
+        },
+        metadata={
+            "transformationId": "isEmailLoggingEnabled",
+            "vendor": "Mimecast",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/mimecast/isURLRewriteEnabled.py
+++ b/safeguards/emailsecurity/mimecast/isURLRewriteEnabled.py
@@ -1,0 +1,161 @@
+"""Transformation: isURLRewriteEnabled — Mimecast TTP URL Protect
+Evaluates whether URL rewriting is enabled by inspecting the managed URL
+rules returned by getTTPUrlManagedUrls. A non-zero meta.pagination.totalCount
+confirms TTP URL Protect is active and rewriting URLs in delivered emails.
+"""
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+
+    if not isinstance(data, dict):
+        data = {}
+
+    # Extract top-level sections
+    fail_list = data.get("fail") or []
+    meta = data.get("meta") or {}
+    pagination = meta.get("pagination") or {}
+    url_items = data.get("data") or []
+
+    total_count = pagination.get("totalCount") or 0
+    page_size = len(url_items)
+
+    # Collect API-level error messages from the fail array
+    api_errors = []
+    for f in fail_list:
+        if isinstance(f, dict):
+            api_errors.append(f.get("message") or str(f))
+        else:
+            api_errors.append(str(f))
+
+    # Count rewrite states across the sampled page
+    rewrite_enabled_count = 0
+    rewrite_disabled_count = 0
+    for item in url_items:
+        if isinstance(item, dict):
+            if item.get("disableRewrite") is False:
+                rewrite_enabled_count = rewrite_enabled_count + 1
+            elif item.get("disableRewrite") is True:
+                rewrite_disabled_count = rewrite_disabled_count + 1
+
+    # Primary verdict: a non-zero totalCount confirms TTP URL Protect is active
+    # and managing URLs through rewriting. An empty list means the feature has
+    # no rules and is effectively not operational.
+    is_url_rewrite_enabled = total_count > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_url_rewrite_enabled:
+        pass_reasons.append(
+            f"TTP URL Protect is active with {total_count} managed URLs configured "
+            f"(meta.pagination.totalCount={total_count}). In the sampled page of "
+            f"{page_size} entries, {rewrite_enabled_count} have URL rewriting enabled "
+            f"(disableRewrite=false) and {rewrite_disabled_count} have rewriting "
+            f"explicitly suppressed (disableRewrite=true) for trusted/permitted domains."
+        )
+    else:
+        fail_reasons.append(
+            "No managed URLs found in TTP URL Protect (meta.pagination.totalCount=0). "
+            "URL rewriting does not appear to be configured or active for this account."
+        )
+        recommendations.append(
+            "Configure TTP URL Protect managed URL rules in the Mimecast administration "
+            "console under Administration > Gateway > Policies > URL Protection. "
+            "Enabling URL rewriting ensures all links in delivered emails are scanned "
+            "and rewritten through Mimecast's proxy before users can click them."
+        )
+
+    return create_response(
+        result={
+            "isURLRewriteEnabled": is_url_rewrite_enabled,
+            "totalManagedUrls": total_count,
+            "sampledUrlsWithRewriteEnabled": rewrite_enabled_count,
+            "sampledUrlsWithRewriteDisabled": rewrite_disabled_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalManagedUrls": total_count,
+            "pageSize": page_size,
+            "sampledRewriteEnabled": rewrite_enabled_count,
+            "sampledRewriteDisabled": rewrite_disabled_count,
+            "apiFailures": len(fail_list),
+        },
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isURLRewriteEnabled",
+            "vendor": "Mimecast",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/mimecast/schemas/__init__.py
+++ b/safeguards/emailsecurity/mimecast/schemas/__init__.py
@@ -1,13 +1,25 @@
-"""Pydantic schemas for transformation inputs."""
+"""Schema registry for this vendor's transformations."""
 
+from .confirmedLicensePurchased import ConfirmedLicensePurchasedInput
 from .confirmedlicensepurchased import ConfirmedlicensepurchasedInput
-from .isantiphishingenabled import IsantiphishingenabledInput
+from
+from .isAntiPhishingEnabled import IsAntiPhishingEnabledInput
+from .isDNSConfigured import IsDNSConfiguredInput
+from .isEmailLoggingEnabled import IsEmailLoggingEnabledInput
+from .isURLRewriteEnabled import IsURLRewriteEnabledInput
 from .isdnsconfigured import IsdnsconfiguredInput
-from .isemailloggingenabled import IsemailloggingenabledInput
+from
 from .isurlrewriteenabled import IsurlrewriteenabledInput
 
+__all__
+
 __all__ = [
+    "ConfirmedLicensePurchasedInput",
     "ConfirmedlicensepurchasedInput",
+    "IsAntiPhishingEnabledInput",
+    "IsDNSConfiguredInput",
+    "IsEmailLoggingEnabledInput",
+    "IsURLRewriteEnabledInput",
     "IsantiphishingenabledInput",
     "IsdnsconfiguredInput",
     "IsemailloggingenabledInput",

--- a/safeguards/emailsecurity/mimecast/schemas/confirmedLicensePurchased.py
+++ b/safeguards/emailsecurity/mimecast/schemas/confirmedLicensePurchased.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class ConfirmedLicensePurchasedInput(BaseModel):
+    """Input schema for the confirmedLicensePurchased transformation.
+
+    Expects the raw Mimecast getAccount API response envelope:
+      {
+        "fail": [],
+        "meta": {"status": 200},
+        "data": [{"accountCode": "...", "accountName": "...", "packages": [...], ...}]
+      }
+    """
+
+    fail: Optional[List[Any]] = None
+    meta: Optional[Dict[str, Any]] = None
+    data: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/mimecast/schemas/isAntiPhishingEnabled.py
+++ b/safeguards/emailsecurity/mimecast/schemas/isAntiPhishingEnabled.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsAntiPhishingEnabledInput(BaseModel):
+    """Input schema for the isAntiPhishingEnabled transformation.
+
+    Expects the raw getAccount response envelope with a top-level 'data'
+    array containing account objects that include a 'packages' list of
+    licensed product strings.
+    """
+
+    fail: Optional[List[Any]] = None
+    meta: Optional[Dict[str, Any]] = None
+    data: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/mimecast/schemas/isDNSConfigured.py
+++ b/safeguards/emailsecurity/mimecast/schemas/isDNSConfigured.py
@@ -1,0 +1,46 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class DnsRecordInfo(BaseModel):
+    """Represents DNS verification state for a single record type (DKIM, DMARC, SPF)."""
+    valid: Optional[bool] = None
+    verified: Optional[bool] = None
+    status: Optional[str] = None
+    configured: Optional[bool] = None
+
+    class Config:
+        extra = "allow"
+
+
+class DomainDnsInfo(BaseModel):
+    """DNS verification fields for an internal domain."""
+    dkim: Optional[Any] = None
+    dmarc: Optional[Any] = None
+    spf: Optional[Any] = None
+
+    class Config:
+        extra = "allow"
+
+
+class InternalDomainItem(BaseModel):
+    """A single internal domain entry from getInternalDomain."""
+    id: Optional[str] = None
+    domain: Optional[str] = None
+    sendOnly: Optional[bool] = None
+    local: Optional[bool] = None
+    inboundType: Optional[str] = None
+    dns: Optional[DomainDnsInfo] = None
+
+    class Config:
+        extra = "allow"
+
+
+class IsDNSConfiguredInput(BaseModel):
+    """Input schema for the isDNSConfigured transformation (Mimecast getInternalDomain)."""
+    fail: Optional[List[Any]] = None
+    meta: Optional[Dict[str, Any]] = None
+    data: Optional[List[Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/mimecast/schemas/isEmailLoggingEnabled.py
+++ b/safeguards/emailsecurity/mimecast/schemas/isEmailLoggingEnabled.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsEmailLoggingEnabledInput(BaseModel):
+    """Input schema for the isEmailLoggingEnabled transformation.
+
+    Expects a Mimecast getAccount API response containing account-level
+    metadata including the packages array which lists all licensed products.
+    """
+
+    fail: Optional[List[Any]] = None
+    meta: Optional[Dict[str, Any]] = None
+    data: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/mimecast/schemas/isURLRewriteEnabled.py
+++ b/safeguards/emailsecurity/mimecast/schemas/isURLRewriteEnabled.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import Any, Dict, List, Optional
+
+
+class IsURLRewriteEnabledInput(BaseModel):
+    """Input schema for the isURLRewriteEnabled transformation.
+
+    Accepts the response from getTTPUrlManagedUrls:
+      - fail: list of API-level error objects
+      - meta.pagination.totalCount: fleet-wide count of managed URL rules
+      - data: sampled page of managed URL entries, each with disableRewrite field
+    """
+
+    fail: Optional[List[Any]] = None
+    meta: Optional[Dict[str, Any]] = None
+    data: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary

This PR delivers five transformation scripts for Mimecast email security (emailsecurity category), covering license verification, anti-phishing protection, DNS configuration, email logging, and URL rewrite status. These scripts parse Mimecast's account and domain API responses to validate critical email security controls, enabling organizations to assess email threat protection posture via Spektrum.

**Context:** Mimecast is being onboarded as a new email security vendor integration. The scripts map three Mimecast API endpoints (getAccount, getInternalDomain, getTTPUrlManagedUrls) to five safeguard criteria covering license/product verification, authentication/protection enablement, and operational configuration.

## What each transformation does

### `confirmedLicensePurchased.py`
Verifies that at least one Mimecast product license is purchased and assigned to the account.

- **Consumes:** Mimecast API `/api/account/get-account` (POST)
- **Pass criteria:** `len(account.packages) > 0` — account's packages array contains at least one licensed product string (e.g., "Impersonation Protection [1060]", "Enhanced Logging [1061]")
- **Key edge cases handled:**
  - No account data in response: fails with recommendation to verify API scope (Accounts | Dashboard | Read)
  - Empty packages array on valid account: fails with recommendation to contact Mimecast support
  - API errors in fail array: captured in api_errors; data_collection status set to "error"
  - Legacy input wrapper formats: unwrapped via extract_input() for compatibility

### `isAntiPhishingEnabled.py`
Confirms that TTP Impersonation Protection (anti-phishing) is licensed and active.

- **Consumes:** Mimecast API `/api/account/get-account` (POST)
- **Pass criteria:** `"Impersonation Protection [1060]" in account.packages` — exact string presence in packages array. Secondary packages (URL Protection [1043], Business Email Compromise [1109]) are logged as supporting signals but do not affect verdict
- **Key edge cases handled:**
  - No account data: returns false with clear fail reason
  - Missing Impersonation Protection: fails with recommendation to license and enable package 1060
  - Presence of supplementary packages: appended as additional pass reasons for visibility
  - **NOTE:** API fail array is not explicitly checked; errors may be silent

### `isDNSConfigured.py`
Validates that DMARC, DKIM, and SPF DNS records are configured and verified for all internal domains registered in Mimecast.

- **Consumes:** Mimecast API `/api/domain/get-internal-domain` (POST)
- **Pass criteria:** All domains with DNS data must have all three records (DKIM, DMARC, SPF) present and verified. Overall criterion passes only if `domains_fully_configured == domains_with_dns_data AND domains_fully_configured > 0`
- **Key edge cases handled:**
  - No domains returned: fails with recommendation to register at least one domain
  - Domains without DNS nested object: counted separately in missing_dns_domains; not counted toward fully_configured
  - Truncation markers in response (e.g., `{"_truncated": "+92 more items"}`): explicitly filtered to avoid false negatives
  - DNS record field variation: check_dns_record() helper tolerates multiple field names ("valid", "verified", "status", "configured") and boolean/string value types
  - API errors in fail array: captured and propagated
  - **NOTE:** Records with valid=False are reported as "missing" in reason text; consider clarifying as "unverified" vs. "absent"

### `isEmailLoggingEnabled.py`
Confirms that Enhanced Logging (package ID 1061) is licensed, enabling SIEM email log integration.

- **Consumes:** Mimecast API `/api/account/get-account` (POST)
- **Pass criteria:** `"Enhanced Logging [1061]" in account.packages` (substring match via `in` operator — more lenient than exact matching)
- **Key edge cases handled:**
  - Empty or missing account data: defaults to empty packages list, returns false
  - Empty packages on valid account: fails with actionable recommendation for admin console path
  - Substring matching: tolerates package string appearing within a larger entry (less brittle than exact match, but inconsistent with other package checks)
  - **NOTE:** API fail array is not checked; API errors may be silent

### `isURLRewriteEnabled.py`
Validates that TTP URL Protect managed URL rules are configured and active, confirming URL rewriting is operational.

- **Consumes:** Mimecast API `/api/ttp/url/get-all-managed-urls` (POST)
- **Pass criteria:** `meta.pagination.totalCount > 0` — non-zero count of managed URLs confirms TTP URL Protect is configured with active rules. Per-entry `disableRewrite` field is sampled for visibility but does not drive verdict
- **Key edge cases handled:**
  - No pagination object in meta: defaults totalCount to 0, fails with recommendation to configure URL rules
  - Empty data array: still checks totalCount (correct; totalCount spans all pages, not just sampled page)
  - All entries with disableRewrite=true: still passes if totalCount > 0 (intentional; these are trusted/permitted domains)
  - API errors in fail array: captured and included in api_errors
  - **NOTE:** If account has many URLs but all are disabled, criterion passes (by design, with documented rationale)

## Architecture notes

All five scripts follow the standardized Spektrum transformation contract: `extract_input()` unwraps legacy wrapper formats and validates input structure, `transform()` evaluates criteria against vendor API data and builds a structured response, and `create_response()` formats the output as a v2.0 schema envelope with five sections (transformedResponse, dataCollection status, validation, transformation, evaluation).

Key patterns:
- **extract_input():** Handles both enriched format (`{data, validation}`) and legacy wrapper keys (api_response, response, result, apiResponse, Output). Falls back to unknown validation status when legacy format is detected.
- **Response structure:** All scripts include passReasons, failReasons, recommendations, and additionalFindings in the evaluation section, with metadata (transformationId, vendor, category, evaluatedAt) and schemaVersion 2.0.
- **Error propagation:** API-level errors from the fail array are captured in additionalInfo.dataCollection.errors, with status set to "error"; transformation-level errors (if any) would be captured in additionalInfo.transformation.errors.
- **RestrictedPython:** All scripts use only safe Python builtins (len, any, isinstance, str methods, dict methods) — no imports of unsafe modules or dynamic code execution.

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation (RestrictedPython safe list)
- [ ] Verify `extract_input()` correctly unwraps legacy wrapper formats and returns (data, validation) tuple
- [ ] Verify `transform()` evaluates correctly for:
  - Valid API response with expected data structure
  - Empty or missing data arrays
  - API errors in fail array (where applicable)
  - Malformed/unexpected field types
- [ ] Confirm field names in `data.get("...")` calls match Mimecast API schema:
  - getAccount: `data`, `packages`, `accountCode`, `accountName`, `fail`, `meta`
  - getInternalDomain: `data`, `dns` (nested), `fail`, `meta`
  - getTTPUrlManagedUrls: `data`, `meta`, `pagination`, `totalCount`, `disableRewrite`, `fail`
- [ ] Spot-check `create_response()` output includes all v2.0 sections:
  - transformedResponse (result dict)
  - additionalInfo.dataCollection (status, errors)
  - additionalInfo.validation (status, errors, warnings)
  - additionalInfo.transformation (status, errors, inputSummary)
  - additionalInfo.evaluation (passReasons, failReasons, recommendations, additionalFindings)
  - additionalInfo.metadata (evaluatedAt ISO timestamp, schemaVersion, transformationId, vendor, category)
- [ ] Verify `confirmedLicensePurchased` handles packages as array vs. string list
- [ ] Verify `isAntiPhishingEnabled` and `isEmailLoggingEnabled` package string matching (note: inconsistent matching strategy — one uses substring `in`, other uses direct membership)
- [ ] Verify `isDNSConfigured` check_dns_record() helper handles multiple field name and type variations
- [ ] Verify `isURLRewriteEnabled` totalCount logic works when data array is empty but pagination exists
- [ ] **Live validation confirmations:**
  - confirmedLicensePurchased: passed HTTP 200 against `/api/account/get-account`
  - isAntiPhishingEnabled: passed HTTP 200 against `/api/account/get-account`
  - isDNSConfigured: passed HTTP 200 against `/api/domain/get-internal-domain`
  - isEmailLoggingEnabled: passed HTTP 200 against `/api/account/get-account`
  - isURLRewriteEnabled: passed HTTP 200 against `/api/ttp/url/get-all-managed-urls`

## Known findings

- **Inconsistent API error handling:** `isAntiPhishingEnabled` and `isEmailLoggingEnabled` do not check the `fail` array for API-level errors, which could mask failures silently. Recommend adding explicit fail array checks to these two scripts for consistency.
- **Package string matching brittleness:** Package presence checks rely on exact or substring string matching (e.g., "Impersonation Protection [1060]"). If Mimecast changes package naming format in a future API release, these scripts will fail silently. Consider adding a fallback check by package ID or a warning log if no packages are found.
- **Validation status:** All scripts report `validation.status: "unknown"` because they fall back to legacy input handling. This is acceptable but limits schema-level pre-validation. If the onboarding pipeline can pass structured {data, validation} envelopes, script validation context could be enriched.

🤖 Generated by Spektrum integration onboarding pipeline