### PR TITLE
fix: qualys asm return vuln counts as numbers

### DIFF
--- a/safeguards/asm/qualys/criticalvulnerabilitycount.py
+++ b/safeguards/asm/qualys/criticalvulnerabilitycount.py
@@ -58,9 +58,9 @@ def evaluate(data):
                 if int(d.get('SEVERITY', 0)) >= 4
                 and d.get('STATUS') in ['New', 'Active', 'Re-Opened']
             )
-        return {"criticalVulnerabilityCount": str(critical_count), "count": critical_count}
+        return {"criticalVulnerabilityCount": critical_count, "count": critical_count}
     except Exception as e:
-        return {"criticalVulnerabilityCount": "0", "error": str(e)}
+        return {"criticalVulnerabilityCount": 0, "error": str(e)}
 
 
 def transform(input):

--- a/safeguards/asm/qualys/knownexploitedvulncount.py
+++ b/safeguards/asm/qualys/knownexploitedvulncount.py
@@ -47,9 +47,9 @@ def evaluate(data):
     try:
         kev_matches = data.get('kev_matches', [])
         count = len(kev_matches)
-        return {"knownExploitedVulnCount": str(count), "count": count, "cves": [m.get('cve', '') for m in kev_matches[:10]]}
+        return {"knownExploitedVulnCount": count, "count": count, "cves": [m.get('cve', '') for m in kev_matches[:10]]}
     except Exception as e:
-        return {"knownExploitedVulnCount": "0", "error": str(e)}
+        return {"knownExploitedVulnCount": 0, "error": str(e)}
 
 
 def transform(input):


### PR DESCRIPTION
Qualys ASM critical and known-exploited vuln counts were returned as strings, causing numeric checks to fail (e.g. "0" ≠ 0); return them as numbers instead.