### PR TITLE
fix: qualys knownExploitedVulnCount pass when count is 0

### DIFF
--- a/safeguards/asm/qualys/knownexploitedvulncount.py
+++ b/safeguards/asm/qualys/knownexploitedvulncount.py
@@ -63,24 +63,29 @@ def transform(input):
         if validation.get("status") == "failed":
             return create_response(result={criteriaKey: False}, validation=validation, fail_reasons=["Input validation failed"])
         eval_result = evaluate(data)
-        result_value = eval_result.get(criteriaKey, False)
+        count_value = eval_result.get(criteriaKey, 0)
         extra_fields = {k: v for k, v in eval_result.items() if k != criteriaKey and k != "error"}
         pass_reasons = []
         fail_reasons = []
         recommendations = []
-        if result_value:
+        # Zero-tolerance count metric: 0 known-exploited vulns is the PASS state.
+        # Do NOT use `if count_value:` here -- a count of 0 is falsy, which wrongly
+        # reported "check failed" even when the value matched the expected 0.
+        had_error = "error" in eval_result
+        passed = (not had_error) and count_value == 0
+        if passed:
             pass_reasons.append(f"{criteriaKey} check passed")
             for k, v in extra_fields.items():
                 pass_reasons.append(f"{k}: {v}")
         else:
             fail_reasons.append(f"{criteriaKey} check failed")
-            if "error" in eval_result:
+            if had_error:
                 fail_reasons.append(eval_result["error"])
             recommendations.append(f"Review Qualys configuration for {criteriaKey}")
         return create_response(
-            result={criteriaKey: result_value, **extra_fields}, validation=validation,
+            result={criteriaKey: count_value, **extra_fields}, validation=validation,
             pass_reasons=pass_reasons, fail_reasons=fail_reasons, recommendations=recommendations,
-            input_summary={criteriaKey: result_value, **extra_fields})
+            input_summary={criteriaKey: count_value, **extra_fields})
     except Exception as e:
         return create_response(
             result={criteriaKey: False}, validation={"status": "error", "errors": [], "warnings": []},


### PR DESCRIPTION
Fix knownExploitedVulnCount to pass when the count is 0 instead of failing, since a count of 0 is the desired state (note: kev_matches is not yet populated, so the count is always 0 until real KEV matching is wired up).