### PR TITLE
feat: add DNSFilter transformations (networksecurity)

### DIFF
--- a/safeguards/networksecurity/dnsfilter/isDNSLoggingEnabled.py
+++ b/safeguards/networksecurity/dnsfilter/isDNSLoggingEnabled.py
@@ -1,9 +1,4 @@
-"""
-Transformation: isDNSLoggingEnabled
-Criterion: DNS-2.4 [Recommended]: DNS Query Logging Enabled
-Vendor: DNSFilter
-Category: Network Security
-"""
+"""Transformation: isDNSLoggingEnabled — DNS query logging active check for DNSFilter."""
 import json
 from datetime import datetime
 
@@ -77,74 +72,68 @@ def transform(input):
     data, validation = extract_input(input)
     data = data if isinstance(data, dict) else {}
 
-    org_data = data.get("data") or {}
-    org_data = org_data if isinstance(org_data, dict) else {}
-    attributes = org_data.get("attributes") or {}
-    attributes = attributes if isinstance(attributes, dict) else {}
+    inner = data.get("data") or {}
+    inner = inner if isinstance(inner, dict) else {}
 
-    org_name = attributes.get("name") or "Unknown"
-    privacy_mode = attributes.get("privacy_mode") or ""
-    msp_privacy_mode = attributes.get("msp_privacy_mode") or ""
+    values = inner.get("values") or []
+    values = values if isinstance(values, list) else []
 
-    # Determine effective privacy mode.
-    # "inherit" means the org defers to the MSP-level setting.
-    # "standard" means full DNS query logging is active.
-    # Other modes ("private", "anonymized", etc.) restrict log visibility.
-    if privacy_mode == "inherit":
-        effective_mode = msp_privacy_mode if msp_privacy_mode else "unknown"
-        mode_source = "msp_privacy_mode (inherited from MSP)"
-    else:
-        effective_mode = privacy_mode if privacy_mode else "unknown"
-        mode_source = "privacy_mode"
+    page = inner.get("page") or {}
+    page = page if isinstance(page, dict) else {}
 
-    logging_enabled = effective_mode == "standard"
+    total_logs = page.get("total")
+    if total_logs is None:
+        total_logs = 0
+    try:
+        total_logs = int(total_logs)
+    except (TypeError, ValueError):
+        total_logs = 0
 
-    input_summary = {
-        "organizationName": org_name,
-        "privacyMode": privacy_mode,
-        "mspPrivacyMode": msp_privacy_mode,
-        "effectiveMode": effective_mode,
-        "modeSource": mode_source,
-    }
+    org_name = inner.get("organization_name") or "unknown"
+    sample_count = len(values)
+
+    logging_enabled = total_logs > 0 or sample_count > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
 
     if logging_enabled:
-        pass_reasons = [
-            f"DNS query logging is enabled for organization '{org_name}'. "
-            f"The effective privacy mode is 'standard' (sourced from {mode_source}), "
-            f"indicating full DNS query logging is active and available for audit and threat analysis."
-        ]
-        if privacy_mode == "inherit":
-            pass_reasons.append(
-                f"Organization privacy_mode is 'inherit'; the MSP-level msp_privacy_mode is "
-                f"'standard', so full logging applies to this organization."
-            )
-        fail_reasons = []
-        recommendations = []
+        pass_reasons.append(
+            f"DNS query logging is active for organization '{org_name}': "
+            f"{total_logs} total log entries recorded (page.total={total_logs}, "
+            f"current page contains {sample_count} entries). "
+            "A non-zero log count confirms that DNS queries are being captured and stored."
+        )
     else:
