### PR TITLE
fix: ninjaone remediation tracking counts patch activity not message text

### DIFF
--- a/safeguards/vulnerabilitymgmt/ninjaone/isvulnerabilityremediationtracked.py
+++ b/safeguards/vulnerabilitymgmt/ninjaone/isvulnerabilityremediationtracked.py
@@ -2,9 +2,24 @@
 Transformation: isVulnerabilityRemediationTracked
 Vendor: NinjaOne
 Category: Vulnerability Management / Remediation Tracking
+Method: getActivities
 
-Validates that vulnerability remediation activities are tracked and documented.
-Checks the activities endpoint for remediation-related activity logs.
+Validates that vulnerability remediation is actually happening, by counting patch
+management activities in the NinjaOne activity log
+(GET /api/v2/activities?df=org = {orgId}).
+
+The verdict keys off the structured `activityType` enum, NOT the free-text
+`message`. An earlier version substring-matched words like 'update', 'install'
+and 'software' against the message, which counted routine software inventory
+noise as remediation: measured live on 2026-07-15, a tenant doing zero patching
+scored 86 of 95 activities as "remediation" purely from lines like
+"Software installed: 'claude', Version: '2.1.209'". Message text is prose and
+describes any software event; activityType is a fixed vocabulary and only
+PATCH_MANAGEMENT / SOFTWARE_PATCH_MANAGEMENT mean patching.
+
+Scope note: this proves patch remediation is being performed and logged for the
+scoped organization. An empty activity feed is a real answer ("nothing recorded"),
+not a collection failure, and is reported as such.
 """
 
 import json
@@ -108,49 +123,50 @@ def transform(input):
 
         total_activities = len(activities)
 
-        if total_activities > 0:
-            remediation_keywords = [
-                'patch', 'update', 'remediat', 'install', 'fix', 'upgrade',
-                'vuln', 'security', 'hotfix', 'software'
-            ]
+        # Only these activityType values represent patching. Anything else is
+        # monitoring, alerting or software inventory, none of which is remediation.
+        patch_activity_types = ["PATCH_MANAGEMENT", "SOFTWARE_PATCH_MANAGEMENT"]
 
-            for activity in activities:
-                if isinstance(activity, dict):
-                    activity_type = str(activity.get('type', activity.get('activityType', ''))).lower()
-                    message = str(activity.get('message', activity.get('description',
-                              activity.get('statusMessage', '')))).lower()
+        type_breakdown = {}
+        for activity in activities:
+            if isinstance(activity, dict):
+                activity_type = str(activity.get("activityType", "unknown")).upper()
+                type_breakdown[activity_type] = type_breakdown.get(activity_type, 0) + 1
+                if activity_type in patch_activity_types:
+                    remediation_activities = remediation_activities + 1
 
-                    if any(kw in activity_type for kw in remediation_keywords) or \
-                       any(kw in message for kw in remediation_keywords):
-                        remediation_activities += 1
-
-            if remediation_activities > 0:
-                remediation_tracked = True
-            else:
-                # Activities exist but none are remediation-related
-                # The system is still tracking activities
-                remediation_tracked = True
-                additional_findings.append(
-                    f"{total_activities} activities found but none explicitly relate to vulnerability remediation"
-                )
+        remediation_tracked = remediation_activities > 0
 
         if remediation_tracked:
-            if remediation_activities > 0:
-                pass_reasons.append(
-                    f"Vulnerability remediation is tracked ({remediation_activities} remediation-related "
-                    f"activities out of {total_activities} total)"
-                )
-            else:
-                pass_reasons.append(f"Activity tracking is enabled ({total_activities} activities logged)")
+            pass_reasons.append(
+                f"Vulnerability remediation is tracked: {remediation_activities} patch management "
+                f"activities recorded out of {total_activities} total activities"
+            )
+            pass_reasons.append(f"activityTypeBreakdown: {type_breakdown}")
+        elif total_activities > 0:
+            # A real answer from NinjaOne: it is logging, but nothing is being patched.
+            fail_reasons.append(
+                f"No patch management activity recorded. NinjaOne returned {total_activities} "
+                f"activities for this organization, none of type PATCH_MANAGEMENT or "
+                f"SOFTWARE_PATCH_MANAGEMENT"
+            )
+            recommendations.append(
+                "Confirm NinjaOne patch management policies are enabled for this organization's "
+                "devices, and that patch scans and installs are running on a schedule"
+            )
+            additional_findings.append(f"activityTypeBreakdown: {type_breakdown}")
         else:
-            fail_reasons.append("No activity data found in NinjaOne")
-            recommendations.append("Ensure NinjaOne activity logging is enabled to track vulnerability remediation")
+            fail_reasons.append("No activity data returned from NinjaOne for this organization")
+            recommendations.append(
+                "Verify the organization ID is correct and that NinjaOne activity logging is enabled"
+            )
 
         return create_response(
             result={
                 criteriaKey: remediation_tracked,
                 "totalActivities": total_activities,
-                "remediationActivities": remediation_activities
+                "remediationActivities": remediation_activities,
+                "activityTypeBreakdown": type_breakdown
             },
             validation=validation,
             pass_reasons=pass_reasons,
@@ -159,7 +175,8 @@ def transform(input):
             additional_findings=additional_findings,
             input_summary={
                 "totalActivities": total_activities,
-                "remediationActivities": remediation_activities
+                "remediationActivities": remediation_activities,
+                "activityTypeBreakdown": type_breakdown
             }
         )
 


### PR DESCRIPTION
- Match the activityType enum (PATCH_MANAGEMENT, SOFTWARE_PATCH_MANAGEMENT) instead of substring-matching free-text message
- Remove the branch that returned true on zero remediation activities
- Add activityTypeBreakdown to the output