### PR TITLE
Fix/ninjaone epp transforms

### DIFF
--- a/safeguards/epp/ninjaone/epp_transform.py
+++ b/safeguards/epp/ninjaone/epp_transform.py
@@ -1,0 +1,221 @@
+"""
+Transformation: epp_transform (NinjaOne)
+Vendor: NinjaOne
+Category: Endpoint Security
+
+Evaluates endpoint protection coverage from the NinjaOne antivirus status report:
+  GET /api/v2/queries/antivirus-status  ->  { cursor, results: [ DeviceAntivirusStatus ] }
+
+Each DeviceAntivirusStatus record (per the NinjaOne Public API 2.0 spec) carries:
+  productName       - AV/EPP/EDR product reported on the device (e.g. "Microsoft Defender Antivirus")
+  productState      - product state string (e.g. "ON" / "OFF" / "EXPIRED" / "SNOOZED")
+  definitionStatus  - signature/definition freshness (e.g. "UP_TO_DATE" / "OUT_OF_DATE")
+  version           - product version
+  deviceId          - NinjaOne device identifier
+  timestamp         - epoch seconds the data was collected
+
+Emits:
+  isEPPDeployed     - at least one device is reporting an active endpoint-protection product
+  isEDRDeployed     - same signal (NinjaOne's antivirus-status does not distinguish EPP from EDR;
+                      modern reported products are EDR-capable, so we mirror EPP rather than fabricate)
+  isEPPConfigured   - protected devices also have up-to-date definitions
+  requiredCoveragePercentage - % of AV-reporting devices that are actively protected
+
+Note: antivirus-status only returns devices that report an AV product, so coverage is measured
+relative to AV-reporting devices. Devices that report NO AV telemetry are surfaced via the
+device inventory, not here.
+"""
+
+import json
+from datetime import datetime
+
+
+ACTIVE_STATES = {"on", "enabled", "active", "ok", "running", "started", "up_to_date"}
+DISABLED_STATES = {"off", "disabled", "expired", "snoozed", "error", "stopped",
+                   "not running", "not_running", "unknown", ""}
+UP_TO_DATE = {"up_to_date", "uptodate", "up-to-date", "current", "ok", "good"}
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "epp_transform",
+                "vendor": "NinjaOne",
+                "category": "Endpoint Security"
+            }
+        }
+    }
+
+
+def transform(input):
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={"isEPPDeployed": False, "isEDRDeployed": False, "isEPPConfigured": False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        additional_findings = []
+
+        # NinjaOne antivirus-status returns { cursor, results: [...] }; tolerate list / data shapes too.
+        records = []
+        if isinstance(data, dict):
+            if isinstance(data.get("results"), list):
+                records = data["results"]
+            elif isinstance(data.get("data"), list):
+                records = data["data"]
+        elif isinstance(data, list):
+            records = data
+
+        reporting_devices = set()
+        protected_devices = set()
+        configured_devices = set()
+        outdated_devices = set()
+        products = {}
+
+        for rec in records:
+            if not isinstance(rec, dict):
+                continue
+            device_id = rec.get("deviceId", rec.get("id"))
+            if device_id is None:
+                continue
+            reporting_devices.add(device_id)
+
+            product_name = str(rec.get("productName", "")).strip()
+            product_state = str(rec.get("productState", "")).strip().lower()
+            definition_status = str(rec.get("definitionStatus", "")).strip().lower()
+
+            is_active = bool(product_name) and (
+                product_state in ACTIVE_STATES or
+                (product_state not in DISABLED_STATES)
+            )
+
+            if is_active:
+                protected_devices.add(device_id)
+                if product_name:
+                    products[product_name] = products.get(product_name, 0) + 1
+                if definition_status in UP_TO_DATE:
+                    configured_devices.add(device_id)
+                elif definition_status:
+                    outdated_devices.add(device_id)
+
+        total_reporting = len(reporting_devices)
+        total_protected = len(protected_devices)
+        total_configured = len(configured_devices)
+
+        coverage = round((total_protected / total_reporting) * 100) if total_reporting > 0 else 0
+        configured_pct = round((total_configured / total_protected) * 100) if total_protected > 0 else 0
+
+        is_epp_deployed = total_protected > 0
+        is_edr_deployed = is_epp_deployed
+        # "Configured" requires protection AND that the majority of protected devices have current definitions.
+        is_epp_configured = is_epp_deployed and total_configured > 0 and configured_pct >= 50
+
+        if is_epp_deployed:
+            product_list = ", ".join(sorted(products.keys())) if products else "an endpoint-protection product"
+            pass_reasons.append(
+                f"Endpoint protection active on {total_protected} of {total_reporting} "
+                f"AV-reporting device(s) ({coverage}% coverage); products: {product_list}"
+            )
+            if outdated_devices:
+                additional_findings.append(
+                    f"{len(outdated_devices)} protected device(s) have out-of-date AV definitions"
+                )
+            if not is_epp_configured:
+                recommendations.append(
+                    "Ensure AV definitions are kept up to date on protected endpoints"
+                )
+        else:
+            fail_reasons.append("No actively-protected endpoints found in NinjaOne antivirus status")
+            recommendations.append(
+                "Deploy and enable an antivirus/EDR product on managed endpoints in NinjaOne"
+            )
+
+        return create_response(
+            result={
+                "isEPPDeployed": is_epp_deployed,
+                "isEDRDeployed": is_edr_deployed,
+                "isEPPConfigured": is_epp_configured,
+                "requiredCoveragePercentage": coverage,
+                "devicesReporting": total_reporting,
+                "protectedDevices": total_protected,
+                "configuredDevices": total_configured,
+                "definitionsUpToDatePercentage": configured_pct
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            additional_findings=additional_findings,
+            input_summary={
+                "devicesReporting": total_reporting,
+                "protectedDevices": total_protected,
+                "configuredDevices": total_configured,
+                "products": products
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={"isEPPDeployed": False, "isEDRDeployed": False, "isEPPConfigured": False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/epp/ninjaone/schemas/epp_transform.py
+++ b/safeguards/epp/ninjaone/schemas/epp_transform.py
@@ -1,0 +1,24 @@
+"""Schema for the NinjaOne epp_transform input.
+
+Consumes the NinjaOne /api/v2/queries/antivirus-status report, which returns
+{ cursor, results: [ { productName, productState, definitionStatus, version,
+deviceId, timestamp } ] }. The presence of devices reporting an active AV/EDR
+product indicates endpoint protection is deployed.
+"""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class EppTransformInput(BaseModel):
+    """Expected input schema for the NinjaOne epp_transform transformation.
+
+    Criteria keys: isEPPDeployed, isEDRDeployed, isEPPConfigured
+    """
+
+    results: Optional[List[Dict[str, Any]]] = None
+    data: Optional[List[Dict[str, Any]]] = None
+    cursor: Optional[Dict[str, Any]] = None
+
+    class Config:
+        extra = "allow"

--- a/safeguards/vulnerabilitymgmt/ninjaone/ispatchmanagementenabled.py
+++ b/safeguards/vulnerabilitymgmt/ninjaone/ispatchmanagementenabled.py
@@ -95,8 +95,11 @@ def transform(input):
         total_patches = 0
         installed_patches = 0
         pending_patches = 0
+        rejected_patches = 0
+        manual_patches = 0
 
-        # NinjaOne /api/v2/queries/os-patches returns a results array of patch records
+        # NinjaOne /v2/queries/os-patches returns a results array of OUTSTANDING patch records.
+        # Installed patches are not present here (they live on /v2/queries/os-patch-installs).
         patches = []
 
         if isinstance(data, dict):
@@ -115,23 +118,43 @@ def transform(input):
             for patch in patches:
                 if isinstance(patch, dict):
                     status = str(patch.get('status', patch.get('installStatus', ''))).lower()
+                    # NinjaOne backlog lifecycle (observed live against the tenant API):
+                    #   INSTALLED/APPLIED/COMPLETED/SUCCESS -> installed (rare here)
+                    #   REJECTED                            -> rejected (by policy, out of scope)
+                    #   MANUAL                              -> pending, requires admin action (tracked separately)
+                    #   APPROVED/PENDING/AVAILABLE/REQUIRED/MISSING/FAILED -> pending
                     if status in ('installed', 'applied', 'completed', 'success'):
                         installed_patches += 1
-                    elif status in ('pending', 'available', 'required', 'missing', 'failed', 'manual'):
+                    elif status == 'rejected':
+                        rejected_patches += 1
+                    elif status == 'manual':
+                        manual_patches += 1
                         pending_patches += 1
                     else:
                         pending_patches += 1
 
         if patch_mgmt_enabled:
             reason = f"Patch management is enabled ({total_patches} OS patch record(s) tracked"
-            if installed_patches > 0 or pending_patches > 0:
-                reason += f", {installed_patches} installed, {pending_patches} pending)"
+            if installed_patches > 0 or pending_patches > 0 or rejected_patches > 0:
+                reason += (
+                    f", {installed_patches} installed, {pending_patches} pending "
+                    f"({manual_patches} require manual action), "
+                    f"{rejected_patches} rejected by policy)"
+                )
             else:
                 reason += ")"
             pass_reasons.append(reason)
 
             if pending_patches > 0:
                 additional_findings.append(f"{pending_patches} patch(es) are pending installation")
+            if manual_patches > 0:
+                additional_findings.append(
+                    f"{manual_patches} patch(es) require manual installation by an admin"
+                )
+            if rejected_patches > 0:
+                additional_findings.append(
+                    f"{rejected_patches} patch(es) rejected by customer's patch policy (out of compliance scope)"
+                )
         else:
             fail_reasons.append("No OS patch data found in NinjaOne")
             recommendations.append("Configure patch management policies in NinjaOne to track and deploy OS patches")
@@ -141,7 +164,9 @@ def transform(input):
                 criteriaKey: patch_mgmt_enabled,
                 "totalPatches": total_patches,
                 "installedPatches": installed_patches,
-                "pendingPatches": pending_patches
+                "pendingPatches": pending_patches,
+                "manualPatches": manual_patches,
+                "rejectedPatches": rejected_patches
             },
             validation=validation,
             pass_reasons=pass_reasons,
@@ -151,7 +176,9 @@ def transform(input):
             input_summary={
                 "totalPatches": total_patches,
                 "installedPatches": installed_patches,
-                "pendingPatches": pending_patches
+                "pendingPatches": pending_patches,
+                "manualPatches": manual_patches,
+                "rejectedPatches": rejected_patches
             }
         )
 

--- a/safeguards/vulnerabilitymgmt/ninjaone/ispatchmanagementvalid.py
+++ b/safeguards/vulnerabilitymgmt/ninjaone/ispatchmanagementvalid.py
@@ -3,13 +3,24 @@ Transformation: isPatchManagementValid
 Vendor: NinjaOne
 Category: Vulnerability Management / Patch Compliance
 
-Ensures that patch management processes exist and SLAs are met for vulnerability remediation.
-Checks the /api/v2/queries/os-patches endpoint for patch compliance — evaluates
-installed vs failed vs pending patches and computes a compliance rate.
+Consumes /v2/queries/os-patch-installs (install history) and validates that
+patch management is actually producing installs within an SLA window.
+
+NinjaOne models patches across two endpoints:
+  - /v2/queries/os-patches         -> outstanding backlog (no INSTALLED records)
+  - /v2/queries/os-patch-installs  -> install history (every applied patch)
+
+Compliance must be measured against install history, not the backlog, because
+the backlog endpoint drops records once a patch is installed (so it can never
+contain INSTALLED records). The safeguard passes when at least one install has
+occurred inside the SLA lookback window (default 30 days).
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
+
+# SLA window: how recent an install must be to count as "actively patching".
+RECENT_INSTALL_DAYS = 30
 
 
 def extract_input(input_data):
@@ -31,7 +42,8 @@ def extract_input(input_data):
 
 
 def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
-                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
     if validation is None:
         validation = {"status": "unknown", "errors": [], "warnings": []}
     return {
@@ -58,7 +70,7 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
                 "additionalFindings": additional_findings or []
             },
             "metadata": {
-                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "evaluatedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
                 "schemaVersion": "1.0",
                 "transformationId": "isPatchManagementValid",
                 "vendor": "NinjaOne",
@@ -66,6 +78,28 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
             }
         }
     }
+
+
+def parse_timestamp(value):
+    """NinjaOne returns unix epoch seconds (float) for installedAt/timestamp.
+
+    Name has no leading underscore: RestrictedPython forbids underscore-prefixed
+    names at runtime even though they work in local_tester.py.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        except (ValueError, OverflowError, OSError):
+            return None
+    if isinstance(value, str):
+        # ISO 8601 fallback
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
 
 
 def transform(input):
@@ -91,74 +125,85 @@ def transform(input):
         recommendations = []
         additional_findings = []
 
-        patch_mgmt_valid = False
-        total_patches = 0
-        installed_patches = 0
-        failed_patches = 0
-        pending_patches = 0
-        critical_pending = 0
-
-        # NinjaOne /api/v2/queries/os-patches returns a results array of patch records
-        patches = []
-
+        installs = []
         if isinstance(data, dict):
             if 'results' in data and isinstance(data['results'], list):
-                patches = data['results']
+                installs = data['results']
             elif 'data' in data and isinstance(data['data'], list):
-                patches = data['data']
+                installs = data['data']
         elif isinstance(data, list):
-            patches = data
+            installs = data
 
-        total_patches = len(patches)
+        total_installs = len(installs)
+        successful_installs = 0
+        failed_installs = 0
+        recent_installs = 0
+        latest_install_at = None
 
-        if total_patches > 0:
-            for patch in patches:
-                if isinstance(patch, dict):
-                    status = str(patch.get('status', patch.get('installStatus', ''))).lower()
-                    severity = str(patch.get('severity', patch.get('priority', patch.get('kbSeverity', '')))).lower()
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(days=RECENT_INSTALL_DAYS)
+        unique_devices = set()
 
-                    if status in ('installed', 'applied', 'completed', 'success'):
-                        installed_patches += 1
-                    elif status in ('failed', 'error'):
-                        failed_patches += 1
-                        if severity in ('critical', 'high', 'important'):
-                            critical_pending += 1
-                    else:
-                        pending_patches += 1
-                        if severity in ('critical', 'high', 'important'):
-                            critical_pending += 1
+        for record in installs:
+            if not isinstance(record, dict):
+                continue
+            status = str(record.get('status', record.get('installStatus', ''))).lower()
+            installed_at = parse_timestamp(record.get('installedAt') or record.get('timestamp'))
+            device_id = record.get('deviceId')
+            if device_id is not None:
+                unique_devices.add(device_id)
 
-            compliance_rate = round((installed_patches / total_patches) * 100, 1) if total_patches > 0 else 0
+            if status in ('installed', 'applied', 'completed', 'success'):
+                successful_installs += 1
+                if installed_at and installed_at >= cutoff:
+                    recent_installs += 1
+                if installed_at and (latest_install_at is None or installed_at > latest_install_at):
+                    latest_install_at = installed_at
+            elif status in ('failed', 'error'):
+                failed_installs += 1
 
-            if installed_patches > 0:
-                patch_mgmt_valid = True
-                pass_reasons.append(
-                    f"Patch management is valid ({compliance_rate}% compliance, "
-                    f"{installed_patches} of {total_patches} OS patches installed)"
-                )
-            else:
-                fail_reasons.append(f"No OS patches have been successfully installed out of {total_patches} tracked")
-                recommendations.append("Review and remediate pending OS patches to improve compliance")
+        compliance_rate = round((successful_installs / total_installs) * 100, 1) if total_installs > 0 else 0
 
-            if failed_patches > 0:
-                additional_findings.append(f"{failed_patches} OS patch(es) failed to install")
-            if critical_pending > 0:
-                additional_findings.append(f"{critical_pending} critical/high severity OS patch(es) pending or failed")
-                recommendations.append("Prioritize remediation of critical and high severity OS patches")
+        patch_mgmt_valid = recent_installs > 0
+
+        if patch_mgmt_valid:
+            pass_reasons.append(
+                f"Patch management is actively producing installs: "
+                f"{recent_installs} install(s) in the last {RECENT_INSTALL_DAYS} days "
+                f"across {len(unique_devices)} device(s)"
+            )
+        elif successful_installs > 0:
+            fail_reasons.append(
+                f"No patch installs in the last {RECENT_INSTALL_DAYS} days "
+                f"(latest install: {latest_install_at.isoformat() if latest_install_at else 'unknown'})"
+            )
+            recommendations.append(
+                f"Investigate why no patches have been applied in the past {RECENT_INSTALL_DAYS} days"
+            )
+        elif total_installs == 0:
+            fail_reasons.append("No patch install history found for this organization")
+            recommendations.append(
+                "Confirm patch management policies are configured to auto-install or to allow manual installs"
+            )
         else:
-            fail_reasons.append("No OS patch data found in NinjaOne")
-            recommendations.append("Configure patch management policies in NinjaOne")
+            fail_reasons.append(
+                f"No successful patch installs in the install-history endpoint "
+                f"({failed_installs} failed install attempts)"
+            )
 
-        compliance_rate = round((installed_patches / total_patches) * 100, 1) if total_patches > 0 else 0
+        if failed_installs > 0:
+            additional_findings.append(f"{failed_installs} patch install(s) failed in the history endpoint")
 
         return create_response(
             result={
                 criteriaKey: patch_mgmt_valid,
-                "totalPatches": total_patches,
-                "installedPatches": installed_patches,
-                "pendingPatches": pending_patches,
-                "failedPatches": failed_patches,
-                "criticalPending": critical_pending,
+                "totalInstallRecords": total_installs,
+                "successfulInstalls": successful_installs,
+                "failedInstalls": failed_installs,
+                "recentInstalls": recent_installs,
+                "recentWindowDays": RECENT_INSTALL_DAYS,
+                "devicesWithInstalls": len(unique_devices),
+                "latestInstallAt": latest_install_at.isoformat() if latest_install_at else None,
                 "complianceRate": compliance_rate
             },
             validation=validation,
@@ -167,10 +212,10 @@ def transform(input):
             recommendations=recommendations,
             additional_findings=additional_findings,
             input_summary={
-                "totalPatches": total_patches,
-                "installedPatches": installed_patches,
-                "pendingPatches": pending_patches,
-                "failedPatches": failed_patches,
+                "totalInstallRecords": total_installs,
+                "successfulInstalls": successful_installs,
+                "failedInstalls": failed_installs,
+                "recentInstalls": recent_installs,
                 "complianceRate": compliance_rate
             }
         )

--- a/safeguards/vulnerabilitymgmt/ninjaone/isvulnerabilityscanningenabled.py
+++ b/safeguards/vulnerabilitymgmt/ninjaone/isvulnerabilityscanningenabled.py
@@ -96,8 +96,11 @@ def transform(input):
         devices_with_patches = set()
         installed_count = 0
         pending_count = 0
+        rejected_count = 0
+        manual_count = 0
 
-        # NinjaOne /api/v2/queries/os-patches returns a results array of patch records
+        # NinjaOne /v2/queries/os-patches returns a results array of OUTSTANDING patch records.
+        # Installed patches live on /v2/queries/os-patch-installs.
         patches = []
 
         if isinstance(data, dict):
@@ -121,9 +124,15 @@ def transform(input):
                         devices_with_patches.add(device_id)
 
                     status = str(patch.get('status', patch.get('installStatus', ''))).lower()
+                    # NinjaOne backlog statuses (see ispatchmanagementenabled.py for full mapping)
                     if status in ('installed', 'applied', 'completed', 'success'):
                         installed_count += 1
-                    elif status in ('pending', 'available', 'required', 'missing', 'failed', 'manual'):
+                    elif status == 'rejected':
+                        rejected_count += 1
+                    elif status == 'manual':
+                        manual_count += 1
+                        pending_count += 1
+                    else:
                         pending_count += 1
 
         device_count = len(devices_with_patches)
@@ -137,7 +146,14 @@ def transform(input):
             pass_reasons.append(reason)
 
             if pending_count > 0:
-                additional_findings.append(f"{pending_count} patch(es) are pending or missing")
+                additional_findings.append(
+                    f"{pending_count} patch(es) are pending or missing "
+                    f"({manual_count} require manual action)"
+                )
+            if rejected_count > 0:
+                additional_findings.append(
+                    f"{rejected_count} patch(es) rejected by policy (still detected by scanner)"
+                )
         else:
             fail_reasons.append("No OS patch data found — vulnerability scanning may not be active")
             recommendations.append("Ensure NinjaOne patch management policies are configured and devices are reporting patch status")
@@ -148,7 +164,9 @@ def transform(input):
                 "totalPatchRecords": total_patches,
                 "devicesScanned": device_count,
                 "installedPatches": installed_count,
-                "pendingPatches": pending_count
+                "pendingPatches": pending_count,
+                "manualPatches": manual_count,
+                "rejectedPatches": rejected_count
             },
             validation=validation,
             pass_reasons=pass_reasons,
@@ -159,7 +177,9 @@ def transform(input):
                 "totalPatchRecords": total_patches,
                 "devicesScanned": device_count,
                 "installedPatches": installed_count,
-                "pendingPatches": pending_count
+                "pendingPatches": pending_count,
+                "manualPatches": manual_count,
+                "rejectedPatches": rejected_count
             }
         )
 

--- a/safeguards/vulnerabilitymgmt/ninjaone/schemas/ispatchmanagementvalid.py
+++ b/safeguards/vulnerabilitymgmt/ninjaone/schemas/ispatchmanagementvalid.py
@@ -9,8 +9,9 @@ class IspatchmanagementvalidInput(BaseModel):
     Expected input schema for the ispatchmanagementvalid transformation.
     Criteria key: isPatchManagementValid
 
-    Validates patch management compliance by checking patch status
-    and severity from the NinjaOne software-patches endpoint.
+    Consumes the NinjaOne /v2/queries/os-patch-installs endpoint, which returns
+    {cursor, results: [...]}. Each install record carries fields like
+    installedAt (unix epoch seconds), status (INSTALLED/FAILED/...), deviceId.
     """
 
     patches: Optional[List[Dict[str, Any]]] = None

--- a/safeguards/vulnerabilitymgmt/ninjaone/schemas/isvulnerabilityscanningenabled.py
+++ b/safeguards/vulnerabilitymgmt/ninjaone/schemas/isvulnerabilityscanningenabled.py
@@ -9,12 +9,14 @@ class IsvulnerabilityscanningenabledInput(BaseModel):
     Expected input schema for the isvulnerabilityscanningenabled transformation.
     Criteria key: isVulnerabilityScanningEnabled
 
-    Validates that devices are being monitored by checking
-    the NinjaOne devices endpoint.
+    Consumes the NinjaOne /v2/queries/os-patches endpoint, which returns
+    {cursor, results: [...]}. The presence of patch records (across any
+    status) indicates that scanning is active on managed devices.
     """
 
-    devices: Optional[List[Dict[str, Any]]] = None
+    patches: Optional[List[Dict[str, Any]]] = None
     data: Optional[List[Dict[str, Any]]] = None
+    results: Optional[List[Dict[str, Any]]] = None
 
     class Config:
         extra = "allow"


### PR DESCRIPTION
Adds a NinjaOne-specific endpoint-protection transform that reads NinjaOne's antivirus-status report (the old code reused a Sophos transform, so every NinjaOne customer wrongly showed "EPP not deployed"). Also includes the improved patch/vuln transforms (correct install-history endpoint, handles rejected/manual patches).