### PR TITLE
LABS-2953: Anthropic Compliance API (AI Governance) safeguard transforms

### DIFF
--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/confirmedlicensepurchased.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/confirmedlicensepurchased.py
@@ -1,0 +1,117 @@
+"""
+Transformation: confirmedLicensePurchased
+Vendor: Anthropic (Claude) Compliance API
+Category: Licensing
+
+Evaluates whether the Compliance API is provisioned and reachable with a valid key.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "confirmedLicensePurchased"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "confirmedLicensePurchased",
+                    "vendor": "Anthropic",
+                    "category": "Licensing"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        if isinstance(data, dict) and "error" in data:
+            result_value = False
+            fail_reasons.append("Activity Feed returned an error: %s" % str(data.get("error")))
+        else:
+            result_value = isinstance(data.get("data"), list) and ("has_more" in data)
+            if result_value:
+                pass_reasons.append("Compliance API entitlement active; Activity Feed reachable")
+            else:
+                fail_reasons.append("Activity Feed envelope not present; key may lack entitlement")
+                recommendations.append("Provision a Compliance Access Key with read:compliance_activities")
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isactivityauditingenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isactivityauditingenabled.py
@@ -1,0 +1,117 @@
+"""
+Transformation: isActivityAuditingEnabled
+Vendor: Anthropic (Claude) Compliance API
+Category: Audit
+
+Evaluates whether the Activity Feed is actively recording events.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isActivityAuditingEnabled"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isActivityAuditingEnabled",
+                    "vendor": "Anthropic",
+                    "category": "Audit"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        if isinstance(data, dict) and "error" in data:
+            result_value = False
+            fail_reasons.append("Activity Feed error: %s" % str(data.get("error")))
+        else:
+            activities = data.get("data", []) if isinstance(data, dict) else []
+            result_value = isinstance(activities, list) and len(activities) > 0
+            if result_value:
+                pass_reasons.append("Activity Feed is recording events (%d sampled)" % len(activities))
+            else:
+                fail_reasons.append("No activity records returned; audit trail not confirmed")
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isapiaccessmonitored.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isapiaccessmonitored.py
@@ -1,0 +1,126 @@
+"""
+Transformation: isApiAccessMonitored
+Vendor: Anthropic (Claude) Compliance API
+Category: Audit
+
+Evaluates whether Compliance API access is itself audited and attributable.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isApiAccessMonitored"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isApiAccessMonitored",
+                    "vendor": "Anthropic",
+                    "category": "Audit"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        if isinstance(data, dict) and "error" in data:
+            result_value = False
+            fail_reasons.append("Activity Feed error: %s" % str(data.get("error")))
+        else:
+            activities = data.get("data", []) if isinstance(data, dict) else []
+            access = [a for a in activities if isinstance(a, dict) and a.get("type") == "compliance_api_accessed"]
+            if not access:
+                result_value = False
+                fail_reasons.append("No compliance_api_accessed events found")
+            else:
+                attributable = []
+                for ev in access:
+                    actor = ev.get("actor", {}) or {}
+                    attributable.append(bool(actor.get("api_key_id") or actor.get("admin_api_key_id")))
+                result_value = all(attributable)
+                if result_value:
+                    pass_reasons.append("Compliance API access is logged and attributable to a key")
+                else:
+                    fail_reasons.append("Some compliance API access events are not attributable to a key")
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/iscodeexecutionegresscontrolled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/iscodeexecutionegresscontrolled.py
@@ -1,0 +1,119 @@
+"""
+Transformation: isCodeExecutionEgressControlled
+Vendor: Anthropic (Claude) Compliance API
+Category: Network
+
+Evaluates whether code-execution sandbox network egress is disabled.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isCodeExecutionEgressControlled"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isCodeExecutionEgressControlled",
+                    "vendor": "Anthropic",
+                    "category": "Network"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        rows = data.get("settings", []) if isinstance(data, dict) else []
+        row = next((r for r in rows if isinstance(r, dict) and r.get("name") == "code_execution_network_egress_enabled"), None)
+        if row is None:
+            result_value = False
+            fail_reasons.append("code_execution_network_egress_enabled not present; cannot attest control")
+        else:
+            egress = row.get("value", True)
+            if isinstance(egress, str):
+                egress = egress.strip().lower() in ("true", "yes", "1", "enabled", "on")
+            result_value = not bool(egress)
+            (pass_reasons if result_value else fail_reasons).append(
+                "Code-execution egress %s" % ("controlled (disabled)" if result_value else "enabled"))
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/iscontentgovernanceenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/iscontentgovernanceenabled.py
@@ -1,0 +1,117 @@
+"""
+Transformation: isContentGovernanceEnabled
+Vendor: Anthropic (Claude) Compliance API
+Category: Data Lifecycle
+
+Evaluates whether content-level governance (eDiscovery/DLP retrieval) is provisioned.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isContentGovernanceEnabled"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isContentGovernanceEnabled",
+                    "vendor": "Anthropic",
+                    "category": "Data Lifecycle"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        if isinstance(data, dict) and "error" in data:
+            result_value = False
+            err = data.get("error", {})
+            fail_reasons.append("Content endpoint not authorized: %s" %
+                                (err.get("type") if isinstance(err, dict) else str(err)))
+            recommendations.append("Grant read:compliance_user_data to the Compliance Access Key")
+        else:
+            result_value = isinstance(data.get("data"), list) and ("has_more" in data)
+            (pass_reasons if result_value else fail_reasons).append(
+                "Content retrieval %s" % ("reachable" if result_value else "not reachable"))
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/iscontentredactionenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/iscontentredactionenabled.py
@@ -1,0 +1,119 @@
+"""
+Transformation: isContentRedactionEnabled
+Vendor: Anthropic (Claude) Compliance API
+Category: Data Lifecycle
+
+Evaluates whether content redaction is enforced for the organization.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isContentRedactionEnabled"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isContentRedactionEnabled",
+                    "vendor": "Anthropic",
+                    "category": "Data Lifecycle"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        rows = data.get("settings", []) if isinstance(data, dict) else []
+        row = next((r for r in rows if isinstance(r, dict) and r.get("name") == "content_redaction_enabled"), None)
+        if not row:
+            result_value = False
+            fail_reasons.append("content_redaction_enabled not present in effective settings")
+        else:
+            v = row.get("value", False)
+            if isinstance(v, str):
+                v = v.strip().lower() in ("true", "yes", "1", "enabled", "on")
+            result_value = bool(v)
+            (pass_reasons if result_value else fail_reasons).append(
+                "Content redaction %s" % ("enabled" if result_value else "disabled"))
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isdataretentionconfigured.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isdataretentionconfigured.py
@@ -1,0 +1,121 @@
+"""
+Transformation: isDataRetentionConfigured
+Vendor: Anthropic (Claude) Compliance API
+Category: Data Lifecycle
+
+Evaluates whether a bounded data-retention policy is in force for claude.ai content.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isDataRetentionConfigured"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isDataRetentionConfigured",
+                    "vendor": "Anthropic",
+                    "category": "Data Lifecycle"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        rows = data.get("settings", []) if isinstance(data, dict) else []
+        row = next((r for r in rows if isinstance(r, dict) and r.get("name") == "data_retention_periods"), None)
+        if not row:
+            result_value = False
+            fail_reasons.append("data_retention_periods not present in effective settings")
+            recommendations.append("Configure a bounded chat retention period")
+        else:
+            chat = (row.get("value", {}) or {}).get("chat", {}) if isinstance(row.get("value"), dict) else {}
+            dur = chat.get("duration")
+            result_value = chat.get("type") in ("fixed", "custom") and isinstance(dur, (int, float)) and dur > 0
+            if result_value:
+                pass_reasons.append("Bounded chat retention in force (%s %s)" % (dur, chat.get("timescale")))
+            else:
+                fail_reasons.append("Retention is unbounded or undefined")
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isipallowlistenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isipallowlistenabled.py
@@ -1,0 +1,121 @@
+"""
+Transformation: isIPAllowlistEnabled
+Vendor: Anthropic (Claude) Compliance API
+Category: Network
+
+Evaluates whether network access is restricted to an IP allowlist.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isIPAllowlistEnabled"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isIPAllowlistEnabled",
+                    "vendor": "Anthropic",
+                    "category": "Network"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        rows = data.get("settings", []) if isinstance(data, dict) else []
+        by_name = {r.get("name"): r for r in rows if isinstance(r, dict)}
+        result_value = False
+        enabled_row = by_name.get("ip_allowlist_enabled")
+        if enabled_row is not None:
+            v = enabled_row.get("value", False)
+            if isinstance(v, str):
+                v = v.strip().lower() in ("true", "yes", "1", "enabled", "on")
+            result_value = bool(v)
+        ranges_row = by_name.get("ip_allowlist_ip_ranges")
+        if enabled_row is None and ranges_row is not None and isinstance(ranges_row.get("value"), list):
+            result_value = len(ranges_row.get("value", [])) > 0
+        (pass_reasons if result_value else fail_reasons).append(
+            "IP allowlist %s" % ("enforced" if result_value else "not enforced"))
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isrbacconfigured.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isrbacconfigured.py
@@ -1,0 +1,114 @@
+"""
+Transformation: isRBACConfigured
+Vendor: Anthropic (Claude) Compliance API
+Category: Access Control
+
+Evaluates whether RBAC roles are defined on the organization.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isRBACConfigured"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isRBACConfigured",
+                    "vendor": "Anthropic",
+                    "category": "Access Control"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        roles = data.get("data", []) if isinstance(data, dict) else []
+        result_value = isinstance(roles, list) and len(roles) > 0
+        if result_value:
+            pass_reasons.append("RBAC configured (%d role(s) defined)" % len(roles))
+        else:
+            fail_reasons.append("No RBAC roles defined")
+            recommendations.append("Define least-privilege RBAC roles")
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isremediationcapable.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isremediationcapable.py
@@ -3,7 +3,16 @@ Transformation: isRemediationCapable
 Vendor: Anthropic (Claude) Compliance API
 Category: Remediation
 
-Evaluates whether the key holds delete:compliance_user_data for automated remediation. Scope-presence only; never invokes a DELETE endpoint.
+Evaluates whether the key holds delete:compliance_user_data for automated remediation.
+
+Per the Anthropic Compliance API docs ("Check your key's scopes"), there is NO
+programmatic scope-introspection endpoint, and Compliance Access Key scopes are
+immutable after creation. Scopes are knowable only via (1) key prefix [type only],
+(2) the claude.ai Settings UI Scopes column, or (3) a 403 "Got: [...]" error from an
+endpoint the key lacks scope for. None of these confirm delete:compliance_user_data
+without attempting a DELETE. This criterion is therefore an OPERATOR ATTESTATION of
+the scope list recorded at key creation (supplied via the grantedScopes setting);
+it is scope-presence only and NEVER invokes a DELETE endpoint.
 """
 
 import json

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isremediationcapable.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isremediationcapable.py
@@ -1,0 +1,118 @@
+"""
+Transformation: isRemediationCapable
+Vendor: Anthropic (Claude) Compliance API
+Category: Remediation
+
+Evaluates whether the key holds delete:compliance_user_data for automated remediation. Scope-presence only; never invokes a DELETE endpoint.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isRemediationCapable"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isRemediationCapable",
+                    "vendor": "Anthropic",
+                    "category": "Remediation"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        scopes = (data.get("scopes") or data.get("granted_scopes") or data.get("grantedScopes")
+                  or data.get("permissions") or []) if isinstance(data, dict) else []
+        if isinstance(scopes, str):
+            scopes = [s.strip() for s in scopes.replace(",", " ").split()]
+        normalized = {str(s).strip().lower() for s in scopes} if isinstance(scopes, list) else set()
+        result_value = "delete:compliance_user_data" in normalized
+        if result_value:
+            pass_reasons.append("Automated remediation provisioned (delete scope granted)")
+        else:
+            fail_reasons.append("delete:compliance_user_data scope not granted")
+            recommendations.append("Grant delete:compliance_user_data if DLP/data-privacy deletion is required")
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isssoenforced.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/isssoenforced.py
@@ -1,0 +1,126 @@
+"""
+Transformation: isSSOEnforced
+Vendor: Anthropic (Claude) Compliance API
+Category: Identity
+
+Evaluates whether SSO / directory provisioning is in force.
+"""
+
+import json
+from datetime import datetime
+
+
+def transform(input):
+    criteriaKey = "isSSOEnforced"
+
+    def extract_input(input_data):
+        if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+            return input_data["data"], input_data["validation"]
+        data = input_data
+        if isinstance(data, dict):
+            wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+            for _ in range(3):
+                unwrapped = False
+                for key in wrapper_keys:
+                    if key in data and isinstance(data.get(key), dict):
+                        data = data[key]
+                        unwrapped = True
+                        break
+                if not unwrapped:
+                    break
+        return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+    def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                        recommendations=None, input_summary=None, transformation_errors=None,
+                        api_errors=None, additional_findings=None):
+        if validation is None:
+            validation = {"status": "unknown", "errors": [], "warnings": []}
+        return {
+            "transformedResponse": result,
+            "additionalInfo": {
+                "dataCollection": {
+                    "status": "error" if (api_errors or []) else "success",
+                    "errors": api_errors or []
+                },
+                "validation": {
+                    "status": validation.get("status", "unknown"),
+                    "errors": validation.get("errors", []),
+                    "warnings": validation.get("warnings", [])
+                },
+                "transformation": {
+                    "status": "error" if (transformation_errors or []) else "success",
+                    "errors": transformation_errors or [],
+                    "inputSummary": input_summary or {}
+                },
+                "evaluation": {
+                    "passReasons": pass_reasons or [],
+                    "failReasons": fail_reasons or [],
+                    "recommendations": recommendations or [],
+                    "additionalFindings": additional_findings or []
+                },
+                "metadata": {
+                    "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                    "schemaVersion": "1.0",
+                    "transformationId": "isSSOEnforced",
+                    "vendor": "Anthropic",
+                    "category": "Identity"
+                }
+            }
+        }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        result_value = False
+
+        rows = data.get("settings", []) if isinstance(data, dict) else []
+        by_name = {r.get("name"): r for r in rows if isinstance(r, dict)}
+        result_value = False
+        prov = by_name.get("sso_provisioning_mode")
+        if prov is not None:
+            mode = prov.get("value")
+            if isinstance(mode, str):
+                result_value = mode.strip().lower() not in ("", "none", "disabled", "off")
+            elif mode:
+                result_value = True
+        if not result_value:
+            enforced = by_name.get("sso_enforced") or by_name.get("sso_required")
+            if enforced:
+                v = enforced.get("value", False)
+                if isinstance(v, str):
+                    v = v.strip().lower() in ("true", "yes", "1", "enabled", "on")
+                result_value = bool(v)
+        (pass_reasons if result_value else fail_reasons).append(
+            "SSO/directory provisioning %s" % ("enforced" if result_value else "not enforced"))
+
+        return create_response(
+            result={criteriaKey: result_value},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={criteriaKey: result_value}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=["Transformation error: %s" % str(e)]
+        )

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/confirmedlicensepurchased.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/confirmedlicensepurchased.py
@@ -1,0 +1,14 @@
+"""Schema for confirmedlicensepurchased transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class ConfirmedlicensepurchasedInput(BaseModel):
+    """
+    Expected input schema for the confirmedlicensepurchased transformation.
+    Criteria key: confirmedLicensePurchased
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isactivityauditingenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isactivityauditingenabled.py
@@ -1,0 +1,14 @@
+"""Schema for isactivityauditingenabled transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IsactivityauditingenabledInput(BaseModel):
+    """
+    Expected input schema for the isactivityauditingenabled transformation.
+    Criteria key: isActivityAuditingEnabled
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isapiaccessmonitored.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isapiaccessmonitored.py
@@ -1,0 +1,14 @@
+"""Schema for isapiaccessmonitored transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IsapiaccessmonitoredInput(BaseModel):
+    """
+    Expected input schema for the isapiaccessmonitored transformation.
+    Criteria key: isApiAccessMonitored
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/iscodeexecutionegresscontrolled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/iscodeexecutionegresscontrolled.py
@@ -1,0 +1,14 @@
+"""Schema for iscodeexecutionegresscontrolled transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IscodeexecutionegresscontrolledInput(BaseModel):
+    """
+    Expected input schema for the iscodeexecutionegresscontrolled transformation.
+    Criteria key: isCodeExecutionEgressControlled
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/iscontentgovernanceenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/iscontentgovernanceenabled.py
@@ -1,0 +1,14 @@
+"""Schema for iscontentgovernanceenabled transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IscontentgovernanceenabledInput(BaseModel):
+    """
+    Expected input schema for the iscontentgovernanceenabled transformation.
+    Criteria key: isContentGovernanceEnabled
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/iscontentredactionenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/iscontentredactionenabled.py
@@ -1,0 +1,14 @@
+"""Schema for iscontentredactionenabled transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IscontentredactionenabledInput(BaseModel):
+    """
+    Expected input schema for the iscontentredactionenabled transformation.
+    Criteria key: isContentRedactionEnabled
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isdataretentionconfigured.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isdataretentionconfigured.py
@@ -1,0 +1,14 @@
+"""Schema for isdataretentionconfigured transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IsdataretentionconfiguredInput(BaseModel):
+    """
+    Expected input schema for the isdataretentionconfigured transformation.
+    Criteria key: isDataRetentionConfigured
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isipallowlistenabled.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isipallowlistenabled.py
@@ -1,0 +1,14 @@
+"""Schema for isipallowlistenabled transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IsipallowlistenabledInput(BaseModel):
+    """
+    Expected input schema for the isipallowlistenabled transformation.
+    Criteria key: isIPAllowlistEnabled
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isrbacconfigured.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isrbacconfigured.py
@@ -1,0 +1,14 @@
+"""Schema for isrbacconfigured transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IsrbacconfiguredInput(BaseModel):
+    """
+    Expected input schema for the isrbacconfigured transformation.
+    Criteria key: isRBACConfigured
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isremediationcapable.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isremediationcapable.py
@@ -1,0 +1,14 @@
+"""Schema for isremediationcapable transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IsremediationcapableInput(BaseModel):
+    """
+    Expected input schema for the isremediationcapable transformation.
+    Criteria key: isRemediationCapable
+    """
+
+    class Config:
+        extra = "allow"

