### PR TITLE
[LABS-3087] Add 8 missing Azure MFA transformation files

### DIFF
--- a/safeguards/mfa/azure/areaccessreviewsconfigured.py
+++ b/safeguards/mfa/azure/areaccessreviewsconfigured.py
@@ -1,0 +1,136 @@
+"""
+Transformation: areAccessReviewsConfigured
+Vendor: Microsoft
+Category: Identity Governance
+
+Evaluates if access reviews are configured in Azure AD.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "areAccessReviewsConfigured",
+                "vendor": "Microsoft",
+                "category": "Identity Governance"
+            }
+        }
+    }
+
+
+def transform(input):
+    criteriaKey = "areAccessReviewsConfigured"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result={criteriaKey: False, "reviewCount": 0},
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False, "reviewCount": 0},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result={criteriaKey: False, "reviewCount": 0},
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        # Mirrored from safeguards/d9b6f27a-2e67-4b55-a09e-0784c5de9abd/areaccessreviewsconfigured.py
+        reviews = data.get("value") or []
+        if not isinstance(reviews, list):
+            reviews = [reviews] if reviews else []
+
+        is_configured = len(reviews) > 0
+
+        if is_configured:
+            pass_reasons.append(f"Access reviews configured: {len(reviews)} review definitions found")
+        else:
+            fail_reasons.append("No access reviews scheduled or configured")
+            recommendations.append("Configure access reviews in Azure AD Identity Governance")
+
+        return create_response(
+            result={criteriaKey: is_configured, "reviewCount": len(reviews)},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"reviewCount": len(reviews)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False, "reviewCount": 0},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/mfa/azure/areadminaccountsseparate.py
+++ b/safeguards/mfa/azure/areadminaccountsseparate.py
@@ -1,0 +1,323 @@
+"""
+Transformation: areAdminAccountsSeparate
+Vendor: Microsoft
+Category: Identity / Admin Accounts
+
+Evaluates whether privileged admin identities are separate from everyday mail-licensed user accounts.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "areAdminAccountsSeparate",
+                "vendor": "Microsoft",
+                "category": "Identity"
+            }
+        }
+    }
+
+
+# Entra built-in directory role TEMPLATE ids (identical in every tenant). Verified against
+# GET /v1.0/directoryRoleTemplates - do not add ids that have not been checked against that list.
+PRIVILEGED_ROLE_IDS = {
+    "62e90394-69f5-4237-9190-012177145e10",  # Global Administrator
+    "e8611ab8-c189-46e8-94e1-60213ab1f814",  # Privileged Role Administrator
+    "7be44c8a-adaf-4e2a-84d6-ab2649e08a13",  # Privileged Authentication Administrator
+    "29232cdf-9323-42fd-ade2-1d097af3e4de",  # Exchange Administrator
+    "f28a1f50-f6e7-4571-818b-6a12f2af6b6c",  # SharePoint Administrator
+    "fe930be7-5e62-47db-91af-98c3a49a38b1",  # User Administrator
+    "9b895d92-2cd3-44c7-9d02-a6ac2d5ea5c3",  # Application Administrator
+    "158c047a-c907-4556-b7ef-446551a6b5f7",  # Cloud Application Administrator
+    "194ae4cb-b126-40b2-bd5b-6091b380977d",  # Security Administrator
+    "b1be1c3e-b65d-4f19-8427-f6fa0d97feb9",  # Conditional Access Administrator
+    "f2ef992c-3afb-46b9-b7cf-a126ee74c451",  # Global Reader (read-only but tenant-wide - conservative inclusion)
+}
+
+# Commercial SKU ids that include an Exchange Online mailbox (Microsoft licensing reference).
+# NON-EXHAUSTIVE by design: unknown SKUs are backstopped by the mail-attribute check below.
+# Complete this list against Microsoft's product-names-and-service-plan-identifiers CSV when
+# the getUsers feed is upgraded to carry assignedLicenses.
+MAIL_EXCHANGE_SKU_IDS = {
+    "4b9405b0-7788-4568-add1-99614e63306e",  # EXCHANGESTANDARD (Exchange Online Plan 1)
+    "efb87545-963c-4f51-83ff-779edf226046",  # EXCHANGEENTERPRISE (Exchange Online Plan 2)
+    "6fd2c87f-b296-42f0-b197-1e91e994b900",  # ENTERPRISEPACK (Office 365 E3)
+    "c7df2760-2c81-4ef7-b578-5b5392b571df",  # ENTERPRISEPREMIUM (Office 365 E5)
+    "05e9a617-0261-4cee-bb44-138d3ef5d965",  # SPE_E3 (Microsoft 365 E3)
+    "06ebc4ee-1bb5-47dd-8120-11324bc54e06",  # SPE_E5 (Microsoft 365 E5)
+    "3b555118-da6a-4418-894f-7df1e2096870",  # O365_BUSINESS_ESSENTIALS (M365 Business Basic)
+    "f245ecc8-75af-4f8e-b61f-27d8114de5f3",  # O365_BUSINESS_PREMIUM (M365 Business Standard; lab-verified)
+    "cbdc14ab-d96c-4c30-b9f4-6ada7cdc1d46",  # SPB (Microsoft 365 Business Premium)
+}
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, dict) and "value" in value:
+        nested = value.get("value")
+        if isinstance(nested, list):
+            return nested
+        return [nested] if nested else []
+    return [value]
+
+
+def _role_id_from_entry(entry):
+    if isinstance(entry, str):
+        return entry
+    if not isinstance(entry, dict):
+        return None
+    return entry.get("roleDefinitionId") or entry.get("roleTemplateId") or entry.get("roleId")
+
+
+def _directory_role_template_id(role):
+    if isinstance(role, str):
+        return role
+    if not isinstance(role, dict):
+        return None
+    return role.get("roleTemplateId") or role.get("roleDefinitionId")
+
+
+def _principal_id_from_entry(entry):
+    if isinstance(entry, str):
+        return entry
+    if not isinstance(entry, dict):
+        return None
+    return entry.get("principalId") or entry.get("id") or entry.get("userId")
+
+
+def _collect_admin_principal_ids(data, users):
+    admin_ids = set()
+
+    for assignment in _as_list(data.get("roleAssignments")):
+        role_id = _role_id_from_entry(assignment)
+        principal_id = _principal_id_from_entry(assignment)
+        if role_id in PRIVILEGED_ROLE_IDS and principal_id:
+            admin_ids.add(principal_id)
+
+    for role in _as_list(data.get("directoryRoles")):
+        role_id = _directory_role_template_id(role)
+        if role_id not in PRIVILEGED_ROLE_IDS:
+            continue
+        if not isinstance(role, dict):
+            continue
+        for member in _as_list(role.get("members")):
+            principal_id = _principal_id_from_entry(member)
+            if principal_id:
+                admin_ids.add(principal_id)
+
+    for user in users:
+        if not isinstance(user, dict):
+            continue
+        user_id = user.get("id")
+        for role_entry in _as_list(user.get("assignedRoles") or user.get("directoryRoleIds")):
+            role_id = _role_id_from_entry(role_entry)
+            if role_id in PRIVILEGED_ROLE_IDS and user_id:
+                admin_ids.add(user_id)
+
+    return admin_ids
+
+
+def _user_has_mail_or_exchange_license(user):
+    licenses = user.get("assignedLicenses") or []
+    for lic in licenses:
+        if not isinstance(lic, dict):
+            continue
+        sku_id = lic.get("skuId")
+        if sku_id and str(sku_id).lower() in MAIL_EXCHANGE_SKU_IDS:
+            return True
+    mail = user.get("mail")
+    if mail and str(mail).strip():
+        return True
+    return False
+
+
+def transform(input):
+    # FEED CAVEAT: the integration's stated intent ("admins hold no mail/Exchange license")
+    # needs role membership + assignedLicenses, but the current getUsers feed is a bare
+    # GET /v1.0/users that carries neither. Until the feed is upgraded, this transform fails
+    # with an explicit feed-update reason rather than pretending to evaluate (no name-pattern
+    # heuristics). The rich branch below activates automatically once the feed carries
+    # role data (directoryRoles/roleAssignments/assignedRoles) AND assignedLicenses.
+    criteriaKey = "areAdminAccountsSeparate"
+    feed_update_reason = (
+        "User feed does not include role/license data required to evaluate admin account "
+        "separation - integration feed update required"
+    )
+    feed_update_recommendation = (
+        "Upgrade the getUsers feed to include assignedLicenses on user objects and "
+        "privileged directory role membership (e.g. directoryRoles or roleAssignments)"
+    )
+    default_result = {
+        criteriaKey: False,
+        "userCount": 0,
+        "adminCount": 0,
+        "adminsWithMailLicense": 0,
+    }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result=default_result,
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result=default_result,
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result=default_result,
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        users = data.get("value") or []
+        if not isinstance(users, list):
+            users = [users] if users else []
+
+        user_count = len(users)
+        users_by_id = {user.get("id"): user for user in users if isinstance(user, dict) and user.get("id")}
+
+        has_license_data = any(isinstance(user, dict) and "assignedLicenses" in user for user in users)
+        admin_principal_ids = _collect_admin_principal_ids(data, users)
+        has_role_data = (
+            bool(_as_list(data.get("directoryRoles")))
+            or bool(_as_list(data.get("roleAssignments")))
+            or len(admin_principal_ids) > 0
+        )
+
+        admin_count = 0
+        admins_with_mail_license = 0
+        admins_missing_from_user_feed = 0
+        is_separate = False
+
+        if has_license_data and has_role_data:
+            for principal_id in admin_principal_ids:
+                admin_count += 1
+                user = users_by_id.get(principal_id)
+                if user is None:
+                    admins_missing_from_user_feed += 1
+                    continue
+                if _user_has_mail_or_exchange_license(user):
+                    admins_with_mail_license += 1
+
+            is_separate = (
+                admin_count > 0
+                and admins_with_mail_license == 0
+                and admins_missing_from_user_feed == 0
+            )
+
+            if is_separate:
+                pass_reasons.append(
+                    f"All {admin_count} privileged admin account(s) are free of mail/Exchange Online licenses"
+                )
+            elif admin_count == 0:
+                fail_reasons.append("No privileged directory role members found in user feed")
+                recommendations.append("Verify directory role membership is included in the integration feed")
+            elif admins_missing_from_user_feed > 0:
+                fail_reasons.append(
+                    f"{admins_missing_from_user_feed} privileged admin account(s) are not present in the user feed"
+                )
+                recommendations.append(
+                    "Include privileged role members in the getUsers feed with assignedLicenses for license evaluation"
+                )
+            else:
+                fail_reasons.append(
+                    f"{admins_with_mail_license} of {admin_count} admin account(s) have mail/Exchange Online licenses"
+                )
+                recommendations.append("Use dedicated admin accounts without mail or Exchange Online licenses")
+        else:
+            fail_reasons.append(feed_update_reason)
+            recommendations.append(feed_update_recommendation)
+
+        return create_response(
+            result={
+                criteriaKey: is_separate,
+                "userCount": user_count,
+                "adminCount": admin_count,
+                "adminsWithMailLicense": admins_with_mail_license,
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"userCount": user_count, "hasLicenseData": has_license_data, "hasRoleData": has_role_data}
+        )
+
+    except Exception as e:
+        return create_response(
+            result=default_result,
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/mfa/azure/areconditionalaccesspoliciesconfigured.py
+++ b/safeguards/mfa/azure/areconditionalaccesspoliciesconfigured.py
@@ -1,0 +1,136 @@
+"""
+Transformation: areConditionalAccessPoliciesConfigured
+Vendor: Microsoft
+Category: Identity / Conditional Access
+
+Evaluates if conditional access policies are configured in Azure AD.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "areConditionalAccessPoliciesConfigured",
+                "vendor": "Microsoft",
+                "category": "Identity"
+            }
+        }
+    }
+
+
+def transform(input):
+    criteriaKey = "areConditionalAccessPoliciesConfigured"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result={criteriaKey: False, "policyCount": 0},
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False, "policyCount": 0},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result={criteriaKey: False, "policyCount": 0},
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        # Mirrored from safeguards/d9b6f27a-2e67-4b55-a09e-0784c5de9abd/areconditionalaccesspoliciesconfigured.py
+        policies = data.get("value") or []
+        if not isinstance(policies, list):
+            policies = [policies] if policies else []
+
+        is_configured = len(policies) > 0
+
+        if is_configured:
+            pass_reasons.append(f"Conditional access policies configured: {len(policies)} policies found")
+        else:
+            fail_reasons.append("No Conditional Access policies configured")
+            recommendations.append("Configure conditional access policies in Azure AD to enforce security controls")
+
+        return create_response(
+            result={criteriaKey: is_configured, "policyCount": len(policies)},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"policyCount": len(policies)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False, "policyCount": 0},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/mfa/azure/isadminmfaphishingresistant.py
+++ b/safeguards/mfa/azure/isadminmfaphishingresistant.py
@@ -1,0 +1,259 @@
+"""
+Transformation: isAdminMFAPhishingResistant
+Vendor: Microsoft
+Category: Identity / Secure Score
+
+Evaluates admin MFA protection using the AdminMFAV2 Microsoft Secure Score control.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isAdminMFAPhishingResistant",
+                "vendor": "Microsoft",
+                "category": "Identity"
+            }
+        }
+    }
+
+
+def parse_api_error(raw_error, source=None):
+    raw_error = raw_error or ""
+    raw_lower = raw_error.lower()
+    src = source or "external service"
+
+    if "401" in raw_error:
+        return (
+            f"Could not connect to {src}: Authentication failed (HTTP 401)",
+            f"Verify {src} credentials and permissions are valid",
+        )
+    elif "403" in raw_error:
+        return (
+            f"Could not connect to {src}: Access denied (HTTP 403)",
+            f"Verify the integration has required {src} permissions",
+        )
+    elif "404" in raw_error:
+        return (
+            f"Could not connect to {src}: Resource not found (HTTP 404)",
+            f"Verify the {src} resource and configuration exist",
+        )
+    elif "429" in raw_error:
+        return (
+            f"Could not connect to {src}: Rate limited (HTTP 429)",
+            "Retry the request after waiting",
+        )
+    elif "500" in raw_error or "502" in raw_error or "503" in raw_error:
+        return (
+            f"Could not connect to {src}: Service unavailable (HTTP 5xx)",
+            f"{src} may be temporarily unavailable, retry later",
+        )
+    elif "timeout" in raw_lower:
+        return (
+            f"Could not connect to {src}: Request timed out",
+            "Check network connectivity and retry",
+        )
+    elif "connection" in raw_lower:
+        return (
+            f"Could not connect to {src}: Connection failed",
+            "Check network connectivity and firewall settings",
+        )
+    else:
+        clean = raw_error[:80] + "..." if len(raw_error) > 80 else raw_error
+        return (
+            f"Could not connect to {src}: {clean}",
+            f"Check {src} credentials and configuration",
+        )
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _as_number(value, default=0):
+    if value is None:
+        return default
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        try:
+            number = float(value)
+            return int(number) if number.is_integer() else number
+        except ValueError:
+            return default
+    return default
+
+
+def transform(input):
+    criteriaKey = "isAdminMFAPhishingResistant"
+    controlName = "AdminMFAV2"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result={criteriaKey: False, "scoreInPercentage": 0.0, "count": 0, "total": 0},
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if "PSError" in data:
+            api_error, recommendation = parse_api_error(data.get("PSError", ""), source="Microsoft 365")
+            return create_response(
+                result={criteriaKey: False, "scoreInPercentage": 0.0, "count": 0, "total": 0},
+                validation={"status": "skipped", "errors": [], "warnings": ["API returned error"]},
+                api_errors=[api_error],
+                fail_reasons=["Could not retrieve data from Microsoft 365"],
+                recommendations=[recommendation]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False, "scoreInPercentage": 0.0, "count": 0, "total": 0},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result={criteriaKey: False, "scoreInPercentage": 0.0, "count": 0, "total": 0},
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+        score_in_percentage = 0.0
+        count = 0
+        total = 0
+        is_resistant = False
+
+        # AdminMFAV2 verifies admin MFA registration, not strict phishing-resistance; a stricter
+        # check would need the authenticationMethodsPolicy feed.
+        values = _as_list(data.get("value") or [])
+        if len(values) > 0:
+            secure_score = values[0] if isinstance(values[0], dict) else {}
+            control_scores = _as_list(secure_score.get("controlScores") or [])
+            matched = [
+                entry for entry in control_scores
+                if isinstance(entry, dict) and entry.get("controlName") == controlName
+            ]
+
+            if len(matched) > 1:
+                fail_reasons.append(
+                    f"Ambiguous data: {len(matched)} objects match controlName '{controlName}'"
+                )
+                return create_response(
+                    result={criteriaKey: False, "scoreInPercentage": 0.0, "count": 0, "total": 0},
+                    validation=validation,
+                    fail_reasons=fail_reasons,
+                    recommendations=["Check Microsoft Secure Score data for duplicate control entries"]
+                )
+            elif len(matched) == 1:
+                matched_obj = matched[0]
+                score_in_percentage = _as_number(matched_obj.get("scoreInPercentage"), 0.0)
+                is_resistant = score_in_percentage == 100.00
+
+                count = _as_number(matched_obj.get("count"), 0)
+                total = _as_number(matched_obj.get("total"), 0)
+
+                if is_resistant:
+                    pass_reasons.append(f"Admin MFA control '{controlName}' is fully satisfied (score: 100%)")
+                else:
+                    fail_reasons.append(f"Admin MFA control '{controlName}' score is {score_in_percentage}%")
+                    recommendations.append("Require MFA for all administrative role members")
+            else:
+                fail_reasons.append(f"Control '{controlName}' not found in Secure Score data")
+                recommendations.append("Verify Microsoft Secure Score is collecting admin MFA data")
+        else:
+            fail_reasons.append("Microsoft Secure Score data not available - verify API permissions")
+            recommendations.append("Verify the Microsoft Graph API integration is returning Secure Score data")
+
+        return create_response(
+            result={
+                criteriaKey: is_resistant,
+                "scoreInPercentage": score_in_percentage,
+                "count": count,
+                "total": total,
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={
+                "hasSecureScoreData": len(values) > 0,
+                "scoreInPercentage": score_in_percentage,
+                "protectedCount": count,
+                "totalCount": total,
+            }
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False, "scoreInPercentage": 0.0, "count": 0, "total": 0},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/mfa/azure/isiamloggingenabled.py
+++ b/safeguards/mfa/azure/isiamloggingenabled.py
@@ -1,0 +1,137 @@
+"""
+Transformation: isIAMLoggingEnabled
+Vendor: Microsoft
+Category: Identity / Audit Logging
+
+Evaluates if identity audit logging is active by checking for directory audit log entries.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isIAMLoggingEnabled",
+                "vendor": "Microsoft",
+                "category": "Identity"
+            }
+        }
+    }
+
+
+def transform(input):
+    criteriaKey = "isIAMLoggingEnabled"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result={criteriaKey: False, "auditRecordCount": 0},
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False, "auditRecordCount": 0},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result={criteriaKey: False, "auditRecordCount": 0},
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        # An empty value array can reflect a short lookback window even when logging is on;
+        # collection-count semantics are accepted house behavior for this feed.
+        audit_records = data.get("value") or []
+        if not isinstance(audit_records, list):
+            audit_records = [audit_records] if audit_records else []
+
+        is_enabled = len(audit_records) > 0
+
+        if is_enabled:
+            pass_reasons.append(f"Directory audit logging is active with {len(audit_records)} recent record(s)")
+        else:
+            fail_reasons.append("No directory audit log records found")
+            recommendations.append("Enable directory audit logging in Microsoft Entra ID")
+
+        return create_response(
+            result={criteriaKey: is_enabled, "auditRecordCount": len(audit_records)},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"auditRecordCount": len(audit_records)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False, "auditRecordCount": 0},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/mfa/azure/isidentityprotectionenabled.py
+++ b/safeguards/mfa/azure/isidentityprotectionenabled.py
@@ -1,0 +1,139 @@
+"""
+Transformation: isIdentityProtectionEnabled
+Vendor: Microsoft
+Category: Identity Protection
+
+Evaluates if identity protection is enabled by checking for risk detections.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isIdentityProtectionEnabled",
+                "vendor": "Microsoft",
+                "category": "Identity Protection"
+            }
+        }
+    }
+
+
+def transform(input):
+    criteriaKey = "isIdentityProtectionEnabled"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result={criteriaKey: False, "riskDetectionCount": 0},
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False, "riskDetectionCount": 0},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result={criteriaKey: False, "riskDetectionCount": 0},
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        # Mirrored from safeguards/d9b6f27a-2e67-4b55-a09e-0784c5de9abd/isidentityprotectionenabled.py
+        # A clean tenant can have zero risk detections even with Identity Protection licensed and on.
+        risk_detections = data.get("value") or []
+        if not isinstance(risk_detections, list):
+            risk_detections = [risk_detections] if risk_detections else []
+
+        is_enabled = len(risk_detections) > 0
+
+        if is_enabled:
+            pass_reasons.append(
+                f"Identity protection is enabled with {len(risk_detections)} risk detections configured"
+            )
+        else:
+            fail_reasons.append("No Identity Protection alerts configured or detected")
+            recommendations.append("Enable Azure AD Identity Protection to detect and respond to identity-based risks")
+
+        return create_response(
+            result={criteriaKey: is_enabled, "riskDetectionCount": len(risk_detections)},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"riskDetectionCount": len(risk_detections)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False, "riskDetectionCount": 0},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/mfa/azure/ismfaenforced.py
+++ b/safeguards/mfa/azure/ismfaenforced.py
@@ -1,0 +1,206 @@
+"""
+Transformation: isMFAEnforced
+Vendor: Microsoft
+Category: Identity / MFA
+
+Evaluates if MFA is enforced at the tenant level via authentication methods and conditional access.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isMFAEnforced",
+                "vendor": "Microsoft",
+                "category": "Identity"
+            }
+        }
+    }
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def transform(input):
+    criteriaKey = "isMFAEnforced"
+    default_result = {
+        criteriaKey: False,
+        "mfaMethodsAvailable": False,
+        "enabledMethods": [],
+        "policiesEnforcingMFAForUsers": [],
+    }
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result=default_result,
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result=default_result,
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result=default_result,
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        # Def description references authenticationMethodsPolicy status == active, but that field
+        # does not exist on the merged getEstateMFAStatus payload; mirror the CA-based logic from
+        # safeguards/mfa/azure/ismfaenforcedforusers.py instead.
+        auth_methods = data.get("authMethodsPolicy") or {}
+        method_configs = _as_list(auth_methods.get("authenticationMethodConfigurations") or [])
+        mfa_method_types = ["microsoftauthenticator", "fido2", "softwareoath", "temporaryaccesspass"]
+        enabled_methods = []
+        for method in method_configs:
+            if not isinstance(method, dict):
+                continue
+            method_id = method.get("id", "")
+            state = method.get("state", "disabled")
+            if state == "enabled" and method_id.lower() in mfa_method_types:
+                enabled_methods.append(method_id)
+
+        methods_available = len(enabled_methods) > 0
+
+        ca_data = data.get("conditionalAccessPolicies") or {}
+        policies = _as_list(ca_data.get("value") or [])
+
+        policies_enforcing_mfa_for_users = []
+        for policy in policies:
+            if not isinstance(policy, dict):
+                continue
+            if policy.get("state") != "enabled":
+                continue
+            grant_controls = policy.get("grantControls") or {}
+            built_in_controls = grant_controls.get("builtInControls") or []
+            if "mfa" not in built_in_controls:
+                continue
+
+            conditions = policy.get("conditions") or {}
+            users = conditions.get("users") or {}
+            include_users = users.get("includeUsers") or []
+            include_groups = users.get("includeGroups") or []
+
+            targets_all = "All" in include_users or "all" in include_users
+            targets_groups = len(include_groups) > 0
+
+            if targets_all or targets_groups:
+                policies_enforcing_mfa_for_users.append(policy.get("displayName"))
+
+        mfa_enforced_for_users = len(policies_enforcing_mfa_for_users) > 0
+        is_enforced = methods_available and mfa_enforced_for_users
+
+        if methods_available:
+            pass_reasons.append(f"MFA methods enabled: {', '.join(enabled_methods)}")
+        else:
+            fail_reasons.append("No MFA authentication methods enabled at the tenant level")
+            recommendations.append(
+                "Enable MFA methods (Microsoft Authenticator, FIDO2, or Software OATH) in authentication methods policy"
+            )
+
+        if mfa_enforced_for_users:
+            pass_reasons.append(
+                f"MFA enforced for users via {len(policies_enforcing_mfa_for_users)} policies: "
+                f"{', '.join(policies_enforcing_mfa_for_users[:3])}"
+            )
+        else:
+            fail_reasons.append("No enabled conditional access policies requiring MFA for all users")
+            recommendations.append(
+                "Create a conditional access policy requiring MFA that targets All Users or relevant groups"
+            )
+
+        return create_response(
+            result={
+                criteriaKey: is_enforced,
+                "mfaMethodsAvailable": methods_available,
+                "enabledMethods": enabled_methods,
+                "policiesEnforcingMFAForUsers": policies_enforcing_mfa_for_users,
+            },
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"enabledMethods": len(enabled_methods), "mfaUserPolicies": len(policies_enforcing_mfa_for_users)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result=default_result,
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )

--- a/safeguards/mfa/azure/isprivilegedidentitymanagementenabled.py
+++ b/safeguards/mfa/azure/isprivilegedidentitymanagementenabled.py
@@ -1,0 +1,137 @@
+"""
+Transformation: isPrivilegedIdentityManagementEnabled
+Vendor: Microsoft
+Category: Identity / PIM
+
+Evaluates if Privileged Identity Management (PIM) is enabled by checking role eligibility schedules.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or []
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", [])
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {}
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or []
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "1.0",
+                "transformationId": "isPrivilegedIdentityManagementEnabled",
+                "vendor": "Microsoft",
+                "category": "Identity"
+            }
+        }
+    }
+
+
+def transform(input):
+    criteriaKey = "isPrivilegedIdentityManagementEnabled"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if not isinstance(data, dict):
+            return create_response(
+                result={criteriaKey: False, "scheduleCount": 0},
+                validation=validation,
+                fail_reasons=["Unexpected input format: expected a JSON object"]
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteriaKey: False, "scheduleCount": 0},
+                validation=validation,
+                fail_reasons=["Input validation failed"]
+            )
+
+        if "error" in data:
+            error_info = data.get("error", {})
+            inner_error = error_info.get("innerError", {})
+            return create_response(
+                result={criteriaKey: False, "scheduleCount": 0},
+                validation={"status": "error", "errors": [error_info.get("message", "API error")], "warnings": []},
+                fail_reasons=[f"Microsoft Graph API error: {error_info.get('code', 'unknown')}"],
+                input_summary={"errorCode": error_info.get("code"), "innerErrorCode": inner_error.get("code") if inner_error else None}
+            )
+
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        # Mirrored from safeguards/d9b6f27a-2e67-4b55-a09e-0784c5de9abd/isprivilegedidentitymanagementenabled.py
+        # Tenants with only permanent role assignments (no eligible/JIT roles) can false-negative here.
+        schedules = data.get("value") or []
+        if not isinstance(schedules, list):
+            schedules = [schedules] if schedules else []
+
+        is_enabled = len(schedules) > 0
+
+        if is_enabled:
+            pass_reasons.append(f"PIM is enabled with {len(schedules)} role eligibility schedules configured")
+        else:
+            fail_reasons.append("No Privileged Identity Management (PIM) roles configured")
+            recommendations.append("Enable Privileged Identity Management in Azure AD")
+
+        return create_response(
+            result={criteriaKey: is_enabled, "scheduleCount": len(schedules)},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={"scheduleCount": len(schedules)}
+        )
+
+    except Exception as e:
+        return create_response(
+            result={criteriaKey: False, "scheduleCount": 0},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(e)],
+            fail_reasons=[f"Transformation error: {str(e)}"]
+        )


