### PR TITLE
fix(emailsecurity): correct DKIM/DNS evaluation for Mimecast & Abnormal

### DIFF
--- a/safeguards/emailsecurity/abnormal/isdnsconfigured.py
+++ b/safeguards/emailsecurity/abnormal/isdnsconfigured.py
@@ -1,13 +1,25 @@
 """
 Transformation: isDNSConfigured
-Vendor: Abnormal Security
-Category: Email Security / DNS
+Vendor: Abnormal Security  |  Category: emailsecurity
+Evaluates: Ensure that DMARC, DKIM and SPF records are set up properly.
 
-Checks if DNS authentication (SPF/DKIM/DMARC) is configured via Abnormal Security.
-Evaluates email authentication settings and integration status.
+isDKIMConfigured / isSPFConfigured / isDMARCConfigured all route to the
+isDNSConfigured method, which calls the Spektrum mail-server security checker
+(mail_server_security_checks/tool). That tool performs a live DNS/CNAME probe of
+the email domain and returns a flat dict keyed by protocol, e.g.:
+
+    {"result": {"SPF": <bool|record-string|false>,
+                "DKIM": <bool|record-string|false>,
+                "DMARC": <bool|record-string|false>,
+                "SMTPBanner": ...}}
+
+DKIM/SPF/DMARC are published DNS records, so they are verified by DNS lookup
+(vendor-agnostic) rather than via the Abnormal API. This transformation reads the
+SPF/DKIM/DMARC values and emits the per-protocol criteria keys plus the aggregate
+isDNSConfigured.
 """
-
 import json
+import ast
 from datetime import datetime
 
 
@@ -17,7 +29,7 @@ def extract_input(input_data):
     data = input_data
     if isinstance(data, dict):
         wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
-        for _ in range(3):
+        for _ in range(4):
             unwrapped = False
             for key in wrapper_keys:
                 if key in data and isinstance(data.get(key), dict):
@@ -30,7 +42,8 @@ def extract_input(input_data):
 
 
 def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
-                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+                    recommendations=None, input_summary=None, transformation_errors=None,
+                    api_errors=None, additional_findings=None):
     if validation is None:
         validation = {"status": "unknown", "errors": [], "warnings": []}
     return {
@@ -61,15 +74,35 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
                 "schemaVersion": "1.0",
                 "transformationId": "isDNSConfigured",
                 "vendor": "Abnormal Security",
-                "category": "Email Security"
+                "category": "emailsecurity"
             }
         }
     }
 
 
-def is_dns_record_present(value):
-    """Check if a DNS record value indicates the record is configured.
-    Handles actual record strings, booleans, and the string 'False'/'None'.
+def coerce_data(value):
+    """Best-effort conversion of a raw response into a dict."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        for parser in (json.loads, ast.literal_eval):
+            try:
+                parsed = parser(value)
+                if isinstance(parsed, dict):
+                    return parsed
+            except Exception:
+                pass
+    return value if isinstance(value, dict) else {}
+
+
+def record_present(value):
+    """True if a protocol value from the DNS tool indicates a record exists.
+
+    The tool returns either a boolean, the actual DNS record string, or a falsey
+    sentinel (False / "" / "False" / "None" / "not found"). Any real record string
+    or boolean True counts as configured.
     """
     if value is None:
         return False
@@ -77,14 +110,24 @@ def is_dns_record_present(value):
         return value
     if isinstance(value, str):
         stripped = value.strip()
-        if stripped.lower() in ("false", "none", "null", "", "no", "0", "no banner found", "not found", "n/a"):
+        if stripped.lower() in ("false", "none", "null", "", "no", "0", "not found", "n/a", "no banner found"):
             return False
         return len(stripped) > 0
     return bool(value)
 
 
+def get_protocol(data, name):
+    """Fetch a protocol value (SPF/DKIM/DMARC) regardless of key casing."""
+    if name in data:
+        return data.get(name)
+    lowered = {k.lower(): v for k, v in data.items() if isinstance(k, str)}
+    return lowered.get(name.lower())
+
+
 def transform(input):
-    criteriaKey = "isDNSConfigured"
+    is_dmarc_configured = False
+    is_dkim_configured = False
+    is_spf_configured = False
 
     try:
         if isinstance(input, str):
@@ -93,10 +136,16 @@ def transform(input):
             input = json.loads(input.decode("utf-8"))
 
         data, validation = extract_input(input)
