### PR TITLE
Fix Britive profile and policy transforms

### DIFF
--- a/safeguards/iam/britive/isapprovalworkflowconfigured.py
+++ b/safeguards/iam/britive/isapprovalworkflowconfigured.py
@@ -45,23 +45,28 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
 def evaluate(data):
     """Core evaluation logic extracted from doc transform."""
     try:
-        # Policy objects have structure:
-        # { "policyId": str, "name": str, "isActive": bool,
-        #   "approvalRequired": bool,
-        #   "approvers": { "userIds": [...], "tags": [...] },
-        #   "notificationMedium": str, "timeToApprove": int, ... }
+        # Britive policy objects have structure:
+        # { "id": str, "name": str, "isActive": bool, "accessType": "Allow",
+        #   "condition": {...}, "members": {...},
+        #   "settings": [ { "settingsType": "APPROVAL"|"JUSTIFICATION"|"IM", ... } ] }
+        # Approval is configured as a policy setting, not a top-level flag.
+        # Integration layer passes merged { "policies": [...] }
 
-        policies = (
-            data.get("policies") or
-            data.get("data") or
-            (data if isinstance(data, list) else [])
-        )
+        if isinstance(data, list):
+            policies = data
+        else:
+            policies = (
+                data.get("policies") or
+                data.get("data") or
+                []
+            )
 
         if not isinstance(policies, list):
             return {"isApprovalWorkflowConfigured": False, "reason": "No policy data found"}
 
         result = False
         approval_policies_count = 0
+        active_policies_count = 0
 
         for policy in policies:
             is_active = policy.get("isActive", True)
@@ -71,24 +76,41 @@ def evaluate(data):
             if not is_active:
                 continue
 
-            approval_required = policy.get("approvalRequired", False)
-            if isinstance(approval_required, str):
-                approval_required = approval_required.lower() in ("true", "yes", "1")
+            active_policies_count += 1
 
-            # Check approvers list as secondary signal
-            approvers = policy.get("approvers", {})
-            has_approvers = False
-            if isinstance(approvers, dict):
-                user_approvers = approvers.get("userIds", approvers.get("users", []))
-                tag_approvers = approvers.get("tags", [])
-                has_approvers = (
-                    (isinstance(user_approvers, list) and len(user_approvers) > 0) or
-                    (isinstance(tag_approvers, list) and len(tag_approvers) > 0)
-                )
+            has_approval = False
+            for setting in (policy.get("settings") or []):
+                if str(setting.get("settingsType", "")).upper() == "APPROVAL":
+                    has_approval = True
+                    break
 
-            if approval_required or has_approvers:
+            if not has_approval:
+                # Fall back to the flat shape used by other/older payloads
+                approval_required = policy.get("approvalRequired", False)
+                if isinstance(approval_required, str):
+                    approval_required = approval_required.lower() in ("true", "yes", "1")
+
+                approvers = policy.get("approvers", {})
+                has_approvers = False
+                if isinstance(approvers, dict):
+                    user_approvers = approvers.get("userIds", approvers.get("users", []))
+                    tag_approvers = approvers.get("tags", [])
+                    has_approvers = (
+                        (isinstance(user_approvers, list) and len(user_approvers) > 0) or
+                        (isinstance(tag_approvers, list) and len(tag_approvers) > 0)
+                    )
+
+                has_approval = bool(approval_required or has_approvers)
+
+            if has_approval:
                 approval_policies_count += 1
                 result = True
+
+        return {
+            "isApprovalWorkflowConfigured": result,
+            "activePoliciesChecked": active_policies_count,
+            "policiesWithApproval": approval_policies_count,
+        }
     except Exception as e:
         return {"isApprovalWorkflowConfigured": False, "error": str(e)}
 

--- a/safeguards/iam/britive/iszerostandingprivilegesenabled.py
+++ b/safeguards/iam/britive/iszerostandingprivilegesenabled.py
@@ -47,16 +47,18 @@ def evaluate(data):
     try:
         # /api/apps/{appId}/paps returns profile objects:
         # { "papId": str, "name": str, "status": "active",
-        #   "expirationInMinutes": int (0 = no expiry),
-        #   "sessionDuration": int|null, ... }
+        #   "expirationDuration": int (milliseconds, 0 = no expiry), ... }
         # Integration layer passes merged { "profiles": [...] }
 
-        profiles = (
-            data.get("profiles") or
-            data.get("data") or
-            data.get("paps") or
-            (data if isinstance(data, list) else [])
-        )
+        if isinstance(data, list):
+            profiles = data
+        else:
+            profiles = (
+                data.get("profiles") or
+                data.get("data") or
+                data.get("paps") or
+                []
+            )
 
         if not isinstance(profiles, list):
             return {"isZeroStandingPrivilegesEnabled": False, "reason": "No profile data found"}
@@ -75,29 +77,31 @@ def evaluate(data):
         profiles_without_expiry = []
 
         for profile in active_profiles:
-            expiry = profile.get("expirationInMinutes", None)
-            session = profile.get("sessionDuration", None)
-
             has_expiry = False
 
-            if expiry is not None:
+            # Britive returns expirationDuration in milliseconds; older shapes
+            # used expirationInMinutes / sessionDuration.
+            for field in ("expirationDuration", "expirationInMinutes", "sessionDuration"):
+                value = profile.get(field)
+                if value is None:
+                    continue
                 try:
-                    if int(expiry) > 0:
+                    if int(value) > 0:
                         has_expiry = True
+                        break
                 except (TypeError, ValueError):
-                    pass
-
-            if not has_expiry and session is not None:
-                try:
-                    if int(session) > 0:
-                        has_expiry = True
-                except (TypeError, ValueError):
-                    pass
+                    continue
 
             if not has_expiry:
                 profiles_without_expiry.append(profile.get("name", profile.get("papId", "unknown")))
 
         result = len(profiles_without_expiry) == 0
+
+        return {
+            "isZeroStandingPrivilegesEnabled": result,
+            "activeProfiles": total,
+            "profilesWithoutExpiry": profiles_without_expiry,
+        }
     except Exception as e:
         return {"isZeroStandingPrivilegesEnabled": False, "error": str(e)}
 


### PR DESCRIPTION
- iszerostandingprivilegesenabled: read expirationDuration (ms — the field Britive actually returns), fallbacks to expirationInMinutes/sessionDuration; handle bare-list input; add missing return
- isapprovalworkflowconfigured: detect approval via settings[].settingsType == "APPROVAL" (where Britive stores it), fallback to flat approvalRequired/approvers; handle bare-list input; add missing return
- Verified against live merged payloads (22 profiles / 22 policies) and the RestrictedPython sandbox: ZSP → true (21 active profiles, all time-bounded); Approval → false, correctly reporting policiesWithApproval: 0
- Pairs with Integration-Service hotfix/britive-iam-mfa-audit; no merge-order dependency