### PR TITLE
fix: sophos epp and mdr

### DIFF
--- a/safeguards/1BC425FA-0638-4BF1-8194-19E7E4F2F43C/epp_transform.py
+++ b/safeguards/1BC425FA-0638-4BF1-8194-19E7E4F2F43C/epp_transform.py
@@ -87,9 +87,20 @@ def transform(input):
         recommendations = []
 
         # Initialize counters
-        isEPPConfigured = data.get("isEPPConfigured", True) if isinstance(data, dict) else True
-
-        items = data.get("items", []) if isinstance(data, dict) else []
+        # Token-Service preprocessing may deliver the endpoints as a bare list
+        # (when the API response's `data` field is itself a list) or as a dict
+        # containing `items`. Handle both so counts aren't silently zeroed.
+        if isinstance(data, list):
+            items = data
+            explicit_configured = None
+        elif isinstance(data, dict):
+            items = data.get("items") or []
+            if not isinstance(items, list):
+                items = []
+            explicit_configured = data.get("isEPPConfigured")
+        else:
+            items = []
+            explicit_configured = None
         total_endpoints = len(items)
         total_computers = 0
         total_servers = 0
@@ -265,7 +276,15 @@ def transform(input):
         coverage_scores["requiredCoveragePercentage"] = coverage_scores["Endpoint Protection"]
         coverage_scores["requiredConfigurationPercentage"] = coverage_scores["Endpoint Protection"]
 
-        coverage_scores["isEPPConfigured"] = isEPPConfigured
+        # "Configured" must reflect real deployment: honor an explicit flag from
+        # the API if present, otherwise require at least one protected endpoint.
+        # Previously this defaulted to True, producing a false PASS on zero data.
+        if explicit_configured is not None:
+            coverage_scores["isEPPConfigured"] = bool(explicit_configured)
+        else:
+            coverage_scores["isEPPConfigured"] = (
+                total_endpoints > 0 and coverage_scores["Endpoint Protection"] > 0
+            )
 
         # Build pass/fail reasons (use concatenation to avoid list mutation in restricted Python)
         epp_coverage = coverage_scores.get('Endpoint Protection', 0)

--- a/safeguards/1BC425FA-0638-4BF1-8194-19E7E4F2F43C/mdr_transform.py
+++ b/safeguards/1BC425FA-0638-4BF1-8194-19E7E4F2F43C/mdr_transform.py
@@ -88,9 +88,20 @@ def transform(input):
         recommendations = []
 
         # Initialize counters
-        isMDRConfigured = data.get("isMDRConfigured", True) if isinstance(data, dict) else True
-
-        items = data.get("items", []) if isinstance(data, dict) else []
+        # Token-Service preprocessing may deliver the endpoints as a bare list
+        # (when the API response's `data` field is itself a list) or as a dict
+        # containing `items`. Handle both so counts aren't silently zeroed.
+        if isinstance(data, list):
+            items = data
+            explicit_configured = None
+        elif isinstance(data, dict):
+            items = data.get("items") or []
+            if not isinstance(items, list):
+                items = []
+            explicit_configured = data.get("isMDRConfigured")
+        else:
+            items = []
+            explicit_configured = None
         total_endpoints = len(items)
         total_computers = 0
         total_servers = 0
@@ -265,7 +276,15 @@ def transform(input):
         coverage_scores["requiredCoveragePercentage"] = coverage_scores["MDR"]
         coverage_scores["requiredConfigurationPercentage"] = coverage_scores["MDR"]
 
-        coverage_scores["isMDRConfigured"] = isMDRConfigured
+        # "Configured" must reflect real deployment: honor an explicit flag from
+        # the API if present, otherwise require at least one MDR-covered endpoint.
+        # Previously this defaulted to True, producing a false PASS on zero data.
+        if explicit_configured is not None:
+            coverage_scores["isMDRConfigured"] = bool(explicit_configured)
+        else:
+            coverage_scores["isMDRConfigured"] = (
+                total_endpoints > 0 and coverage_scores["MDR"] > 0
+            )
 
         # Build pass/fail reasons
         if coverage_scores["isMDREnabled"]:


### PR DESCRIPTION
- isEPPConfigured/isMDRConfigured defaulted to True instead of being derived from the data.
- The bare-list input shape wasn't handled, zeroing out all endpoint counts.