+        data = coerce_data(data)
 
         if validation.get("status") == "failed":
             return create_response(
-                result={criteriaKey: False, "isSPFConfigured": False, "isDKIMConfigured": False, "isDMARCConfigured": False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
+                result={
+                    "isDNSConfigured": False,
+                    "isDMARCConfigured": False,
+                    "isDKIMConfigured": False,
+                    "isSPFConfigured": False
+                },
                 validation=validation,
                 fail_reasons=["Input validation failed"]
             )
@@ -106,88 +155,52 @@ def transform(input):
         recommendations = []
         additional_findings = []
 
-        dns_configured = False
-        spf_configured = False
-        dkim_configured = False
-        dmarc_configured = False
+        is_spf_configured = record_present(get_protocol(data, "SPF"))
+        is_dkim_configured = record_present(get_protocol(data, "DKIM"))
+        is_dmarc_configured = record_present(get_protocol(data, "DMARC"))
 
-        if isinstance(data, dict):
-            # Normalize keys to lowercase for case-insensitive matching
-            lower_data = {k.lower(): v for k, v in data.items()}
+        is_dns_configured = is_dmarc_configured and is_dkim_configured and is_spf_configured
 
-            # Check for flat DNS record format: {SPF: "v=spf1...", DKIM: "...", DMARC: "v=DMARC1..."}
-            if 'spf' in lower_data or 'dkim' in lower_data or 'dmarc' in lower_data:
-                spf_configured = is_dns_record_present(lower_data.get('spf'))
-                dkim_configured = is_dns_record_present(lower_data.get('dkim'))
-                dmarc_configured = is_dns_record_present(lower_data.get('dmarc'))
-                dns_configured = spf_configured and dkim_configured and dmarc_configured
+        if is_dns_configured:
+            pass_reasons.append("All email DNS records (DMARC, DKIM, SPF) are properly configured")
+        else:
+            not_configured = []
+            if not is_dmarc_configured:
+                not_configured.append("DMARC")
+            if not is_dkim_configured:
+                not_configured.append("DKIM")
+            if not is_spf_configured:
+                not_configured.append("SPF")
+            fail_reasons.append("Missing DNS records: " + ", ".join(not_configured))
+            recommendations.append(
+                "Publish the missing DNS records (" + ", ".join(not_configured) + ") for the email domain."
+            )
+
+        for metric, configured, label in (
+            ("isDMARCConfigured", is_dmarc_configured, "DMARC"),
+            ("isDKIMConfigured", is_dkim_configured, "DKIM"),
+            ("isSPFConfigured", is_spf_configured, "SPF"),
+        ):
+            if configured:
+                additional_findings.append({
+                    "metric": metric,
+                    "status": "pass",
+                    "reason": label + " record is configured"
+                })
             else:
-                # Check Abnormal Security settings for email authentication
-                settings = data.get('settings', data)
-
-                # Check for email authentication settings
-                email_auth = settings.get('emailAuthentication', settings.get('authentication', {}))
-                if isinstance(email_auth, dict):
-                    spf = email_auth.get('spf', {})
-                    dkim = email_auth.get('dkim', {})
-                    dmarc = email_auth.get('dmarc', {})
-
-                    if isinstance(spf, dict):
-                        spf_configured = is_dns_record_present(spf.get('enabled', spf.get('configured', False)))
-                    else:
-                        spf_configured = is_dns_record_present(spf)
-                    if isinstance(dkim, dict):
-                        dkim_configured = is_dns_record_present(dkim.get('enabled', dkim.get('configured', False)))
-                    else:
-                        dkim_configured = is_dns_record_present(dkim)
-                    if isinstance(dmarc, dict):
-                        dmarc_configured = is_dns_record_present(dmarc.get('enabled', dmarc.get('configured', False)))
-                    else:
-                        dmarc_configured = is_dns_record_present(dmarc)
-
-                    dns_configured = spf_configured or dkim_configured or dmarc_configured
-                elif 'integrations' in settings:
-                    # If Abnormal has integrations configured, DNS is set up
-                    integrations = settings['integrations']
-                    if isinstance(integrations, list) and len(integrations) > 0:
-                        dns_configured = True
-
-                # If we get a valid response from settings, that implies basic DNS config
-                if not dns_configured and isinstance(data, dict) and len(data) > 0:
-                    if 'organization' in data or 'account' in data:
-                        dns_configured = True
-
-        # Build additional findings for sub-criteria
-        if spf_configured:
-            additional_findings.append({"metric": "spfConfigured", "status": "pass", "reason": "SPF record is configured"})
-        else:
-            additional_findings.append({"metric": "spfConfigured", "status": "fail", "reason": "SPF record not configured", "recommendation": "Configure SPF record for email domain"})
-
-        if dkim_configured:
-            additional_findings.append({"metric": "dkimConfigured", "status": "pass", "reason": "DKIM record is configured"})
-        else:
-            additional_findings.append({"metric": "dkimConfigured", "status": "fail", "reason": "DKIM record not configured", "recommendation": "Configure DKIM record for email signing"})
-
-        if dmarc_configured:
-            additional_findings.append({"metric": "dmarcConfigured", "status": "pass", "reason": "DMARC record is configured"})
-        else:
-            additional_findings.append({"metric": "dmarcConfigured", "status": "fail", "reason": "DMARC record not configured", "recommendation": "Configure DMARC record for domain authentication"})
-
-        if dns_configured:
-            pass_reasons.append("DNS email authentication is configured")
-        else:
-            fail_reasons.append("DNS email authentication (SPF/DKIM/DMARC) is not configured")
-            recommendations.append("Configure SPF, DKIM, and DMARC records for email authentication")
+                additional_findings.append({
+                    "metric": metric,
+                    "status": "fail",
+                    "reason": label + " DNS record not found",
+                    "recommendation": "Configure " + label + " record for the email domain"
+                })
 
         return create_response(
             result={
-                criteriaKey: dns_configured,
-                "isSPFConfigured": spf_configured,
-                "isDKIMConfigured": dkim_configured,
-                "isDMARCConfigured": dmarc_configured,
-                "spfConfigured": spf_configured,
-                "dkimConfigured": dkim_configured,
-                "dmarcConfigured": dmarc_configured
+                "isDMARCConfigured": is_dmarc_configured,
+                "isDKIMConfigured": is_dkim_configured,
+                "isSPFConfigured": is_spf_configured,
+                "isDNSConfigured": is_dns_configured
             },
             validation=validation,
             pass_reasons=pass_reasons,
@@ -195,16 +208,21 @@ def transform(input):
             recommendations=recommendations,
             additional_findings=additional_findings,
             input_summary={
-                "spfConfigured": spf_configured,
-                "dkimConfigured": dkim_configured,
-                "dmarcConfigured": dmarc_configured
+                "dmarcConfigured": is_dmarc_configured,
+                "dkimConfigured": is_dkim_configured,
+                "spfConfigured": is_spf_configured
             }
         )
 
     except Exception as e:
         return create_response(
-            result={criteriaKey: False, "isSPFConfigured": False, "isDKIMConfigured": False, "isDMARCConfigured": False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
+            result={
+                "isDNSConfigured": False,
+                "isDMARCConfigured": is_dmarc_configured,
+                "isDKIMConfigured": is_dkim_configured,
+                "isSPFConfigured": is_spf_configured
+            },
             validation={"status": "error", "errors": [], "warnings": []},
             transformation_errors=[str(e)],
-            fail_reasons=[f"Transformation error: {str(e)}"]
+            fail_reasons=["Transformation error: " + str(e)]
         )

--- a/safeguards/emailsecurity/abnormal/isdnsconfigured.py
+++ b/safeguards/emailsecurity/abnormal/isdnsconfigured.py
@@ -96,7 +96,7 @@ def transform(input):
 
         if validation.get("status") == "failed":
             return create_response(
-                result={criteriaKey: False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
+                result={criteriaKey: False, "isSPFConfigured": False, "isDKIMConfigured": False, "isDMARCConfigured": False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
                 validation=validation,
                 fail_reasons=["Input validation failed"]
             )
@@ -182,6 +182,9 @@ def transform(input):
         return create_response(
             result={
                 criteriaKey: dns_configured,
+                "isSPFConfigured": spf_configured,
+                "isDKIMConfigured": dkim_configured,
+                "isDMARCConfigured": dmarc_configured,
                 "spfConfigured": spf_configured,
                 "dkimConfigured": dkim_configured,
                 "dmarcConfigured": dmarc_configured
@@ -200,7 +203,7 @@ def transform(input):
 
     except Exception as e:
         return create_response(
-            result={criteriaKey: False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
+            result={criteriaKey: False, "isSPFConfigured": False, "isDKIMConfigured": False, "isDMARCConfigured": False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
             validation={"status": "error", "errors": [], "warnings": []},
             transformation_errors=[str(e)],
             fail_reasons=[f"Transformation error: {str(e)}"]

--- a/safeguards/emailsecurity/mimecast/isantiphishingenabled.py
+++ b/safeguards/emailsecurity/mimecast/isantiphishingenabled.py
@@ -1,17 +1,23 @@
-"""
-Transformation: isAntiPhishingEnabled
-Vendor: Mimecast
-Category: Email Security / Anti-Phishing
+"""Transformation: isAntiPhishingEnabled — Mimecast getAccount
 
-Evaluates whether Mimecast TTP Impersonation Protect is active by checking
-the impersonation protect logs from /api/ttp/impersonation/get-logs.
-A successful response (HTTP 200 with meta.status == 200) confirms the feature
-is configured and scanning, even if the impersonationLogs array is empty.
-Log entries provide additional evidence of active detection.
+Anti-phishing protection is licensed at the account level. The getAccount response
+lists active product packages; the presence of any phishing-defense package
+(Impersonation Protection [1060], Business Email Compromise [1109], CyberGraph
+[1095], or URL Protection (Site) [1043]) confirms anti-phishing email filtering is
+active. Packages are matched by their bracketed product-id token so renames don't
+break the check.
 """
-
 import json
 from datetime import datetime
+
+
+# Product-id tokens (stable) for Mimecast packages that provide anti-phishing defense.
+ANTI_PHISHING_PACKAGE_IDS = {
+    "[1060]": "Impersonation Protection",
+    "[1109]": "Business Email Compromise",
+    "[1095]": "CyberGraph",
+    "[1043]": "URL Protection (Site)",
+}
 
 
 def extract_input(input_data):
@@ -20,175 +26,133 @@ def extract_input(input_data):
     data = input_data
     if isinstance(data, dict):
         wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
-        for attempt in range(3):
+        for _ in range(3):
             unwrapped = False
             for key in wrapper_keys:
-                if key in data and isinstance(data.get(key), (dict, list)):
+                if key in data and isinstance(data.get(key), dict):
                     data = data[key]
                     unwrapped = True
                     break
             if not unwrapped:
                 break
-    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
 
 
 def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
-                    recommendations=None, input_summary=None, transformation_errors=None,
-                    api_errors=None, additional_findings=None):
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
     if validation is None:
         validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
     return {
         "transformedResponse": result,
         "additionalInfo": {
-            "dataCollection": {"status": "error" if (api_errors or []) else "success", "errors": api_errors or []},
-            "validation": {"status": validation.get("status", "unknown"), "errors": validation.get("errors", []), "warnings": validation.get("warnings", [])},
-            "transformation": {"status": "error" if (transformation_errors or []) else "success", "errors": transformation_errors or [], "inputSummary": input_summary or {}},
-            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": additional_findings or []},
-            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0", "transformationId": "isAntiPhishingEnabled", "vendor": "Mimecast", "category": "Email Security"}
-        }
+            "dataCollection": {"status": "error" if api_err_list else "success", "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": "error" if transform_err_list else "success",
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
     }
 
 
-def parse_api_error(data):
-    """Check for Mimecast error responses."""
-    if not isinstance(data, dict):
-        return None
-    meta = data.get("meta", {})
-    if isinstance(meta, dict):
-        status = meta.get("status")
-        if isinstance(status, int) and status >= 400:
-            return "Mimecast API returned status " + str(status)
-    fail_list = data.get("fail", [])
-    if isinstance(fail_list, list) and len(fail_list) > 0:
-        first_fail = fail_list[0] if isinstance(fail_list[0], dict) else {}
-        err_msg = first_fail.get("message", str(fail_list[0]))
-        return "Mimecast API error: " + str(err_msg)
-    return None
-
-
 def transform(input):
-    criteriaKey = "isAntiPhishingEnabled"
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
 
-    try:
-        if isinstance(input, str):
-            input = json.loads(input)
-        elif isinstance(input, bytes):
-            input = json.loads(input.decode("utf-8"))
+    account_list = data.get("data") or []
+    fail_list = data.get("fail") or []
+    meta = data.get("meta") or {}
+    meta_status = meta.get("status") if isinstance(meta, dict) else None
+    api_errors = [str(f) for f in fail_list] if fail_list else []
 
-        data, validation = extract_input(input)
+    metadata = {
+        "transformationId": "isAntiPhishingEnabled",
+        "vendor": "Mimecast",
+        "category": "Email Security",
+    }
 
-        # Schema validation failure should not block evaluation — proceed with
-        # the data and carry the validation warnings through to the response.
-        if validation.get("status") == "failed":
-            validation["status"] = "warning"
-            if not validation.get("warnings"):
-                validation["warnings"] = []
-            for err in validation.get("errors", []):
-                validation["warnings"].append("Schema: " + str(err))
-            validation["errors"] = []
+    if not account_list:
+        return create_response(
+            result={"isAntiPhishingEnabled": False, "antiPhishingPackages": []},
+            validation=validation,
+            fail_reasons=["No account data was returned in the getAccount response. Cannot confirm anti-phishing protection."],
+            recommendations=["Verify the API credentials have account read scope and that the account is active."],
+            input_summary={"accountCount": 0, "metaStatus": meta_status, "failCount": len(fail_list)},
+            api_errors=api_errors,
+            metadata=metadata,
+        )
 
-        pass_reasons = []
+    account = account_list[0] if isinstance(account_list[0], dict) else {}
+    account_name = account.get("accountName") or ""
+    packages = account.get("packages") or []
+
+    found = []
+    for pkg in packages:
+        pkg_str = str(pkg)
+        for token, label in ANTI_PHISHING_PACKAGE_IDS.items():
+            if token in pkg_str and label not in found:
+                found.append(label)
+
+    is_enabled = len(found) > 0
+
+    if is_enabled:
+        pass_reasons = [
+            "Mimecast account '" + account_name + "' has anti-phishing protection licensed via: "
+            + ", ".join(found) + "."
+        ]
         fail_reasons = []
         recommendations = []
-        additional_findings = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            "Mimecast account '" + account_name + "' has no anti-phishing defense packages "
+            "(Impersonation Protection, Business Email Compromise, CyberGraph, or URL Protection) in its licensed packages."
+        ]
+        recommendations = [
+            "Enable a Mimecast anti-phishing package (e.g. Impersonation Protection or CyberGraph) to block phishing and impersonation attacks."
+        ]
 
-        antiphishing_enabled = False
-        log_count = 0
-        actions_seen = []
-        identifiers_seen = []
-
-        # Check for API-level errors first
-        api_error = parse_api_error(data)
-        if api_error:
-            fail_reasons.append(api_error)
-            recommendations.append("Verify the API application has 'Monitoring | Impersonation Protection | Read' permission in Mimecast")
-            return create_response(
-                result={criteriaKey: False},
-                validation=validation,
-                fail_reasons=fail_reasons,
-                recommendations=recommendations,
-                api_errors=[api_error]
-            )
-
-        if isinstance(data, dict):
-            # Mimecast wraps response in data[] array
-            data_array = data.get("data", [])
-            if isinstance(data_array, list) and len(data_array) > 0:
-                first_entry = data_array[0] if isinstance(data_array[0], dict) else {}
-                logs = first_entry.get("impersonationLogs", [])
-            else:
-                logs = []
-
-            # A successful response from the impersonation protect logs endpoint
-            # confirms the feature is configured, even with zero log entries.
-            meta = data.get("meta", {})
-            meta_status = None
-            if isinstance(meta, dict):
-                meta_status = meta.get("status")
-
-            if meta_status == 200 or "data" in data:
-                antiphishing_enabled = True
-
-            if isinstance(logs, list):
-                log_count = len(logs)
-                for log_entry in logs:
-                    if not isinstance(log_entry, dict):
-                        continue
-                    action = log_entry.get("action", "")
-                    if action and action not in actions_seen:
-                        actions_seen.append(str(action))
-                    entry_identifiers = log_entry.get("identifiers", [])
-                    if isinstance(entry_identifiers, list):
-                        for ident in entry_identifiers:
-                            if ident and str(ident) not in identifiers_seen:
-                                identifiers_seen.append(str(ident))
-
-        elif isinstance(data, list):
-            # Direct list of log entries
-            antiphishing_enabled = True
-            log_count = len(data)
-
-        if antiphishing_enabled:
-            if log_count > 0:
-                pass_reasons.append(
-                    "Mimecast TTP Impersonation Protect is active with "
-                    + str(log_count) + " detection(s) in the reporting period"
-                )
-                if actions_seen:
-                    additional_findings.append("Actions taken: " + ", ".join(actions_seen))
-                if identifiers_seen:
-                    additional_findings.append("Detection types: " + ", ".join(identifiers_seen))
-            else:
-                pass_reasons.append(
-                    "Mimecast TTP Impersonation Protect is configured (API responded successfully, no detections in reporting period)"
-                )
-        else:
-            fail_reasons.append("Mimecast TTP Impersonation Protect does not appear to be configured")
-            recommendations.append("Enable TTP Impersonation Protect in the Mimecast Admin Console under Gateway > Policies > Impersonation Protect")
-            recommendations.append("Ensure the API application has 'Monitoring | Impersonation Protection | Read' permission")
-
-        return create_response(
-            result={
-                criteriaKey: antiphishing_enabled,
-                "detectionCount": log_count,
-            },
-            validation=validation,
-            pass_reasons=pass_reasons,
-            fail_reasons=fail_reasons,
-            recommendations=recommendations,
-            additional_findings=additional_findings,
-            input_summary={
-                "antiphishingActive": antiphishing_enabled,
-                "logEntries": log_count,
-                "actionTypes": actions_seen,
-                "identifierTypes": identifiers_seen,
-            }
-        )
-
-    except Exception as e:
-        return create_response(
-            result={criteriaKey: False},
-            validation={"status": "error", "errors": [], "warnings": []},
-            transformation_errors=[str(e)],
-            fail_reasons=["Transformation error: " + str(e)]
-        )
+    return create_response(
+        result={
+            "isAntiPhishingEnabled": is_enabled,
+            "antiPhishingPackages": found,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "accountCount": len(account_list),
+            "packageCount": len(packages),
+            "antiPhishingPackagesFound": len(found),
+            "metaStatus": meta_status,
+        },
+        api_errors=api_errors,
+        metadata=metadata,
+    )

--- a/safeguards/emailsecurity/mimecast/isdnsconfigured.py
+++ b/safeguards/emailsecurity/mimecast/isdnsconfigured.py
@@ -3,21 +3,20 @@ Transformation: isDNSConfigured
 Vendor: Mimecast  |  Category: emailsecurity
 Evaluates: Ensure that DMARC, DKIM and SPF records are set up properly.
 
-The Mimecast workflow routes isDKIMConfigured / isSPFConfigured / isDMARCConfigured
-to the isDNSConfigured method. That method calls the Spektrum mail-server security
-checker (mail_server_security_checks/tool), which performs a live DNS/CNAME probe and
-returns a flat dict keyed by protocol name, e.g.:
+isDKIMConfigured / isSPFConfigured / isDMARCConfigured all route to the
+isDNSConfigured method, which calls the Spektrum mail-server security checker
+(mail_server_security_checks/tool). That tool performs a live DNS/CNAME probe of
+the email domain and returns a flat dict keyed by protocol, e.g.:
 
-    {"SPF": <bool|record-string|false>,
-     "DKIM": <bool|record-string|false>,
-     "DMARC": <bool|record-string|false>,
-     "Open Relay": ..., "SMTP Banner": ..., "SSL/TLS": ...}
+    {"result": {"SPF": <bool|record-string|false>,
+                "DKIM": <bool|record-string|false>,
+                "DMARC": <bool|record-string|false>,
+                "SMTPBanner": ...}}
 
-This transformation reads the SPF/DKIM/DMARC values from that flat response and emits
-the per-protocol criteria keys (isDKIMConfigured, isSPFConfigured, isDMARCConfigured)
-plus the aggregate isDNSConfigured. It also tolerates Mimecast's getInternalDomain
-shape ({"data": [{"dns": {"dkim": ..., "dmarc": ..., "spf": ...}}, ...]}) so the same
-logic keeps working if the data source is switched to that endpoint.
+DKIM/SPF/DMARC are published DNS records, so they are verified by DNS lookup
+(vendor-agnostic) rather than via a Mimecast API. This transformation reads the
+SPF/DKIM/DMARC values and emits the per-protocol criteria keys plus the aggregate
+isDNSConfigured.
 """
 import json
 import ast
@@ -30,7 +29,7 @@ def extract_input(input_data):
     data = input_data
     if isinstance(data, dict):
         wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
-        for _ in range(3):
+        for _ in range(4):
             unwrapped = False
             for key in wrapper_keys:
                 if key in data and isinstance(data.get(key), dict):
@@ -82,27 +81,28 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
 
 
 def coerce_data(value):
-    """Best-effort conversion of a raw response into a dict or list."""
-    if isinstance(value, (dict, list)):
+    """Best-effort conversion of a raw response into a dict."""
+    if isinstance(value, dict):
         return value
     if isinstance(value, bytes):
         value = value.decode("utf-8")
     if isinstance(value, str):
         for parser in (json.loads, ast.literal_eval):
             try:
-                return parser(value)
+                parsed = parser(value)
+                if isinstance(parsed, dict):
+                    return parsed
             except Exception:
                 pass
-    return value
+    return value if isinstance(value, dict) else {}
 
 
 def record_present(value):
-    """Return True if a protocol value indicates a DNS record exists.
+    """True if a protocol value from the DNS tool indicates a record exists.
 
-    The DNS tool returns either a boolean, the actual DNS record string, or a falsey
-    sentinel (False / "" / "False" / "None" / "not found"). A nested dict (e.g. the
-    getInternalDomain dns verification object) is considered present when it reports
-    valid/verified/configured or carries a record value.
+    The tool returns either a boolean, the actual DNS record string, or a falsey
+    sentinel (False / "" / "False" / "None" / "not found"). Any real record string
+    or boolean True counts as configured.
     """
     if value is None:
         return False
@@ -113,50 +113,15 @@ def record_present(value):
         if stripped.lower() in ("false", "none", "null", "", "no", "0", "not found", "n/a", "no banner found"):
             return False
         return len(stripped) > 0
-    if isinstance(value, dict):
-        for flag in ("valid", "verified", "configured", "enabled"):
-            if flag in value:
-                return bool(value.get(flag))
-        for rec in ("record", "value", "txt"):
-            if rec in value:
-                return record_present(value.get(rec))
-        return len(value) > 0
     return bool(value)
 
 
-def protocol_from_mapping(mapping, name):
-    """Fetch a protocol value (SPF/DKIM/DMARC) from a dict regardless of key casing."""
-    if name in mapping:
-        return mapping.get(name)
-    lowered = {k.lower(): v for k, v in mapping.items() if isinstance(k, str)}
+def get_protocol(data, name):
+    """Fetch a protocol value (SPF/DKIM/DMARC) regardless of key casing."""
+    if name in data:
+        return data.get(name)
+    lowered = {k.lower(): v for k, v in data.items() if isinstance(k, str)}
     return lowered.get(name.lower())
-
-
-def evaluate_protocols(data):
-    """Return (spf, dkim, dmarc) booleans from either the flat DNS-tool dict or the
-    Mimecast getInternalDomain list shape."""
-    if isinstance(data, dict):
-        # getInternalDomain shape: {"data": [ {"dns": {...}}, ... ]}
-        domains = data.get("data")
-        if isinstance(domains, list) and domains:
-            spf = dkim = dmarc = False
-            for entry in domains:
-                dns = entry.get("dns", entry) if isinstance(entry, dict) else {}
-                if not isinstance(dns, dict):
-                    continue
-                spf = spf or record_present(protocol_from_mapping(dns, "SPF"))
-                dkim = dkim or record_present(protocol_from_mapping(dns, "DKIM"))
-                dmarc = dmarc or record_present(protocol_from_mapping(dns, "DMARC"))
-            return spf, dkim, dmarc
-
-        # Flat DNS-tool shape: {"SPF": ..., "DKIM": ..., "DMARC": ...}
-        return (
-            record_present(protocol_from_mapping(data, "SPF")),
-            record_present(protocol_from_mapping(data, "DKIM")),
-            record_present(protocol_from_mapping(data, "DMARC")),
-        )
-
-    return False, False, False
 
 
 def transform(input):
@@ -190,7 +155,9 @@ def transform(input):
         recommendations = []
         additional_findings = []
 
-        is_spf_configured, is_dkim_configured, is_dmarc_configured = evaluate_protocols(data)
+        is_spf_configured = record_present(get_protocol(data, "SPF"))
+        is_dkim_configured = record_present(get_protocol(data, "DKIM"))
+        is_dmarc_configured = record_present(get_protocol(data, "DMARC"))
 
         is_dns_configured = is_dmarc_configured and is_dkim_configured and is_spf_configured
 

--- a/safeguards/emailsecurity/mimecast/isdnsconfigured.py
+++ b/safeguards/emailsecurity/mimecast/isdnsconfigured.py
@@ -1,10 +1,26 @@
 """
 Transformation: isDNSConfigured
 Vendor: Mimecast  |  Category: emailsecurity
-Evaluates: Ensure that DMARC, DKIM and SPF records are set up properly
-           by verifying at least one active DNS Authentication Outbound policy exists.
+Evaluates: Ensure that DMARC, DKIM and SPF records are set up properly.
+
+The Mimecast workflow routes isDKIMConfigured / isSPFConfigured / isDMARCConfigured
+to the isDNSConfigured method. That method calls the Spektrum mail-server security
+checker (mail_server_security_checks/tool), which performs a live DNS/CNAME probe and
+returns a flat dict keyed by protocol name, e.g.:
+
+    {"SPF": <bool|record-string|false>,
+     "DKIM": <bool|record-string|false>,
+     "DMARC": <bool|record-string|false>,
+     "Open Relay": ..., "SMTP Banner": ..., "SSL/TLS": ...}
+
+This transformation reads the SPF/DKIM/DMARC values from that flat response and emits
+the per-protocol criteria keys (isDKIMConfigured, isSPFConfigured, isDMARCConfigured)
+plus the aggregate isDNSConfigured. It also tolerates Mimecast's getInternalDomain
+shape ({"data": [{"dns": {"dkim": ..., "dmarc": ..., "spf": ...}}, ...]}) so the same
+logic keeps working if the data source is switched to that endpoint.
 """
 import json
+import ast
 from datetime import datetime
 
 
@@ -65,78 +81,89 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
     }
 
 
-def get_policy_list(data):
+def coerce_data(value):
+    """Best-effort conversion of a raw response into a dict or list."""
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    if isinstance(value, str):
+        for parser in (json.loads, ast.literal_eval):
+            try:
+                return parser(value)
+            except Exception:
+                pass
+    return value
+
+
+def record_present(value):
+    """Return True if a protocol value indicates a DNS record exists.
+
+    The DNS tool returns either a boolean, the actual DNS record string, or a falsey
+    sentinel (False / "" / "False" / "None" / "not found"). A nested dict (e.g. the
+    getInternalDomain dns verification object) is considered present when it reports
+    valid/verified/configured or carries a record value.
     """
-    Extract the list of DNS auth outbound policies from the API response.
-    Mimecast /api/gateway/policies/dns-auth-outbound returns:
-      { "data": [ { "id": "...", "policy": { ... }, "option": { ... } }, ... ] }
-    The returnSpec maps data -> data, so by the time we receive it the top-level
-    key is already 'data'.
-    """
-    if isinstance(data, list):
-        return data
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.lower() in ("false", "none", "null", "", "no", "0", "not found", "n/a", "no banner found"):
+            return False
+        return len(stripped) > 0
+    if isinstance(value, dict):
+        for flag in ("valid", "verified", "configured", "enabled"):
+            if flag in value:
+                return bool(value.get(flag))
+        for rec in ("record", "value", "txt"):
+            if rec in value:
+                return record_present(value.get(rec))
+        return len(value) > 0
+    return bool(value)
+
+
+def protocol_from_mapping(mapping, name):
+    """Fetch a protocol value (SPF/DKIM/DMARC) from a dict regardless of key casing."""
+    if name in mapping:
+        return mapping.get(name)
+    lowered = {k.lower(): v for k, v in mapping.items() if isinstance(k, str)}
+    return lowered.get(name.lower())
+
+
+def evaluate_protocols(data):
+    """Return (spf, dkim, dmarc) booleans from either the flat DNS-tool dict or the
+    Mimecast getInternalDomain list shape."""
     if isinstance(data, dict):
-        for key in ["data", "policies", "items", "results"]:
-            val = data.get(key)
-            if isinstance(val, list):
-                return val
-    return []
+        # getInternalDomain shape: {"data": [ {"dns": {...}}, ... ]}
+        domains = data.get("data")
+        if isinstance(domains, list) and domains:
+            spf = dkim = dmarc = False
+            for entry in domains:
+                dns = entry.get("dns", entry) if isinstance(entry, dict) else {}
+                if not isinstance(dns, dict):
+                    continue
+                spf = spf or record_present(protocol_from_mapping(dns, "SPF"))
+                dkim = dkim or record_present(protocol_from_mapping(dns, "DKIM"))
+                dmarc = dmarc or record_present(protocol_from_mapping(dns, "DMARC"))
+            return spf, dkim, dmarc
 
+        # Flat DNS-tool shape: {"SPF": ..., "DKIM": ..., "DMARC": ...}
+        return (
+            record_present(protocol_from_mapping(data, "SPF")),
+            record_present(protocol_from_mapping(data, "DKIM")),
+            record_present(protocol_from_mapping(data, "DMARC")),
+        )
 
-def is_policy_enabled(policy_entry):
-    """Return True if a policy entry is considered active/enabled."""
-    if isinstance(policy_entry, dict):
-        # Direct enabled flag
-        if "enabled" in policy_entry:
-            return bool(policy_entry.get("enabled"))
-        # Nested under 'policy' key
-        nested = policy_entry.get("policy")
-        if isinstance(nested, dict) and "enabled" in nested:
-            return bool(nested.get("enabled"))
-        # If there is no explicit enabled flag, treat existence as enabled
-        return True
-    return False
-
-
-def evaluate(data):
-    """
-    Core evaluation logic for isDNSConfigured.
-
-    Criteria: At least one DNS Authentication Outbound policy must exist
-    and be enabled, indicating that DKIM/SPF/DMARC outbound signing or
-    verification is configured in Mimecast.
-    """
-    try:
-        policies = get_policy_list(data)
-        total_policies = len(policies)
-
-        if total_policies == 0:
-            return {
-                "isDNSConfigured": False,
-                "totalPolicies": 0,
-                "enabledPolicies": 0,
-                "error": "No DNS Authentication Outbound policies found"
-            }
-
-        enabled_count = 0
-        for policy in policies:
-            if is_policy_enabled(policy):
-                enabled_count = enabled_count + 1
-
-        is_configured = enabled_count > 0
-
-        return {
-            "isDNSConfigured": is_configured,
-            "totalPolicies": total_policies,
-            "enabledPolicies": enabled_count
-        }
-
-    except Exception as e:
-        return {"isDNSConfigured": False, "error": str(e)}
+    return False, False, False
 
 
 def transform(input):
-    criteriaKey = "isDNSConfigured"
+    is_dmarc_configured = False
+    is_dkim_configured = False
+    is_spf_configured = False
+
     try:
         if isinstance(input, str):
             input = json.loads(input)
@@ -144,87 +171,91 @@ def transform(input):
             input = json.loads(input.decode("utf-8"))
 
         data, validation = extract_input(input)
+        data = coerce_data(data)
 
         if validation.get("status") == "failed":
             return create_response(
-                result={criteriaKey: False},
+                result={
+                    "isDNSConfigured": False,
+                    "isDMARCConfigured": False,
+                    "isDKIMConfigured": False,
+                    "isSPFConfigured": False
+                },
                 validation=validation,
                 fail_reasons=["Input validation failed"]
             )
-
-        eval_result = evaluate(data)
-        result_value = eval_result.get(criteriaKey, False)
-        extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
 
         pass_reasons = []
         fail_reasons = []
         recommendations = []
         additional_findings = []
 
-        total = eval_result.get("totalPolicies", 0)
-        enabled = eval_result.get("enabledPolicies", 0)
+        is_spf_configured, is_dkim_configured, is_dmarc_configured = evaluate_protocols(data)
 
-        if result_value:
-            pass_reasons.append(
-                "DNS Authentication Outbound policies are configured: "
-                + str(enabled) + " of " + str(total) + " policy(s) are enabled"
-            )
-            pass_reasons.append(
-                "DKIM/SPF/DMARC outbound configuration is active in Mimecast"
-            )
+        is_dns_configured = is_dmarc_configured and is_dkim_configured and is_spf_configured
+
+        if is_dns_configured:
+            pass_reasons.append("All email DNS records (DMARC, DKIM, SPF) are properly configured")
         else:
-            if total == 0:
-                fail_reasons.append(
-                    "No DNS Authentication Outbound policies found in Mimecast"
-                )
-                recommendations.append(
-                    "Create at least one DNS Authentication Outbound policy in the Mimecast "
-                    "Administration Console under Gateway | Policies | DNS Authentication Outbound"
-                )
-            else:
-                fail_reasons.append(
-                    str(total) + " DNS Authentication Outbound policy(s) exist but none are enabled"
-                )
-                recommendations.append(
-                    "Enable at least one DNS Authentication Outbound policy in Mimecast to ensure "
-                    "DKIM signing and DMARC/SPF verification are active"
-                )
+            not_configured = []
+            if not is_dmarc_configured:
+                not_configured.append("DMARC")
+            if not is_dkim_configured:
+                not_configured.append("DKIM")
+            if not is_spf_configured:
+                not_configured.append("SPF")
+            fail_reasons.append("Missing DNS records: " + ", ".join(not_configured))
             recommendations.append(
-                "Ensure DMARC, DKIM, and SPF DNS records are published and that Mimecast "
-                "DNS Authentication policies reference the correct signing profile"
+                "Publish the missing DNS records (" + ", ".join(not_configured) + ") for the email domain. "
+                "For Mimecast-signed DKIM, ensure the Mimecast DKIM selector CNAME(s) are published."
             )
 
-            if "error" in eval_result:
-                fail_reasons.append(eval_result["error"])
-
-        additional_findings.append(
-            "Total DNS Auth Outbound policies: " + str(total)
-        )
-        additional_findings.append(
-            "Enabled DNS Auth Outbound policies: " + str(enabled)
-        )
-
-        full_result = {criteriaKey: result_value}
-        for k, v in extra_fields.items():
-            full_result[k] = v
+        for metric, configured, label in (
+            ("isDMARCConfigured", is_dmarc_configured, "DMARC"),
+            ("isDKIMConfigured", is_dkim_configured, "DKIM"),
+            ("isSPFConfigured", is_spf_configured, "SPF"),
+        ):
+            if configured:
+                additional_findings.append({
+                    "metric": metric,
+                    "status": "pass",
+                    "reason": label + " record is configured"
+                })
+            else:
+                additional_findings.append({
+                    "metric": metric,
+                    "status": "fail",
+                    "reason": label + " DNS record not found",
+                    "recommendation": "Configure " + label + " record for the email domain"
+                })
 
         return create_response(
-            result=full_result,
+            result={
+                "isDMARCConfigured": is_dmarc_configured,
+                "isDKIMConfigured": is_dkim_configured,
+                "isSPFConfigured": is_spf_configured,
+                "isDNSConfigured": is_dns_configured
+            },
             validation=validation,
             pass_reasons=pass_reasons,
             fail_reasons=fail_reasons,
             recommendations=recommendations,
+            additional_findings=additional_findings,
             input_summary={
-                criteriaKey: result_value,
-                "totalPolicies": total,
-                "enabledPolicies": enabled
-            },
-            additional_findings=additional_findings
+                "dmarcConfigured": is_dmarc_configured,
+                "dkimConfigured": is_dkim_configured,
+                "spfConfigured": is_spf_configured
+            }
         )
 
     except Exception as e:
         return create_response(
-            result={criteriaKey: False},
+            result={
+                "isDNSConfigured": False,
+                "isDMARCConfigured": is_dmarc_configured,
+                "isDKIMConfigured": is_dkim_configured,
+                "isSPFConfigured": is_spf_configured
+            },
             validation={"status": "error", "errors": [], "warnings": []},
             transformation_errors=[str(e)],
             fail_reasons=["Transformation error: " + str(e)]


### PR DESCRIPTION
- isDNSConfigured (Mimecast & Abnormal) now parses the DNS lookup tool's {SPF,DKIM,DMARC} response and emits isDKIMConfigured/isSPFConfigured/isDMARCConfigured
- Mimecast: was parsing a policy-list shape the tool never returns; Abnormal: emitted camelCase keys the token didn't read
- Mimecast isAntiPhishingEnabled rewired to getAccount packages (old version passed on any HTTP 200)
- Validated against EPIC's live data + RestrictedPython sandbox