### PR DESCRIPTION
## Summary
The active "Azure AD" integration evaluates 8 criteria whose transformation files do not exist in this repo - the engine 404s the download and those checks silently fail on every scan: `areAdminAccountsSeparate`, `isMFAEnforced`, `isIAMLoggingEnabled`, `isAdminMFAPhishingResistant`, `areConditionalAccessPoliciesConfigured`, `isIdentityProtectionEnabled`, `isPrivilegedIdentityManagementEnabled`, `areAccessReviewsConfigured`.

This PR adds the 8 files under `safeguards/mfa/azure/`, purely additive - no existing file is touched. Four mirror their existing `d9b6f27a` siblings (collection-count semantics, with null-value coalescing). `isMFAEnforced` mirrors the conditional-access logic of the existing `ismfaenforcedforusers.py`. `isAdminMFAPhishingResistant` keys on Secure Score control `AdminMFAV2` (a documented proxy - Secure Score has no dedicated phishing-resistance control). `areAdminAccountsSeparate` cannot honestly evaluate from the current bare `/v1.0/users` feed, so it fails with an explicit "feed update required" reason instead of a heuristic, and activates real license/role evaluation automatically once the feed carries that data; its role template ids and SKU ids are verified against `directoryRoleTemplates` and Microsoft's licensing reference, name-commented per line.

## Verification
- Offline harness (real lab-tenant fixtures + documented-schema fixtures for the license-gated feeds): all verdicts correct in both directions, identical results for wrapped/bare/string inputs, and no exceptions on hostile shapes (null collections, Graph error envelopes, single-item collapse).
- Adversarial review pass on all 8 files; imports restricted to `json`/`datetime`; fail-closed on every ambiguous path.

Note for product: once merged, these 8 checks begin producing real verdicts on legacy Azure AD scans (they currently fail silently) - customer scores may visibly move.
