### PR TITLE
fix(Fusion): [Resilience/Demo] AWS Cloud Security CIScompliancePercenta…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "enabledPlugins": [
+    "shared@spektrum",
+    "engineering@spektrum",
+    "spektrum-platform@spektrum"
+  ],
+  "marketplaces": {
+    "spektrum": {
+      "path": "/opt/spektrum-skills"
+    }
+  },
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "deny": [
+      "Read(./.env*)",
+      "Read(./**/secrets/**)",
+      "Edit(./.github/**)",
+      "Edit(./infra/**)",
+      "Bash(git push:*)",
+      "Bash(git push --force:*)",
+      "Bash(rm -rf:*)"
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,23 @@
+{
+  "mcpServers": {
+    "atlassian": {
+      "type": "http",
+      "url": "https://mcp.atlassian.com/v1/sse",
+      "headers": {
+        "Authorization": "Bearer ${ATLASSIAN_OAUTH_TOKEN}"
+      }
+    },
+    "spektrum": {
+      "command": "spektrum-debug",
+      "args": [
+        "serve",
+        "--profile",
+        "${SPEKTRUM_PROFILE:-dev}"
+      ],
+      "env": {
+        "SPEKTRUM_CLIENT_ID": "${SPEKTRUM_CLIENT_ID}",
+        "SPEKTRUM_CLIENT_SECRET": "${SPEKTRUM_CLIENT_SECRET}"
+      }
+    }
+  }
+}

--- a/JIRA_BRIEF.md
+++ b/JIRA_BRIEF.md
@@ -1,0 +1,681 @@
+# LABS-2842: [Resilience/Demo] AWS Cloud Security CIScompliancePercentage transform counts SUPPRESSED Security Hub findings (returns ~95.0% instead of 100%)
+
+- **Type:** Bug
+- **Status:** To Do
+- **Priority:** High
+- **Reporter:** josh.brown@spektrum.ai
+- **Labels:** (none)
+- **Components:** Fusion
+- **Repo hints:** standards/cis-aws-foundations-benchmark, inflates/weights, spektrum-labs/transformations, subnet/detail, checks/industry
+
+## Description
+
+h2. Summary
+In the new Resilience workflows (demo environment), the AWS Cloud Security safeguard reports an incorrect CIScompliancePercentage. The transform counts a SUPPRESSED Security Hub finding as a failure. AWS Security Hub's own security score excludes suppressed findings, so the value should be 100% but the platform shows ~95.0%.
+h2. Environment
+Resilience workflows — demo environment
+Safeguard: AWS Cloud Security (Security Hub integration)
+Config: {{configurations/cloudsecurity/awssecurityhub.json}}
+AWS account in payload: 401656386916, region us-east-1
+h2. Root cause (confirmed in config)
+The {{CIScompliancePercentage}} criteriaKey maps to method {{getSecurityHubComplianceCIS}} ({{awssecurityhub.json}} lines 48-53 / 176-222). Its Security Hub filter is:
+{{RecordState = ACTIVE}}
+{{ComplianceStatus IN (PASSED, FAILED)}}
+{{ComplianceAssociatedStandardsId = standards/cis-aws-foundations-benchmark/v/1.4.0}}
+It does NOT filter on {{Workflow.Status}}. As a result, findings with {{Workflow.Status = SUPPRESSED}} are pulled into the dataset and counted by the shared {{compliancepercentage.py}} transform, even though AWS excludes suppressed findings from compliance scoring.
+h2. Evidence from the sample payload (20 CIS findings)
+19 PASSED, 1 FAILED.
+The single FAILED finding is IAM.6 — "Hardware MFA should be enabled for the root user" (CRITICAL) — with {{"Workflow": { "Status": "SUPPRESSED" }}} and {{RecordState: ACTIVE}}.
+Naive count: 19 / 20 = 95.0% (what the platform shows).
+Suppressed-excluded: 19 / 19 = 100% (what AWS Security Hub shows, and what we should report).
+h2. Steps to reproduce
+Connect the demo AWS account (401656386916) Security Hub integration in Resilience workflows.
+Run the AWS Cloud Security safeguard evaluation.
+Observe {{CIScompliancePercentage}} renders ~95.0% while the AWS Security Hub console CIS v1.4.0 score reads 100% (the only failing control, IAM.6, is suppressed).
+h2. Expected vs actual
+Expected: CIScompliancePercentage = 100% (suppressed findings excluded, matching AWS scoring).
+Actual: ~95.0% (suppressed CRITICAL IAM.6 failure counted against the score).
+h2. Suggested fix
+Primary — exclude suppressed findings. Either:
+Add a {{WorkflowStatus}} filter to {{getSecurityHubComplianceCIS}} (and {{getSecurityHubComplianceAWS}}) for NEW / NOTIFIED / RESOLVED (i.e. exclude SUPPRESSED), or
+Drop findings where {{Workflow.Status == SUPPRESSED}} inside {{compliancepercentage.py}}.
+Secondary issues to check while in here:
+{{compliancePercentage}} (FSBP) and {{CIScompliancePercentage}} (CIS) point to the 
+same
+ {{compliancepercentage.py}} transform (lines 45 & 51). Confirm the shared logic handles both standards correctly and isn't conflating them.
+No per-control dedup.
+ The payload has resource-level duplicates for the same control (S3.5 ×4, RDS.3 ×2). CIS scoring is per-control (a control passes only if all its resources pass); counting per-finding inflates/weights the denominator. Confirm the transform dedupes by {{Compliance.SecurityControlId}}.
+Consider whether {{ComplianceStatus}} should also exclude {{WARNING}} / {{NOT_AVAILABLE}} (e.g. EC2.21 PASSED via {{CONFIG_EVALUATIONS_EMPTY}} — no resources in scope; verify these shouldn't skew results).
+h2. Raw findings payload
+Attached as a comment on this ticket.
+h2. Transform reference
+{{https://github.com/spektrum-labs/Transformations/blob/main/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py}}
+Repo: spektrum-labs/Transformations
+
+## Comments (recent)
+### josh.brown@spektrum.ai — 2026-06-02T15:11:01.530+0000
+Raw AWS Security Hub findings payload from the demo environment (account 401656386916, us-east-1). 20 findings total: 19 PASSED, 1 FAILED. The single FAILED finding (IAM.6, CRITICAL) has Workflow.Status = SUPPRESSED. Verbose non-diagnostic metadata (Remediation URLs, ProductFields, full RDS subnet/detail blocks) condensed to fit the Jira comment size limit; byte-exact full payload available on request.
+{
+  "apiResponse": {
+    "Findings": [
+      {
+        "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/securityhub",
+        "Types": [
+          "Software and Configuration Checks/Industry and Regulatory Standards"
+        ],
+        "Description": "This AWS control checks whether your AWS account is enabled to use a hardware multi-factor authentication (MFA) device to sign in with root user credentials.",
+        "Compliance": {
+          "Status": "FAILED",
+          "SecurityControlId": "IAM.6",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/1.6"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "ProductName": "Security Hub",
+        "FirstObservedAt": "2023-06-21T06:04:20.956Z",
+        "CreatedAt": "2023-06-21T06:04:20.956Z",
+        "LastObservedAt": "2026-06-01T18:48:51.456Z",
+        "CompanyName": "AWS",
+        "FindingProviderFields": {
+          "Types": [
+            "Software and Configuration Checks/Industry and Regulatory Standards"
+          ],
+          "Severity": {
+            "Normalized": 90,
+            "Label": "CRITICAL",
+            "Original": "CRITICAL"
+          }
+        },
+        "ProductFields": {
+          "RelatedAWSResources:0/name": "securityhub-root-account-hardware-mfa-enabled-a5e95840",
+          "RelatedAWSResources:0/type": "AWS::Config::ConfigRule",
+          "aws/securityhub/ProductName": "Security Hub",
+          "aws/securityhub/CompanyName": "AWS",
+          "Resources:0/Id": "arn:aws:iam::401656386916:root",
+          "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1::product/aws/securityhub/arn:aws:securityhub:us-east-1:401656386916:security-control/IAM.6/finding/8c32d4d0-588c-448f-84b1-2d47598a6053",
+          "PreviousComplianceStatus": "FAILED"
+        },
+        "Remediation": {
+          "Recommendation": {
+            "Text": "For information on how to correct this issue, consult the AWS Security Hub controls documentation.",
+            "Url": "https://docs.aws.amazon.com/console/securityhub/IAM.6/remediation"
+          }
+        },
+        "SchemaVersion": "2018-10-08",
+        "GeneratorId": "security-control/IAM.6",
+        "RecordState": "ACTIVE",
+        "Title": "Hardware MFA should be enabled for the root user",
+        "Workflow": {
+          "Status": "SUPPRESSED"
+        },
+        "Severity": {
+          "Normalized": 90,
+          "Label": "CRITICAL",
+          "Original": "CRITICAL"
+        },
+        "UpdatedAt": "2026-06-01T18:50:06.012Z",
+        "WorkflowState": "NEW",
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/IAM.6/finding/8c32d4d0-588c-448f-84b1-2d47598a6053",
+        "Resources": [
+          {
+            "Partition": "aws",
+            "Type": "AwsAccount",
+            "Owner": {
+              "Account": {
+                "Id": "401656386916"
+              }
+            },
+            "Region": "us-east-1",
+            "Id": "AWS::::Account:401656386916",
+            "Provider": "AWS"
+          }
+        ],
+        "ProcessedAt": "2026-06-01T18:50:18.378Z"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "StatusReasons": [
+            {
+              "Description": "AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted.",
+              "ReasonCode": "CONFIG_EVALUATIONS_EMPTY"
+            }
+          ],
+          "SecurityControlId": "EC2.21",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/5.1"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Network ACLs should not allow ingress from 0.0.0.0/0 to port 22 or port 3389",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/EC2.21/finding/5b062199-3765-47cd-9175-c69a2f7bb2d7"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "Config.1",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/3.5"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ],
+          "SecurityControlParameters": [
+            {
+              "Value": [
+                "true"
+              ],
+              "Name": "includeConfigServiceLinkedRoleCheck"
+            }
+          ]
+        },
+        "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/Config.1/finding/cd663ff8-c6c0-49f8-aff2-9c0ffacf6086"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.9",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.9"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for AWS Config configuration changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.9/finding/53ea1eff-71e6-4d07-8fc4-85424e143a5c"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.8",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.8"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for S3 bucket policy changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.8/finding/4210f544-cef9-4e21-8b15-4aa153f3f804"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.7",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.7"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.7/finding/0859a9a2-53b9-472c-a08c-23e5b472f795"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.6",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.6"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for AWS Management Console authentication failures",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.6/finding/12edeaa0-649c-4c10-8672-e7b9c8ebcb3b"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.5"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for CloudTrail configuration changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.5/finding/e4a7b351-90d2-412e-8096-8a59da6b3ce5"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.4",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.4"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for IAM policy changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.4/finding/df2932e1-6152-4ba4-a78e-73c349f0ea84"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.14",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.14"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for VPC changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.14/finding/0ccda245-629b-43a4-b06a-f1cd51a79b31"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.13",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.13"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for route table changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.13/finding/e2131a2e-7c4e-44d8-aa5c-475f5541f705"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.12",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.12"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for changes to network gateways",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.12/finding/1e0e3252-1e7d-47b4-b15c-1054bad24413"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.11",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.11"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL)",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.11/finding/d078bf5d-ef3c-43cf-9e70-aa3f04d0005d"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.1",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/1.7",
+            "CIS AWS Foundations Benchmark v1.4.0/4.3"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "A log metric filter and alarm should exist for usage of the \"root\" user",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.1/finding/a99f3f0b-9dfd-40c9-98e3-b592f2bff206"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "RDS.3",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.3.1"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "RDS DB instances should have encryption at-rest enabled",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/RDS.3/finding/6f8be423-1e1a-4700-b891-4b983ef904de",
+        "Resources": [
+          {
+            "Type": "AwsRdsDbInstance",
+            "Id": "arn:aws:rds:us-east-1:401656386916:db:horizon-production",
+            "Details": {
+              "AwsRdsDbInstance": {
+                "StorageEncrypted": true,
+                "DBInstanceIdentifier": "horizon-production",
+                "Engine": "sqlserver-se",
+                "MultiAz": true
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "RDS.3",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.3.1"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "RDS DB instances should have encryption at-rest enabled",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/RDS.3/finding/748fbb09-000e-48cb-b417-96676d25840d",
+        "Resources": [
+          {
+            "Type": "AwsRdsDbInstance",
+            "Id": "arn:aws:rds:us-east-1:401656386916:db:horizon-db-restore",
+            "Details": {
+              "AwsRdsDbInstance": {
+                "StorageEncrypted": true,
+                "DBInstanceIdentifier": "horizon-db-restore",
+                "Engine": "sqlserver-se",
+                "MultiAz": false
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/5f42be24-a3af-4e84-9425-63f54643dff1",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::spektrum-underwriter-report"
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/db281411-3de5-4071-b3b0-a0b3f10723a5",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::testfors3horizon"
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/9915f2a0-0e5b-4b6c-9dfb-0c306b3d4157",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::spektrum-config"
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/e72b3893-37a0-4490-a3d1-9e46b9f0263c",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::spektrum-datadog-forwarder-product-forwarderbucket-vppm0322pjqr"
+          }
+        ]
+      }
+    ],
+    "NextToken": "U2FsdGVkX1+XE2xsEP/ruNGEEeGOJjfz45pqBwUpvT+...(truncated)"
+  }
+}

--- a/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py
+++ b/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py
@@ -66,6 +66,66 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
     }
 
 
+# AWS Security Hub associated-standard identifiers used to scope each score.
+CIS_STANDARD = "cis-aws-foundations-benchmark"
+FSBP_STANDARD = "aws-foundational-security-best-practices"
+
+
+def _is_suppressed(finding):
+    """True when a Security Hub finding is suppressed (excluded from AWS scoring)."""
+    if not isinstance(finding, dict):
+        return False
+    workflow = finding.get("Workflow")
+    if isinstance(workflow, dict):
+        return str(workflow.get("Status", "")).upper() == "SUPPRESSED"
+    return False
+
+
+def _matches_standard(finding, standard):
+    """Whether a finding is associated with the given standard.
+
+    Returns True/False when the finding carries AssociatedStandards, or None
+    when the finding has no standard association (so callers can fall back to
+    legacy, standard-agnostic behaviour for non-Security-Hub inputs).
+    """
+    compliance = finding.get("Compliance") if isinstance(finding, dict) else None
+    if not isinstance(compliance, dict):
+        return None
+    standards = compliance.get("AssociatedStandards") or []
+    ids = [str(s.get("StandardsId")) for s in standards
+           if isinstance(s, dict) and s.get("StandardsId")]
+    if not ids:
+        return None
+    return any(standard in sid for sid in ids)
+
+
+def _score_by_control(findings):
+    """Score findings per security control (CIS/FSBP scoring is per-control).
+
+    Resource-level duplicates of the same control collapse to one result; a
+    control passes only if all of its findings pass. Only PASSED/FAILED
+    findings count toward the score (WARNING/NOT_AVAILABLE are ignored, matching
+    AWS Security Hub).
+    """
+    control_passed = {}
+    for obj in findings:
+        compliance = obj.get("Compliance") if isinstance(obj, dict) else None
+        if not isinstance(compliance, dict) or "Status" not in compliance:
+            continue
+        status = str(compliance["Status"]).lower()
+        if status not in ("passed", "failed"):
+            continue
+        control_id = compliance.get("SecurityControlId") or obj.get("Id") or id(obj)
+        passed = status == "passed"
+        control_passed[control_id] = control_passed.get(control_id, True) and passed
+
+    passed_count = sum(1 for ok in control_passed.values() if ok)
+    failed_count = len(control_passed) - passed_count
+    total = len(control_passed)
+    percentage = int((passed_count / total) * 100) if total > 0 else 0
+    return percentage, passed_count, failed_count, total
+
+
 def transform(input):
     try:
         if isinstance(input, str):
@@ -93,38 +153,49 @@ def transform(input):
         elif isinstance(data, list):
             findings = data
 
-        passed = [obj for obj in findings if 'Compliance' in obj and 'Status' in obj['Compliance'] and str(obj['Compliance']['Status']).lower() == "passed"]
-        failed = [obj for obj in findings if 'Compliance' in obj and 'Status' in obj['Compliance'] and str(obj['Compliance']['Status']).lower() == "failed"]
+        # Exclude suppressed findings — AWS Security Hub omits them from its
+        # security score, so the IAM.6 (SUPPRESSED) failure should not count.
+        active = [obj for obj in findings if not _is_suppressed(obj)]
 
-        total = len(passed) + len(failed)
-        compliance_percentage = int((len(passed) / total) * 100) if total > 0 else 0
+        # Scope each score to its own standard so the CIS and FSBP keys are not
+        # conflated. Findings without an AssociatedStandards block (non Security
+        # Hub inputs) fall back to legacy, standard-agnostic scoring.
+        cis_findings = [obj for obj in active if _matches_standard(obj, CIS_STANDARD)]
+        fsbp_findings = [obj for obj in active if _matches_standard(obj, FSBP_STANDARD)]
+        if not cis_findings and not fsbp_findings:
+            cis_findings = active
+            fsbp_findings = active
 
-        if compliance_percentage >= 80:
-            pass_reasons.append(f"Good compliance level: {compliance_percentage}% ({len(passed)} passed, {len(failed)} failed)")
-        elif compliance_percentage >= 50:
-            fail_reasons.append(f"Moderate compliance level: {compliance_percentage}%")
+        cis_percentage, cis_passed, cis_failed, cis_total = _score_by_control(cis_findings)
+        fsbp_percentage, _, _, _ = _score_by_control(fsbp_findings)
+
+        if cis_percentage >= 80:
+            pass_reasons.append(f"Good compliance level: {cis_percentage}% ({cis_passed} passed, {cis_failed} failed)")
+        elif cis_percentage >= 50:
+            fail_reasons.append(f"Moderate compliance level: {cis_percentage}%")
             recommendations.append("Address failed compliance findings to improve security posture")
         else:
-            fail_reasons.append(f"Low compliance level: {compliance_percentage}%")
+            fail_reasons.append(f"Low compliance level: {cis_percentage}%")
             recommendations.append("Urgently address compliance failures to meet security requirements")
 
         return create_response(
             result={
-                "compliancePercentage": compliance_percentage,
-                "CIScompliancePercentage": compliance_percentage,
-                "totalPassed": len(passed),
-                "totalFailed": len(failed),
-                "totalFindings": total
+                "compliancePercentage": fsbp_percentage,
+                "CIScompliancePercentage": cis_percentage,
+                "totalPassed": cis_passed,
+                "totalFailed": cis_failed,
+                "totalFindings": cis_total
             },
             validation=validation,
             pass_reasons=pass_reasons,
             fail_reasons=fail_reasons,
             recommendations=recommendations,
             input_summary={
-                "compliancePercentage": compliance_percentage,
-                "totalPassed": len(passed),
-                "totalFailed": len(failed),
-                "totalFindings": total
+                "compliancePercentage": fsbp_percentage,
+                "CIScompliancePercentage": cis_percentage,
+                "totalPassed": cis_passed,
+                "totalFailed": cis_failed,
+                "totalFindings": cis_total
             }
         )
 

--- a/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/sample_response.json
+++ b/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/sample_response.json
@@ -1,0 +1,624 @@
+{
+  "apiResponse": {
+    "Findings": [
+      {
+        "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/securityhub",
+        "Types": [
+          "Software and Configuration Checks/Industry and Regulatory Standards"
+        ],
+        "Description": "This AWS control checks whether your AWS account is enabled to use a hardware multi-factor authentication (MFA) device to sign in with root user credentials.",
+        "Compliance": {
+          "Status": "FAILED",
+          "SecurityControlId": "IAM.6",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/1.6"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "ProductName": "Security Hub",
+        "FirstObservedAt": "2023-06-21T06:04:20.956Z",
+        "CreatedAt": "2023-06-21T06:04:20.956Z",
+        "LastObservedAt": "2026-06-01T18:48:51.456Z",
+        "CompanyName": "AWS",
+        "FindingProviderFields": {
+          "Types": [
+            "Software and Configuration Checks/Industry and Regulatory Standards"
+          ],
+          "Severity": {
+            "Normalized": 90,
+            "Label": "CRITICAL",
+            "Original": "CRITICAL"
+          }
+        },
+        "ProductFields": {
+          "RelatedAWSResources:0/name": "securityhub-root-account-hardware-mfa-enabled-a5e95840",
+          "RelatedAWSResources:0/type": "AWS::Config::ConfigRule",
+          "aws/securityhub/ProductName": "Security Hub",
+          "aws/securityhub/CompanyName": "AWS",
+          "Resources:0/Id": "arn:aws:iam::401656386916:root",
+          "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1::product/aws/securityhub/arn:aws:securityhub:us-east-1:401656386916:security-control/IAM.6/finding/8c32d4d0-588c-448f-84b1-2d47598a6053",
+          "PreviousComplianceStatus": "FAILED"
+        },
+        "Remediation": {
+          "Recommendation": {
+            "Text": "For information on how to correct this issue, consult the AWS Security Hub controls documentation.",
+            "Url": "https://docs.aws.amazon.com/console/securityhub/IAM.6/remediation"
+          }
+        },
+        "SchemaVersion": "2018-10-08",
+        "GeneratorId": "security-control/IAM.6",
+        "RecordState": "ACTIVE",
+        "Title": "Hardware MFA should be enabled for the root user",
+        "Workflow": {
+          "Status": "SUPPRESSED"
+        },
+        "Severity": {
+          "Normalized": 90,
+          "Label": "CRITICAL",
+          "Original": "CRITICAL"
+        },
+        "UpdatedAt": "2026-06-01T18:50:06.012Z",
+        "WorkflowState": "NEW",
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/IAM.6/finding/8c32d4d0-588c-448f-84b1-2d47598a6053",
+        "Resources": [
+          {
+            "Partition": "aws",
+            "Type": "AwsAccount",
+            "Owner": {
+              "Account": {
+                "Id": "401656386916"
+              }
+            },
+            "Region": "us-east-1",
+            "Id": "AWS::::Account:401656386916",
+            "Provider": "AWS"
+          }
+        ],
+        "ProcessedAt": "2026-06-01T18:50:18.378Z"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "StatusReasons": [
+            {
+              "Description": "AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted.",
+              "ReasonCode": "CONFIG_EVALUATIONS_EMPTY"
+            }
+          ],
+          "SecurityControlId": "EC2.21",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/5.1"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Network ACLs should not allow ingress from 0.0.0.0/0 to port 22 or port 3389",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/EC2.21/finding/5b062199-3765-47cd-9175-c69a2f7bb2d7"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "Config.1",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/3.5"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ],
+          "SecurityControlParameters": [
+            {
+              "Value": [
+                "true"
+              ],
+              "Name": "includeConfigServiceLinkedRoleCheck"
+            }
+          ]
+        },
+        "Title": "AWS Config should be enabled and use the service-linked role for resource recording",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/Config.1/finding/cd663ff8-c6c0-49f8-aff2-9c0ffacf6086"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.9",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.9"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for AWS Config configuration changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.9/finding/53ea1eff-71e6-4d07-8fc4-85424e143a5c"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.8",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.8"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for S3 bucket policy changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.8/finding/4210f544-cef9-4e21-8b15-4aa153f3f804"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.7",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.7"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.7/finding/0859a9a2-53b9-472c-a08c-23e5b472f795"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.6",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.6"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for AWS Management Console authentication failures",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.6/finding/12edeaa0-649c-4c10-8672-e7b9c8ebcb3b"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.5"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for CloudTrail configuration changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.5/finding/e4a7b351-90d2-412e-8096-8a59da6b3ce5"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.4",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.4"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for IAM policy changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.4/finding/df2932e1-6152-4ba4-a78e-73c349f0ea84"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.14",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.14"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for VPC changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.14/finding/0ccda245-629b-43a4-b06a-f1cd51a79b31"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.13",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.13"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for route table changes",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.13/finding/e2131a2e-7c4e-44d8-aa5c-475f5541f705"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.12",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.12"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for changes to network gateways",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.12/finding/1e0e3252-1e7d-47b4-b15c-1054bad24413"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.11",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/4.11"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL)",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.11/finding/d078bf5d-ef3c-43cf-9e70-aa3f04d0005d"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "CloudWatch.1",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/1.7",
+            "CIS AWS Foundations Benchmark v1.4.0/4.3"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "A log metric filter and alarm should exist for usage of the \"root\" user",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/CloudWatch.1/finding/a99f3f0b-9dfd-40c9-98e3-b592f2bff206"
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "RDS.3",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.3.1"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "RDS DB instances should have encryption at-rest enabled",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/RDS.3/finding/6f8be423-1e1a-4700-b891-4b983ef904de",
+        "Resources": [
+          {
+            "Type": "AwsRdsDbInstance",
+            "Id": "arn:aws:rds:us-east-1:401656386916:db:horizon-production",
+            "Details": {
+              "AwsRdsDbInstance": {
+                "StorageEncrypted": true,
+                "DBInstanceIdentifier": "horizon-production",
+                "Engine": "sqlserver-se",
+                "MultiAz": true
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "RDS.3",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.3.1"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "RDS DB instances should have encryption at-rest enabled",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "AwsAccountId": "401656386916",
+        "Region": "us-east-1",
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/RDS.3/finding/748fbb09-000e-48cb-b417-96676d25840d",
+        "Resources": [
+          {
+            "Type": "AwsRdsDbInstance",
+            "Id": "arn:aws:rds:us-east-1:401656386916:db:horizon-db-restore",
+            "Details": {
+              "AwsRdsDbInstance": {
+                "StorageEncrypted": true,
+                "DBInstanceIdentifier": "horizon-db-restore",
+                "Engine": "sqlserver-se",
+                "MultiAz": false
+              }
+            }
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/5f42be24-a3af-4e84-9425-63f54643dff1",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::spektrum-underwriter-report"
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/db281411-3de5-4071-b3b0-a0b3f10723a5",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::testfors3horizon"
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/9915f2a0-0e5b-4b6c-9dfb-0c306b3d4157",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::spektrum-config"
+          }
+        ]
+      },
+      {
+        "Compliance": {
+          "Status": "PASSED",
+          "SecurityControlId": "S3.5",
+          "RelatedRequirements": [
+            "CIS AWS Foundations Benchmark v1.4.0/2.1.2"
+          ],
+          "AssociatedStandards": [
+            {
+              "StandardsId": "standards/aws-foundational-security-best-practices/v/1.0.0"
+            },
+            {
+              "StandardsId": "standards/cis-aws-foundations-benchmark/v/1.4.0"
+            }
+          ]
+        },
+        "Title": "S3 general purpose buckets should require requests to use SSL",
+        "RecordState": "ACTIVE",
+        "Workflow": {
+          "Status": "RESOLVED"
+        },
+        "Severity": {
+          "Label": "INFORMATIONAL"
+        },
+        "Id": "arn:aws:securityhub:us-east-1:401656386916:security-control/S3.5/finding/e72b3893-37a0-4490-a3d1-9e46b9f0263c",
+        "Resources": [
+          {
+            "Type": "AwsS3Bucket",
+            "Id": "arn:aws:s3:::spektrum-datadog-forwarder-product-forwarderbucket-vppm0322pjqr"
+          }
+        ]
+      }
+    ],
+    "NextToken": "U2FsdGVkX1+XE2xsEP/ruNGEEeGOJjfz45pqBwUpvT+...(truncated)"
+  }
+}

--- a/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/test_compliancepercentage.py
+++ b/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/test_compliancepercentage.py
@@ -1,0 +1,128 @@
+"""Regression tests for the compliancepercentage transformation (LABS-2842).
+
+Plain-python tests (no pytest dependency). Run directly:
+
+    python test_compliancepercentage.py
+
+Covers:
+- Suppressed Security Hub findings are excluded from the score (the bug).
+- Findings are deduped per security control (resource-level duplicates).
+- CIS and FSBP scores are scoped to their own associated standard.
+- Legacy / non Security Hub inputs (no AssociatedStandards) still score.
+"""
+
+import copy
+import importlib.util
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+spec = importlib.util.spec_from_file_location(
+    "compliancepercentage", os.path.join(HERE, "compliancepercentage.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def _result(payload):
+    return mod.transform(payload)["transformedResponse"]
+
+
+def _cis_finding(control_id, status="PASSED", workflow="RESOLVED",
+                 standards=("cis-aws-foundations-benchmark/v/1.4.0",), finding_id=None):
+    return {
+        "Compliance": {
+            "Status": status,
+            "SecurityControlId": control_id,
+            "AssociatedStandards": [{"StandardsId": "standards/" + s} for s in standards],
+        },
+        "RecordState": "ACTIVE",
+        "Workflow": {"Status": workflow},
+        "Id": finding_id or f"finding/{control_id}/{status}/{workflow}",
+    }
+
+
+def test_sample_payload_excludes_suppressed():
+    """The ticket payload should report 100% — IAM.6 FAILED is SUPPRESSED."""
+    with open(os.path.join(HERE, "sample_response.json")) as f:
+        payload = json.load(f)
+    res = _result(payload)
+    assert res["CIScompliancePercentage"] == 100, res
+    assert res["compliancePercentage"] == 100, res
+    # 20 findings -> IAM.6 suppressed dropped, S3.5 (x4) + RDS.3 (x2) deduped.
+    assert res["totalFailed"] == 0, res
+    assert res["totalFindings"] == 15, res
+
+
+def test_unsuppressed_failure_counts():
+    """A genuine (non-suppressed) failed control must lower the score."""
+    findings = [
+        _cis_finding("IAM.6", status="FAILED", workflow="NEW"),
+        _cis_finding("Config.1", status="PASSED"),
+        _cis_finding("S3.5", status="PASSED"),
+        _cis_finding("RDS.3", status="PASSED"),
+    ]
+    res = _result({"Findings": findings})
+    assert res["CIScompliancePercentage"] == 75, res
+    assert res["totalFailed"] == 1, res
+    assert res["totalFindings"] == 4, res
+
+
+def test_dedup_per_control_failure():
+    """A control fails if any of its resource findings fail; duplicates collapse."""
+    findings = [
+        _cis_finding("S3.5", status="PASSED", finding_id="a"),
+        _cis_finding("S3.5", status="FAILED", finding_id="b"),  # one resource fails
+        _cis_finding("Config.1", status="PASSED"),
+    ]
+    res = _result({"Findings": findings})
+    # Two controls: S3.5 (fails) and Config.1 (passes) -> 50%.
+    assert res["CIScompliancePercentage"] == 50, res
+    assert res["totalFindings"] == 2, res
+
+
+def test_cis_and_fsbp_scored_independently():
+    """CIS and FSBP keys must reflect their own standard, not be aliases."""
+    findings = [
+        # CIS-only control that fails -> drags CIS down, not FSBP.
+        _cis_finding("IAM.6", status="FAILED", workflow="NEW",
+                     standards=("cis-aws-foundations-benchmark/v/1.4.0",)),
+        # FSBP-only control that passes.
+        _cis_finding("EC2.1", status="PASSED",
+                     standards=("aws-foundational-security-best-practices/v/1.0.0",)),
+    ]
+    res = _result({"Findings": findings})
+    assert res["CIScompliancePercentage"] == 0, res
+    assert res["compliancePercentage"] == 100, res
+
+
+def test_legacy_input_without_standards():
+    """Inputs lacking AssociatedStandards fall back to standard-agnostic scoring."""
+    findings = [
+        {"Compliance": {"Status": "PASSED", "SecurityControlId": "X.1"}},
+        {"Compliance": {"Status": "FAILED", "SecurityControlId": "X.2"}},
+    ]
+    res = _result({"Findings": findings})
+    assert res["CIScompliancePercentage"] == 50, res
+    assert res["compliancePercentage"] == 50, res
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failures = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL {t.__name__}: {e}")
+        except Exception as e:  # pragma: no cover
+            failures += 1
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    raise SystemExit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- [Resilience/Demo] AWS Cloud Security CIScompliancePercentage transform counts SUPPRESSED Security Hub findings (returns ~95.0% instead of 100%)

## JIRA

Closes [LABS-2842](https://https/browse/LABS-2842)

## Automated agent run

Generated by the JIRA-triggered fix pipeline (`agents/jira-fix-agent/`).

| Stat | Plan phase | Exec phase |
|---|---|---|
| Turns | 7 | 22 |
| Duration | 69s | 163s |
| Cost (USD) | 0.4175 | 1.4685 |
| Exit | 0 | 0 |

**Total:** 238s wall-clock, $1.8861 Anthropic spend, 6 files changed (+91/-20).

### Router decision

Selected plugins: `shared`, `engineering`, `spektrum-platform`.
Target repo: `spektrum-labs/transformations`.

> LABS-2842 is a high-priority bug in AWS Security Hub compliance scoring within the Resilience demo environment. The ticket explicitly references the transformation pipeline (compliancepercentage.py in spektrum-labs/transformations) and the awssecurityhub.json integration config. The fix requires modifying the Security Hub query filter to exclude SUPPRESSED findings and/or updating the transform logic. This is a platform/safeguard transformation issue, not a core product fix. Loading: (1) 'shared' for Spektrum domain knowledge (safeguards, transformations, posture scoring); (2) 'engineering' for JIRA context, PR authoring, and e2e test execution (the fix will need test coverage); (3) 'spektrum-platform' for transformation scaffolding and debugging passport data to validate the fix against the sample payload. No compliance or sales context needed. Target repo is spektrum-labs/transformations (inferred from repoHints and the explicit reference to the transform file path).

<details><summary>Plan phase transcript (23 events)</summary>

| # | Kind | Tool | Detail |
|---|---|---|---|
| 1 | system:init |  | tools=30 mcps=atlassian,spektrum |
| 2 | assistant:text |  | I'll start by reading the JIRA brief and exploring the relevant source files. |
| 3 | assistant:tool_use | Read | file_path=/tmp/spektrum-jira-ydDzfh/transformations/JIRA_BRIEF.md |
| 4 | tool_result |  | 1	# LABS-2842: [Resilience/Demo] AWS Cloud Security CIScompliancePercentage transform counts SUPPRE… |
| 5 | assistant |  | (empty) |
| 6 | assistant:text |  | Now let me explore the relevant source files. |
| 7 | assistant:tool_use | Bash | ls safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/ 2>/dev/null && echo "---" && find . -iname "*compliancepercentage*"… |
| 8 | tool_result |  | compliancepercentage.py schemas --- ./safeguards/asm/qualys/patchcompliancepercentage.py ./safeguar… |
| 9 | assistant:tool_use | Read | file_path=/tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py |
| 10 | tool_result |  | 1	""" 2	Transformation: compliancepercentage 3	Vendor: Cloud Security 4	Category: Cloud Security / … |
| 11 | assistant |  | (empty) |
| 12 | assistant:tool_use | Bash | echo "=== cloudsecurity/awssecurityhub dir ===" && ls -la safeguards/cloudsecurity/awssecurityhub/ 2>/dev/null; echo "=… |
| 13 | tool_result |  | === cloudsecurity/awssecurityhub dir === total 12 drwxr-xr-x 2 agent agent 4096 Jun  3 13:52 . drwx… |
| 14 | assistant |  | (empty) |
| 15 | assistant:tool_use | Read | file_path=/tmp/spektrum-jira-ydDzfh/transformations/local_tester.py |
| 16 | tool_result |  | 1	# Used to test a raw API response against a transformation locally 2	# Replicates the Token-Servi… |
| 17 | assistant |  | (empty) |
| 18 | assistant:text |  | Now I have a complete understanding. Let me check the one file in the cloudsecurity dir and confirm the config JSON isn… |
| 19 | assistant:tool_use | Bash | grep -rl "getSecurityHubComplianceCIS\\|CIScompliancePercentage\\|compliancepercentage" --include=*.py --include=*.json .… |
| 20 | tool_result |  | ./safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py ./safeguards/9b380a34-693… |
| 21 | assistant |  | (empty) |
| 22 | assistant:text |  | The config JSON (`awssecurityhub.json`) referenced in the ticket lives in a separate `configurations` repo not present … |
| 23 | result:success |  | turns=7 duration_ms=68094 is_error=false |

</details>

<details><summary>Exec phase transcript (62 events)</summary>

| # | Kind | Tool | Detail |
|---|---|---|---|
| 1 | system:init |  | tools=30 mcps=atlassian,spektrum |
| 2 | assistant |  | (empty) |
| 3 | assistant:text |  | Let me look at how tests are run and existing test conventions before editing. |
| 4 | assistant:tool_use | Bash | ls -la; echo "=== e2e ==="; find . -iname "*e2e*" -o -iname "*test*" 2>/dev/null \| grep -v node_modules \| grep -v "\.gi… |
| 5 | tool_result |  | total 112 drwxr-xr-x  5 agent agent  4096 Jun  3 13:52 . drwx------  3 agent agent  4096 Jun  3 13:… |
| 6 | assistant |  | (empty) |
| 7 | assistant:tool_use | ToolSearch | {"query":"e2e-runner run transformation tests","max_results":5} |
| 8 | tool_result |  | [{"type":"tool_reference","tool_name":"TaskUpdate"},{"type":"tool_reference","tool_name":"CronCreat… |
| 9 | assistant |  | (empty) |
| 10 | assistant:text |  | The e2e-runner isn't a tool. Let me check the `.claude` directory and repo for it. |
| 11 | assistant:tool_use | Bash | find .claude -type f 2>/dev/null; echo "=== search e2e-runner ==="; grep -rl "e2e-runner\\|e2e_runner" . --include=*.py … |
| 12 | tool_result |  | ERROR Exit code 1 .claude/settings.json === search e2e-runner === === python ver === Python 3.11.2 |
| 13 | assistant:tool_use | Bash | cat .claude/settings.json |
| 14 | tool_result |  | {   "enabledPlugins": [     "shared@spektrum",     "engineering@spektrum",     "spektrum-platform@s… |
| 15 | assistant |  | (empty) |
| 16 | assistant:tool_use | Bash | find /opt/spektrum-skills -maxdepth 4 -iname "*e2e*" 2>/dev/null; echo "==="; ls /opt/spektrum-skills 2>/dev/null; echo… |
| 17 | tool_result |  | === CODEOWNERS docs plugins scripts === skills === /opt/spektrum-skills/plugins/shared/skills/srn-r… |
| 18 | assistant:tool_use | Bash | find /opt/spektrum-skills/plugins -type d \| grep -i "e2e\\|runner\\|test" ; echo "=== all commands/scripts ==="; find /op… |
| 19 | tool_result |  | === all commands/scripts === === grep e2e === /opt/spektrum-skills/docs/PLATFORMS.md /opt/spektrum-… |
| 20 | assistant:tool_use | Bash | grep -n -i "e2e" /opt/spektrum-skills/docs/PLATFORMS.md /opt/spektrum-skills/.claude-plugin/marketplace.json |
| 21 | tool_result |  | /opt/spektrum-skills/docs/PLATFORMS.md:124:5. Opens a draft or ready-for-review PR depending on whe… |
| 22 | assistant:tool_use | Bash | find /opt/spektrum-skills/plugins/engineering -type f \| head -50 |
| 23 | tool_result |  | find: '/opt/spektrum-skills/plugins/engineering': No such file or directory |
| 24 | assistant:tool_use | Bash | ls /opt/spektrum-skills/plugins; echo "==="; cat /opt/spektrum-skills/.claude-plugin/marketplace.json \| python3 -c "imp… |
| 25 | tool_result |  | compliance sales shared spektrum-platform === ["shared", "spektrum-platform", "sales", "compliance"… |
| 26 | assistant |  | (empty) |
| 27 | assistant:text |  | `e2e-runner` belongs to the `engineering` plugin which is declared but not physically installed; the repo's actual test… |
| 28 | assistant:tool_use | Edit | file_path=/tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py |
| 29 | tool_result |  | The file /tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/… |
| 30 | assistant:text |  | Now replace the scoring/return block in `transform`: |
| 31 | assistant:tool_use | Edit | file_path=/tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py |
| 32 | tool_result |  | The file /tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/… |
| 33 | assistant:text |  | Now create the test fixture from the ticket payload and run the local tester: |
| 34 | assistant:tool_use | Bash | python3 - <<'PY' import re, json text = open("JIRA_BRIEF.md").read() # Extract the JSON payload (starts at the first '{… |
| 35 | tool_result |  | findings: 20 |
| 36 | assistant:tool_use | Bash | python3 local_tester.py safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py safeguards/9b380a34-693… |
| 37 | tool_result |  | Traceback (most recent call last):   File "/tmp/spektrum-jira-ydDzfh/transformations/local_tester.p… |
| 38 | assistant |  | (empty) |
| 39 | assistant:tool_use | Bash | pip install requests pydantic -q 2>&1 \| tail -3 \|\| pip3 install requests pydantic -q 2>&1 \| tail -3 |
| 40 | tool_result |  | note: If you believe this is a mistake, please contact your Python installation or OS distribution … |
| 41 | assistant:tool_use | Bash | pip install --break-system-packages -q requests pydantic 2>&1 \| tail -3; python3 -c "import requests, pydantic; print('… |
| 42 | tool_result |  |   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-… |
| 43 | assistant:tool_use | Bash | python3 local_tester.py safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py safeguards/9b380a34-693… |
| 44 | tool_result |  |   "transformedResponse": {     "compliancePercentage": 100,     "CIScompliancePercentage": 100,    … |
| 45 | assistant |  | (empty) |
| 46 | assistant:text |  | Primary fix verified: `CIScompliancePercentage = 100`, deduped to 15 controls, suppressed IAM.6 excluded. Now let me ad… |
| 47 | assistant:tool_use | Bash | python3 -c "import pytest; print('pytest', pytest.__version__)" 2>&1 |
| 48 | tool_result |  | ERROR Exit code 1 Traceback (most recent call last):   File "<string>", line 1, in <module> ModuleNotFoun… |
| 49 | assistant |  | (empty) |
| 50 | assistant:tool_use | Write | file_path=/tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/test_compliancepercentage.py |
| 51 | tool_result |  | File created successfully at: /tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48… |
| 52 | assistant:tool_use | Bash | cd safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3 && python3 test_compliancepercentage.py |
| 53 | tool_result |  | PASS test_cis_and_fsbp_scored_independently PASS test_dedup_per_control_failure PASS test_legacy_in… |
| 54 | assistant:text |  | All 5 tests pass. Let me verify the full diff and confirm no other callers of this transform break (legacy fallback pre… |
| 55 | assistant:tool_use | Bash | cd /tmp/spektrum-jira-ydDzfh/transformations && git status --short && echo "=== diff stat ===" && git diff --stat |
| 56 | tool_result |  |  M safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py ?? .claude/ ?? .mcp.json… |
| 57 | assistant |  | (empty) |
| 58 | assistant:text |  | The change is scoped to the single transform file (+91/−20) plus a new test and sample fixture. Let me do a final revie… |
| 59 | assistant:tool_use | Read | file_path=/tmp/spektrum-jira-ydDzfh/transformations/safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py |
| 60 | tool_result |  | 150	        findings = [] 151	        if isinstance(data, dict) and 'Findings' in data: 152	       … |
| 61 | assistant:text |  | The implementation is complete and verified. Summary of what changed:  **Root cause fixed** — `compliancepercentage.py`… |
| 62 | result:success |  | turns=22 duration_ms=162299 is_error=false |

</details>

<details><summary>Files touched (6)</summary>

- .claude/settings.json
- .mcp.json
- JIRA_BRIEF.md
- safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/sample_response.json
- safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/test_compliancepercentage.py
- safeguards/9b380a34-6933-48e0-8b35-fe30f3bc3db3/compliancepercentage.py

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LABS-2842]: https://spektrumlabs.atlassian.net/browse/LABS-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