### PR TITLE
Fix broken MS 365 anti-phishing transformation syntax

### DIFF
--- a/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/areantiphishingpoliciesconfigured.py
+++ b/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/areantiphishingpoliciesconfigured.py
@@ -66,38 +66,6 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
     }
 
 
-def transform(input):
-    criteriaKey = "areAntiPhishingPoliciesConfigured"
-
-    try:
-        if isinstance(input, str):
-            input = json.loads(input)
-        elif isinstance(input, bytes):
-            input = json.loads(input.decode("utf-8"))
-
-        data, validation = extract_input(input)
-
-        if validation.get("status") == "failed":
-            return create_response(
-                result={criteriaKey: False},
-                validation=validation,
-                fail_reasons=["Input validation failed"]
-            )
-
-        # Check for PowerShell/API error
-        if 'PSError' in data:
-            raw_error = data.get('PSError', '')
-            api_error, recommendation = parse_api_error(raw_error, source="Microsoft 365")
-
-            return create_response(
-                result={criteriaKey: False},
-                validation={"status": "skipped", "errors": [], "warnings": ["API returned error"]},
-                api_errors=[api_error],
-                fail_reasons=["Could not retrieve anti-phishing policies from Microsoft 365"],
-                recommendations=[recommendation]
-            )
-
-
 def parse_api_error(raw_error: str, source: str = None) -> tuple:
     """Parse raw API error into clean message with source."""
     raw_lower = raw_error.lower() if raw_error else ''
@@ -128,6 +96,38 @@ def parse_api_error(raw_error: str, source: str = None) -> tuple:
         clean = raw_error[:80] + "..." if len(raw_error) > 80 else raw_error
         return (f"Could not connect to {src}: {clean}",
                 f"Check {src} credentials and configuration")
+
+
+def transform(input):
+    criteriaKey = "areAntiPhishingPoliciesConfigured"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        # Check for PowerShell/API error
+        if 'PSError' in data:
+            raw_error = data.get('PSError', '')
+            api_error, recommendation = parse_api_error(raw_error, source="Microsoft 365")
+
+            return create_response(
+                result={criteriaKey: False},
+                validation={"status": "skipped", "errors": [], "warnings": ["API returned error"]},
+                api_errors=[api_error],
+                fail_reasons=["Could not retrieve anti-phishing policies from Microsoft 365"],
+                recommendations=[recommendation]
+            )
 
         pass_reasons = []
         fail_reasons = []


### PR DESCRIPTION
## Summary

Fixes a syntax error in the MS 365 Email Security anti-phishing transformation.

`parse_api_error()` had been placed inside the middle of `transform()`'s `try` block, which caused the file to fail at import/compile time. This PR moves `parse_api_error()` back to module scope above `transform()`.

No transformation logic was changed.

## Scope

Changed one file:

- `safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/areantiphishingpoliciesconfigured.py`

## Verification

- Confirmed `develop` fails to parse this file before the fix.
- Confirmed this branch compiles.
- Confirmed `parse_api_error` and `transform` are both module-level functions.
- Ran smoke checks for compliant policy, noncompliant policy, PowerShell/API error path, and real MS 365 anti-phishing Lambda output.
- `git diff --check` passes.

## Reviewers

Tim and Simon