### PR TITLE
Fix remaining Britive IAM transforms

### DIFF
--- a/safeguards/iam/britive/areadminaccountsseparate.py
+++ b/safeguards/iam/britive/areadminaccountsseparate.py
@@ -53,7 +53,7 @@ def evaluate(data):
         # ] }
         result = False
 
-        users = data.get("data", data.get("users", []))
+        users = data if isinstance(data, list) else data.get("data", data.get("users", []))
         if not isinstance(users, list) or len(users) == 0:
             return {
                 "areAdminAccountsSeparate": False,
@@ -68,11 +68,16 @@ def evaluate(data):
 
         admin_users = []
         for user in active_users:
+            # Britive flags tenant admins either via a populated adminRoles list
+            # (e.g. "TenantAdmin") or the rootUser boolean. Count both.
+            is_admin = bool(user.get("rootUser", False))
             roles = user.get("adminRoles", [])
             if isinstance(roles, list):
                 admin_role_names = [r.get("name", "") for r in roles]
                 if "TenantAdmin" in admin_role_names:
-                    admin_users.append(user.get("username", user.get("userId", "unknown")))
+                    is_admin = True
+            if is_admin:
+                admin_users.append(user.get("username", user.get("userId", "unknown")))
 
         admin_count = len(admin_users)
         admin_ratio = admin_count / total_active if total_active > 0 else 0
@@ -80,6 +85,12 @@ def evaluate(data):
         # Pass if fewer than 20% of active users are admins (separation of duties)
         # Also pass if admin accounts exist but none have regular user overlap
         result = admin_count > 0 and admin_ratio <= 0.20
+
+        return {
+            "areAdminAccountsSeparate": result,
+            "totalActiveUsers": total_active,
+            "adminAccounts": admin_count,
+        }
     except Exception as e:
         return {"areAdminAccountsSeparate": False, "error": str(e)}
 

--- a/safeguards/iam/britive/confirmedlicensepurchased.py
+++ b/safeguards/iam/britive/confirmedlicensepurchased.py
@@ -49,15 +49,22 @@ def evaluate(data):
         # or for newer versions: {"totalCount": N, "data": [...]}
         result = False
 
-        total = data.get("count", data.get("totalCount", 0))
-        users = data.get("data", data.get("users", []))
+        # /api/users may arrive as a bare list of users or wrapped as {count, data:[...]}
+        if isinstance(data, list):
+            users = data
+            total = len(data)
+        else:
+            total = data.get("count", data.get("totalCount", 0))
+            users = data.get("data", data.get("users", []))
 
-        if isinstance(total, (int, float)) and total > 0:
-            result = True
-        elif isinstance(users, list) and len(users) > 0:
+        if isinstance(users, list) and len(users) > 0:
             # Confirm at least one active user — confirms active subscription
             active_users = [u for u in users if u.get("status", "").lower() == "active"]
             result = len(active_users) > 0
+        elif isinstance(total, (int, float)) and total > 0:
+            result = True
+
+        return {"confirmedLicensePurchased": result, "userCount": total}
     except Exception as e:
         return {"confirmedLicensePurchased": False, "error": str(e)}
 

--- a/safeguards/iam/britive/isjitaccessenabled.py
+++ b/safeguards/iam/britive/isjitaccessenabled.py
@@ -63,6 +63,8 @@ def evaluate(data):
                 if status == "active" and has_valid_paps:
                     result = True
                     break
+
+        return {"isJITAccessEnabled": result}
     except Exception as e:
         return {"isJITAccessEnabled": False, "error": str(e)}
 

--- a/safeguards/iam/britive/issamlenforced.py
+++ b/safeguards/iam/britive/issamlenforced.py
@@ -59,6 +59,8 @@ def evaluate(data):
                 if issuer and sign_in_url:
                     result = True
                     break
+
+        return {"isSAMLEnforced": result}
     except Exception as e:
         return {"isSAMLEnforced": False, "error": str(e)}
 


### PR DESCRIPTION
- confirmedLicensePurchased: add missing return + handle bare-list /api/users response; passes (18 active users)
- isSAMLEnforced: add missing return; passes (issuer + signInUrl present)
- areAdminAccountsSeparate: add missing return, handle bare-list input, count rootUser admins (Britive leaves adminRoles empty); passes (1 admin / 18 users)
- isJITAccessEnabled: add missing return (still fails; /api/apps returns hasValidPaps: null, needs profiles chaining, tracked separately)