-        fail_reasons = [
-            f"DNS query logging is not fully enabled for organization '{org_name}'. "
-            f"The effective privacy mode is '{effective_mode}' (sourced from {mode_source}), "
-            f"which restricts DNS query log data visibility."
-        ]
-        pass_reasons = []
-        recommendations = [
-            f"Set the organization's privacy_mode (or the MSP-level msp_privacy_mode if using "
-            f"'inherit') to 'standard' to enable full DNS query logging for audit and threat analysis."
-        ]
+        fail_reasons.append(
+            f"No DNS query log entries found for organization '{org_name}' "
+            f"(page.total={total_logs}, values returned={sample_count}). "
+            "The getQueryLogs endpoint returned an empty result set, indicating "
+            "that DNS query logging may not be active or no queries have been processed."
+        )
+        recommendations.append(
+            "Verify that the DNSFilter deployment is actively routing DNS traffic "
+            "for this organization. Ensure at least one network, site, or roaming client "
+            "is connected and generating DNS queries through DNSFilter."
+        )
 
     return create_response(
         result={
             "isDNSLoggingEnabled": logging_enabled,
+            "totalLogEntries": total_logs,
+            "currentPageEntries": sample_count,
             "organizationName": org_name,
-            "privacyMode": privacy_mode,
-            "mspPrivacyMode": msp_privacy_mode,
-            "effectivePrivacyMode": effective_mode,
         },
         validation=validation,
         pass_reasons=pass_reasons,
         fail_reasons=fail_reasons,
         recommendations=recommendations,
-        input_summary=input_summary,
+        input_summary={
+            "totalLogEntries": total_logs,
+            "currentPageEntries": sample_count,
+            "organizationName": org_name,
+        },
         metadata={
             "transformationId": "isDNSLoggingEnabled",
             "vendor": "DNSFilter",

--- a/safeguards/networksecurity/dnsfilter/schemas/__init__.py
+++ b/safeguards/networksecurity/dnsfilter/schemas/__init__.py
@@ -2,9 +2,12 @@
 
 from .confirmedlicensepurchased import ConfirmedlicensepurchasedInput
 from
+from
 from .isDNSLoggingEnabled import IsDNSLoggingEnabledInput
 from .isdnspolicyconfigured import IsdnspolicyconfiguredInput
 from
+
+__all__
 
 __all__ = [
     "ConfirmedlicensepurchasedInput",

--- a/safeguards/networksecurity/dnsfilter/schemas/isDNSLoggingEnabled.py
+++ b/safeguards/networksecurity/dnsfilter/schemas/isDNSLoggingEnabled.py
@@ -1,12 +1,14 @@
 from pydantic import BaseModel
-from typing import Optional, List, Any
+from typing import Any, Dict, List, Optional
 
 
 class IsDNSLoggingEnabledInput(BaseModel):
     """Input schema for the isDNSLoggingEnabled transformation.
 
-    Expects the DNSFilter getOrganization API response containing the
-    organization attributes with privacy_mode and msp_privacy_mode fields.
+    Accepts the DNSFilter getQueryLogs response envelope. The key fields are:
+    - data.values: list of DNS query log entries for the current page
+    - data.page.total: aggregate count of all log entries across all pages
+    - data.organization_name: name of the organization being evaluated
     """
 
     class Config:


### PR DESCRIPTION
## Integration Onboarding — DNSFilter (Network Security)

Auto-generated **transformation modules** for **DNSFilter** (Network Security), produced by the V2 onboarding pipeline.

### Run summary

| Metric | Value |
| --- | --- |
| Shipped | 1 / 2 criteria |
| Dropped at live validation | 0 |
| Unroutable (no API surface) | 0 |
| Duration | 4m 32s |

### Authentication

| Field | Value |
| --- | --- |
| Scheme | apiKey |
| Header | Authorization |
| Prefix | `Bearer` |
| Token setting key | `apiKey` |

### Methods catalogue

| Method | Endpoint | Serves criteria |
| --- | --- | --- |
| `getQueryLogs` | `GET` https://api.dnsfilter.com/v1/traffic_reports/query_logs | `isDNSLoggingEnabled` |
| `getOrganization` | `GET` https://api.dnsfilter.com/v1/organizations/{$organizationId} | `isDNSLoggingEnabled` |

### Per-criterion outcome

| Criterion | Method | Live val | Outcome |
| --- | --- | --- | --- |
| `isDNSLoggingEnabled` | `getQueryLogs` | passed (HTTP 200) | shipped |

### Audit

**Receipt ID:** `2b06c518-ace1-459c-9e08-8113d3581d74`  
**Phase-1 web searches:** 8  
**Tokens (in/out):** 7,136 / 15,240

---
*Auto-generated by Token Service V2 onboarding pipeline.*