--- a/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isssoenforced.py
+++ b/safeguards/0641eadb-dd78-494a-9872-8e85697f8560/schemas/isssoenforced.py
@@ -1,0 +1,14 @@
+"""Schema for isssoenforced transformation input."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class IsssoenforcedInput(BaseModel):
+    """
+    Expected input schema for the isssoenforced transformation.
+    Criteria key: isSSOEnforced
+    """
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
Adds the Python transforms for the new **AI Governance** safeguard (Anthropic Claude Compliance API).

- **SRN**: `safeguards/0641eadb-dd78-494a-9872-8e85697f8560/`
- 11 L4 criteria across Activity Feeds, Content Retrieval, and Automated Remediation: confirmedLicensePurchased, isActivityAuditingEnabled, isApiAccessMonitored, isDataRetentionConfigured, isContentRedactionEnabled, isSSOEnforced, isIPAllowlistEnabled, isCodeExecutionEgressControlled, isRBACConfigured, isContentGovernanceEnabled, isRemediationCapable.
- Repo-style `transform(input)` → `extract_input`/`create_response` (`transformedResponse`+`additionalInfo`), with `schemas/`.
- Smoke-tested: pass/fail/error verified per criterion.

**Safety**: `isRemediationCapable` attests the `delete:compliance_user_data` scope by **presence only** — no DELETE endpoint is ever invoked (Compliance API deletes are permanent, no recovery window).

Pairs with spektrum-labs/Integrations#feature/LABS-2953-anthropic-compliance (config `configurations/compliance/anthropic.json` references these via raw URLs).

Jira: LABS-2953

🤖 Generated with [Claude Code](https://claude.com/claude-code)