### PR TITLE
[LABS-3196] Add Microsoft one-click Email and Endpoint evidence transforms

### DIFF
--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
@@ -3,10 +3,10 @@ Transformation: isSSOEnabled (Endpoint Administrator MFA)
 Vendor: Microsoft
 Category: Endpoint Security
 
-Evaluates whether Endpoint Security administrator access requires MFA. The
-check deliberately accepts only broad, enforceable Conditional Access policies.
-Narrower policies need additional identity and application evidence before they
-can safely prove that every Endpoint administrator is covered.
+Evaluates whether Endpoint Security administrator access requires MFA. Accepts
+either tenant-wide coverage or complete coverage of the Microsoft Entra roles
+that administer Defender, targeting all resources or the Defender admin portal.
+Ambiguous exclusions and conditional coverage remain fail-closed.
 """
 
 import json
@@ -16,6 +16,38 @@ from datetime import datetime
 # Preserve the legacy requirement key while replacing its invalid identity-provider
 # evidence with a real Conditional Access MFA evaluation.
 CRITERIA_KEY = "isSSOEnabled"
+
+# Microsoft Entra roles with Defender administrative permissions. Read-only
+# Global Reader and Security Reader access is deliberately outside this
+# administrative-access criterion.
+DEFENDER_ADMIN_ROLE_IDS = (
+    "62e90394-69f5-4237-9190-012177145e10",  # Global Administrator
+    "194ae4cb-b126-40b2-bd5b-6091b380977d",  # Security Administrator
+    "5f2222b1-57c3-48ba-8ad5-d4759f1fde6f",  # Security Operator
+)
+
+DEFENDER_PORTAL_APP_ID = "80ccca67-54bd-44ab-8625-4b79c4dc7775"
+DEFENDER_APPLICATION_TARGETS = (
+    "microsoftadminportals",
+    DEFENDER_PORTAL_APP_ID,
+)
+
+# Microsoft-managed authentication strengths whose documented requirement is
+# MFA. A custom strength is accepted only when the response explicitly says it
+# satisfies MFA; an opaque custom ID is not enough evidence.
+MFA_AUTHENTICATION_STRENGTH_IDS = (
+    "00000000-0000-0000-0000-000000000002",
+    "00000000-0000-0000-0000-000000000003",
+    "00000000-0000-0000-0000-000000000004",
+)
+
+
+def normalized_values(values):
+    if values is None:
+        return []
+    if not isinstance(values, list):
+        return None
+    return [str(value).strip().lower() for value in values]
 
 
 def extract_input(input_data):
@@ -85,47 +117,110 @@ def requires_mfa(grant_controls):
     if not isinstance(grant_controls, dict):
         return False
 
-    controls = grant_controls.get("builtInControls") or []
-    if not isinstance(controls, list) or "mfa" not in controls:
+    controls = normalized_values(grant_controls.get("builtInControls"))
+    if controls is None:
+        return False
+    if "mfa" in controls:
+        operator = str(grant_controls.get("operator") or "").upper()
+        if operator == "AND":
+            return True
+        if operator == "OR" and controls == ["mfa"]:
+            return not any([
+                grant_controls.get("customAuthenticationFactors"),
+                grant_controls.get("termsOfUse"),
+                grant_controls.get("authenticationStrength"),
+            ])
+
+    authentication_strength = grant_controls.get("authenticationStrength")
+    if not isinstance(authentication_strength, dict):
         return False
 
+    # Authentication strength must itself be mandatory. An OR policy that also
+    # permits another grant control does not require MFA on every sign-in.
     operator = str(grant_controls.get("operator") or "").upper()
-    if operator == "AND":
-        return True
-    if operator != "OR" or controls != ["mfa"]:
+    if operator not in ("AND", "OR"):
+        return False
+    for key in ("customAuthenticationFactors", "termsOfUse"):
+        value = grant_controls.get(key)
+        if value is not None and not isinstance(value, list):
+            return False
+    alternative_controls = any([
+        controls,
+        grant_controls.get("customAuthenticationFactors"),
+        grant_controls.get("termsOfUse"),
+    ])
+    if alternative_controls and operator != "AND":
         return False
 
-    return not (
-        grant_controls.get("authenticationStrength")
-        or grant_controls.get("customAuthenticationFactors")
-        or grant_controls.get("termsOfUse")
+    requirements_satisfied = str(
+        authentication_strength.get("requirementsSatisfied") or ""
+    ).strip().lower()
+    if requirements_satisfied == "mfa":
+        return True
+
+    return (
+        str(authentication_strength.get("id") or "").strip().lower()
+        in MFA_AUTHENTICATION_STRENGTH_IDS
     )
 
 
-def covers_all_users(users):
-    if not isinstance(users, dict) or "All" not in (users.get("includeUsers") or []):
+def covers_endpoint_administrators(users):
+    if not isinstance(users, dict):
         return False
 
-    return not any([
+    # Without role membership evidence, any user/group/role exclusion could
+    # remove an Endpoint administrator from the policy.
+    if any([
         users.get("excludeUsers"),
         users.get("excludeGroups"),
         users.get("excludeRoles"),
         users.get("excludeGuestsOrExternalUsers"),
-    ])
+    ]):
+        return False
+
+    include_users = normalized_values(users.get("includeUsers"))
+    include_roles = normalized_values(users.get("includeRoles"))
+    if include_users is None or include_roles is None:
+        return False
+    if "all" in include_users:
+        return True
+
+    return all(role_id in include_roles for role_id in DEFENDER_ADMIN_ROLE_IDS)
 
 
-def covers_all_applications(applications):
+def covers_defender_admin_portal(applications):
     if not isinstance(applications, dict):
         return False
+
+    included = normalized_values(applications.get("includeApplications"))
+    excluded = normalized_values(applications.get("excludeApplications"))
+    if included is None or excluded is None:
+        return False
+    if (
+        "applicationFilter" in applications
+        and applications.get("applicationFilter") is not None
+    ):
+        return False
+
+    # Excluding the admin-portals grouping, the Defender portal directly, or
+    # the Office 365 grouping makes Defender coverage ambiguous.
+    relevant_exclusions = DEFENDER_APPLICATION_TARGETS + ("office365",)
+    if any(target in excluded for target in relevant_exclusions):
+        return False
+
     return (
-        "All" in (applications.get("includeApplications") or [])
-        and not applications.get("excludeApplications")
+        "all" in included
+        or any(target in included for target in DEFENDER_APPLICATION_TARGETS)
     )
 
 
 def has_no_narrowing_conditions(conditions):
-    client_app_types = conditions.get("clientAppTypes") or []
-    if client_app_types and "all" not in [str(value).lower() for value in client_app_types]:
+    client_app_types = normalized_values(conditions.get("clientAppTypes"))
+    if client_app_types is None:
+        return False
+    if client_app_types and not any(
+        value in client_app_types for value in ("all", "browser")
+    ):
         return False
 
     return not any([
@@ -150,8 +245,8 @@ def is_enforced_endpoint_admin_mfa_policy(policy):
         return False
 
     return (
-        covers_all_users(conditions.get("users"))
-        and covers_all_applications(conditions.get("applications"))
+        covers_endpoint_administrators(conditions.get("users"))
+        and covers_defender_admin_portal(conditions.get("applications"))
         and has_no_narrowing_conditions(conditions)
         and requires_mfa(policy.get("grantControls"))
     )
@@ -222,7 +317,7 @@ def transform(input):
                 result,
                 validation=validation,
                 pass_reasons=[
-                    "Enabled Conditional Access policy requires MFA for all users and cloud applications: "
+                    "Enabled Conditional Access policy requires MFA for Endpoint Security administrative access: "
                     + ", ".join(names)
                 ],
                 input_summary={"totalPolicies": len(policies), "matchingPolicies": len(matches)},
@@ -235,7 +330,7 @@ def transform(input):
                 "No enabled Conditional Access policy proves MFA is required for all Endpoint administrators"
             ],
             recommendations=[
-                "Enable a Conditional Access policy that requires MFA for all users and all cloud applications without exclusions"
+                "Require MFA for all users or all supported Defender administrator roles, targeting all resources or Microsoft Admin Portals without relevant exclusions"
             ],
             input_summary={"totalPolicies": len(policies), "matchingPolicies": 0},
         )

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
@@ -1,0 +1,200 @@
+"""Evaluate whether Endpoint Security administrator access requires MFA.
+
+The check deliberately accepts only broad, enforceable Conditional Access
+policies. Narrower policies need additional identity and application evidence
+before they can safely prove that every Endpoint administrator is covered.
+"""
+
+import json
+from datetime import datetime
+
+
+CRITERIA_KEY = "isMFAEnforcedForEndpointAdmins"
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+
+    data = input_data
+    if isinstance(data, dict):
+        for _ in range(3):
+            unwrapped = False
+            for key in ["api_response", "response", "result", "apiResponse", "Output"]:
+                if key in data and isinstance(data.get(key), (dict, list)):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+
+    return data, {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, transformation_errors=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "success", "errors": []},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": [],
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "2.0",
+                "transformationId": CRITERIA_KEY,
+                "vendor": "Microsoft",
+                "category": "Endpoint Security",
+            },
+        },
+    }
+
+
+def requires_mfa(grant_controls):
+    if not isinstance(grant_controls, dict):
+        return False
+
+    controls = grant_controls.get("builtInControls") or []
+    if not isinstance(controls, list) or "mfa" not in controls:
+        return False
+
+    operator = str(grant_controls.get("operator") or "").upper()
+    if operator == "AND":
+        return True
+    if operator != "OR" or controls != ["mfa"]:
+        return False
+
+    return not (
+        grant_controls.get("authenticationStrength")
+        or grant_controls.get("customAuthenticationFactors")
+        or grant_controls.get("termsOfUse")
+    )
+
+
+def covers_all_users(users):
+    if not isinstance(users, dict) or "All" not in (users.get("includeUsers") or []):
+        return False
+
+    return not any([
+        users.get("excludeUsers"),
+        users.get("excludeGroups"),
+        users.get("excludeRoles"),
+        users.get("excludeGuestsOrExternalUsers"),
+    ])
+
+
+def covers_all_applications(applications):
+    if not isinstance(applications, dict):
+        return False
+    return (
+        "All" in (applications.get("includeApplications") or [])
+        and not applications.get("excludeApplications")
+    )
+
+
+def has_no_narrowing_conditions(conditions):
+    client_app_types = conditions.get("clientAppTypes") or []
+    if client_app_types and "all" not in [str(value).lower() for value in client_app_types]:
+        return False
+
+    return not any([
+        conditions.get("signInRiskLevels"),
+        conditions.get("userRiskLevels"),
+        conditions.get("servicePrincipalRiskLevels"),
+        conditions.get("platforms"),
+        conditions.get("locations"),
+        conditions.get("devices"),
+        conditions.get("clientApplications"),
+        conditions.get("authenticationFlows"),
+        conditions.get("insiderRiskLevels"),
+    ])
+
+
+def is_enforced_endpoint_admin_mfa_policy(policy):
+    if not isinstance(policy, dict) or str(policy.get("state") or "").lower() != "enabled":
+        return False
+
+    conditions = policy.get("conditions") or {}
+    if not isinstance(conditions, dict):
+        return False
+
+    return (
+        covers_all_users(conditions.get("users"))
+        and covers_all_applications(conditions.get("applications"))
+        and has_no_narrowing_conditions(conditions)
+        and requires_mfa(policy.get("grantControls"))
+    )
+
+
+def transform(input):
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+        policies = data.get("value", []) if isinstance(data, dict) else []
+        if not isinstance(policies, list):
+            policies = []
+
+        matches = [
+            policy for policy in policies
+            if is_enforced_endpoint_admin_mfa_policy(policy)
+        ]
+        is_enforced = bool(matches)
+        result = {
+            CRITERIA_KEY: is_enforced,
+            "matchingPolicies": len(matches),
+        }
+
+        if is_enforced:
+            names = [str(policy.get("displayName") or "unnamed") for policy in matches]
+            return create_response(
+                result,
+                validation=validation,
+                pass_reasons=[
+                    "Enabled Conditional Access policy requires MFA for all users and cloud applications: "
+                    + ", ".join(names)
+                ],
+                input_summary={"totalPolicies": len(policies), "matchingPolicies": len(matches)},
+            )
+
+        return create_response(
+            result,
+            validation=validation,
+            fail_reasons=[
+                "No enabled Conditional Access policy proves MFA is required for all Endpoint administrators"
+            ],
+            recommendations=[
+                "Enable a Conditional Access policy that requires MFA for all users and all cloud applications without exclusions"
+            ],
+            input_summary={"totalPolicies": len(policies), "matchingPolicies": 0},
+        )
+    except Exception as error:
+        return create_response(
+            {CRITERIA_KEY: False, "matchingPolicies": 0},
+            transformation_errors=[str(error)],
+            fail_reasons=["Transformation error: " + str(error)],
+        )

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
@@ -1,8 +1,12 @@
-"""Evaluate whether Endpoint Security administrator access requires MFA.
+"""
+Transformation: isSSOEnabled (Endpoint Administrator MFA)
+Vendor: Microsoft
+Category: Endpoint Security
 
-The check deliberately accepts only broad, enforceable Conditional Access
-policies. Narrower policies need additional identity and application evidence
-before they can safely prove that every Endpoint administrator is covered.
+Evaluates whether Endpoint Security administrator access requires MFA. The
+check deliberately accepts only broad, enforceable Conditional Access policies.
+Narrower policies need additional identity and application evidence before they
+can safely prove that every Endpoint administrator is covered.
 """
 
 import json
@@ -38,14 +42,18 @@ def extract_input(input_data):
 
 
 def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
-                    recommendations=None, input_summary=None, transformation_errors=None):
+                    recommendations=None, input_summary=None,
+                    transformation_errors=None, api_errors=None):
     if validation is None:
         validation = {"status": "unknown", "errors": [], "warnings": []}
 
     return {
         "transformedResponse": result,
         "additionalInfo": {
-            "dataCollection": {"status": "success", "errors": []},
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or [],
+            },
             "validation": {
                 "status": validation.get("status", "unknown"),
                 "errors": validation.get("errors", []),
@@ -157,9 +165,46 @@ def transform(input):
             input = json.loads(input.decode("utf-8"))
 
         data, validation = extract_input(input)
-        policies = data.get("value", []) if isinstance(data, dict) else []
-        if not isinstance(policies, list):
-            policies = []
+
+        if isinstance(data, dict) and ("PSError" in data or "error" in data):
+            return create_response(
+                {CRITERIA_KEY: False, "matchingPolicies": 0},
+                validation=validation,
+                api_errors=[
+                    "Microsoft Graph could not return Conditional Access policies"
+                ],
+                fail_reasons=["Could not retrieve Conditional Access policies"],
+                recommendations=[
+                    "Verify Microsoft Graph permissions and re-check the connection"
+                ],
+            )
+
+        if validation.get("status") == "failed":
+            errors = validation.get("errors") or ["Input validation failed"]
+            return create_response(
+                {CRITERIA_KEY: False, "matchingPolicies": 0},
+                validation=validation,
+                fail_reasons=["Conditional Access evidence could not be validated"],
+                transformation_errors=errors,
+            )
+
+        malformed_error = None
+        if not isinstance(data, dict):
+            malformed_error = "Conditional Access response must be an object"
+        elif "value" not in data:
+            malformed_error = "Conditional Access response is missing 'value'"
+        elif not isinstance(data.get("value"), list):
+            malformed_error = "Conditional Access response 'value' must be a list"
+
+        if malformed_error:
+            return create_response(
+                {CRITERIA_KEY: False, "matchingPolicies": 0},
+                validation=validation,
+                fail_reasons=["Conditional Access evidence is malformed"],
+                transformation_errors=[malformed_error],
+            )
+
+        policies = data["value"]
 
         matches = [
             policy for policy in policies

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/ismfaenforcedforendpointadmins.py
@@ -9,7 +9,9 @@ import json
 from datetime import datetime
 
 
-CRITERIA_KEY = "isMFAEnforcedForEndpointAdmins"
+# Preserve the legacy requirement key while replacing its invalid identity-provider
+# evidence with a real Conditional Access MFA evaluation.
+CRITERIA_KEY = "isSSOEnabled"
 
 
 def extract_input(input_data):

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
@@ -51,7 +51,7 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
         response = self.evaluate([policy()])
 
         self.assertTrue(
-            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+            response["transformedResponse"]["isSSOEnabled"]
         )
         self.assertEqual(
             response["transformedResponse"]["matchingPolicies"],
@@ -64,7 +64,7 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
         ])
 
         self.assertFalse(
-            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+            response["transformedResponse"]["isSSOEnabled"]
         )
 
     def test_user_exclusion_does_not_prove_all_admins_are_protected(self):
@@ -78,7 +78,7 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
         ])
 
         self.assertFalse(
-            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+            response["transformedResponse"]["isSSOEnabled"]
         )
 
     def test_application_exclusion_does_not_prove_defender_is_protected(self):
@@ -90,7 +90,7 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
         ])
 
         self.assertFalse(
-            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+            response["transformedResponse"]["isSSOEnabled"]
         )
 
     def test_or_policy_with_an_alternative_control_does_not_require_mfa(self):
@@ -102,7 +102,7 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
         ])
 
         self.assertFalse(
-            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+            response["transformedResponse"]["isSSOEnabled"]
         )
 
     def test_identity_provider_records_do_not_count_as_mfa_evidence(self):
@@ -112,7 +112,7 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
         }])
 
         self.assertFalse(
-            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+            response["transformedResponse"]["isSSOEnabled"]
         )
 
 

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
@@ -81,17 +81,171 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
             response["transformedResponse"]["isSSOEnabled"]
         )
 
-    def test_application_exclusion_does_not_prove_defender_is_protected(self):
+    def test_microsoft_admin_portals_policy_passes(self):
+        response = self.evaluate([
+            policy(applications={
+                "includeApplications": ["MicrosoftAdminPortals"],
+                "excludeApplications": [],
+            }),
+        ])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_defender_portal_policy_passes(self):
+        response = self.evaluate([
+            policy(applications={
+                "includeApplications": [
+                    "80ccca67-54bd-44ab-8625-4b79c4dc7775",
+                ],
+                "excludeApplications": [],
+            }),
+        ])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_defender_application_exclusion_does_not_prove_protection(self):
         response = self.evaluate([
             policy(applications={
                 "includeApplications": ["All"],
-                "excludeApplications": ["excluded-app"],
+                "excludeApplications": ["MicrosoftAdminPortals"],
             }),
         ])
 
         self.assertFalse(
             response["transformedResponse"]["isSSOEnabled"]
         )
+
+    def test_unrelated_application_exclusion_keeps_defender_covered(self):
+        response = self.evaluate([
+            policy(applications={
+                "includeApplications": ["All"],
+                "excludeApplications": ["unrelated-app"],
+            }),
+        ])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_complete_defender_admin_role_coverage_passes(self):
+        response = self.evaluate([
+            policy(users={
+                "includeUsers": [],
+                "includeRoles": list(
+                    self.transformation.DEFENDER_ADMIN_ROLE_IDS
+                ),
+                "excludeUsers": [],
+                "excludeGroups": [],
+                "excludeRoles": [],
+            }),
+        ])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_partial_defender_admin_role_coverage_does_not_pass(self):
+        response = self.evaluate([
+            policy(users={
+                "includeUsers": [],
+                "includeRoles": [
+                    self.transformation.DEFENDER_ADMIN_ROLE_IDS[0],
+                ],
+                "excludeUsers": [],
+                "excludeGroups": [],
+                "excludeRoles": [],
+            }),
+        ])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_builtin_mfa_authentication_strength_passes(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "operator": "OR",
+                "builtInControls": [],
+                "authenticationStrength": {
+                    "id": "00000000-0000-0000-0000-000000000004",
+                    "displayName": "Phishing-resistant MFA",
+                },
+            }),
+        ])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_explicit_mfa_custom_authentication_strength_passes(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "operator": "OR",
+                "builtInControls": [],
+                "authenticationStrength": {
+                    "id": "custom-strength",
+                    "requirementsSatisfied": "mfa",
+                },
+            }),
+        ])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_unknown_custom_authentication_strength_does_not_pass(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "operator": "OR",
+                "builtInControls": [],
+                "authenticationStrength": {
+                    "id": "custom-strength",
+                },
+            }),
+        ])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_authentication_strength_without_operator_does_not_pass(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "builtInControls": [],
+                "authenticationStrength": {
+                    "id": "00000000-0000-0000-0000-000000000004",
+                },
+            }),
+        ])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_scalar_builtin_control_does_not_pass(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "operator": "OR",
+                "builtInControls": "compliantDevice",
+                "authenticationStrength": {
+                    "id": "00000000-0000-0000-0000-000000000004",
+                },
+            }),
+        ])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_or_authentication_strength_with_alternative_control_does_not_pass(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "operator": "OR",
+                "builtInControls": ["compliantDevice"],
+                "authenticationStrength": {
+                    "id": "00000000-0000-0000-0000-000000000004",
+                },
+            }),
+        ])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_and_authentication_strength_with_additional_control_passes(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "operator": "AND",
+                "builtInControls": ["compliantDevice"],
+                "authenticationStrength": {
+                    "id": "00000000-0000-0000-0000-000000000004",
+                },
+            }),
+        ])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
 
     def test_or_policy_with_an_alternative_control_does_not_require_mfa(self):
         response = self.evaluate([
@@ -104,6 +258,45 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
         self.assertFalse(
             response["transformedResponse"]["isSSOEnabled"]
         )
+
+    def test_browser_client_condition_still_covers_the_defender_console(self):
+        candidate = policy()
+        candidate["conditions"]["clientAppTypes"] = ["browser"]
+
+        response = self.evaluate([candidate])
+
+        self.assertTrue(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_location_condition_does_not_prove_universal_admin_mfa(self):
+        candidate = policy()
+        candidate["conditions"]["locations"] = {
+            "includeLocations": ["trusted-location"],
+        }
+
+        response = self.evaluate([candidate])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_scalar_application_exclusion_does_not_pass(self):
+        response = self.evaluate([
+            policy(applications={
+                "includeApplications": ["All"],
+                "excludeApplications": "MicrosoftAdminPortals",
+            }),
+        ])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+
+    def test_empty_application_filter_does_not_pass(self):
+        response = self.evaluate([
+            policy(applications={
+                "includeApplications": ["All"],
+                "excludeApplications": [],
+                "applicationFilter": {},
+            }),
+        ])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
 
     def test_identity_provider_records_do_not_count_as_mfa_evidence(self):
         response = self.evaluate([{

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
@@ -1,0 +1,120 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+TRANSFORMATION_PATH = Path(__file__).with_name("ismfaenforcedforendpointadmins.py")
+
+
+def load_transformation():
+    spec = importlib.util.spec_from_file_location(
+        "ismfaenforcedforendpointadmins",
+        TRANSFORMATION_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def policy(*, state="enabled", users=None, applications=None, grant_controls=None):
+    return {
+        "displayName": "Require MFA for Microsoft access",
+        "state": state,
+        "conditions": {
+            "users": users or {
+                "includeUsers": ["All"],
+                "excludeUsers": [],
+                "excludeGroups": [],
+                "excludeRoles": [],
+            },
+            "applications": applications or {
+                "includeApplications": ["All"],
+                "excludeApplications": [],
+            },
+        },
+        "grantControls": grant_controls or {
+            "operator": "OR",
+            "builtInControls": ["mfa"],
+        },
+    }
+
+
+class EndpointAdministratorMfaTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.transformation = load_transformation()
+
+    def evaluate(self, policies):
+        return self.transformation.transform({"value": policies})
+
+    def test_enabled_all_users_all_apps_mfa_policy_passes(self):
+        response = self.evaluate([policy()])
+
+        self.assertTrue(
+            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+        )
+        self.assertEqual(
+            response["transformedResponse"]["matchingPolicies"],
+            1,
+        )
+
+    def test_report_only_policy_does_not_pass(self):
+        response = self.evaluate([
+            policy(state="enabledForReportingButNotEnforced"),
+        ])
+
+        self.assertFalse(
+            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+        )
+
+    def test_user_exclusion_does_not_prove_all_admins_are_protected(self):
+        response = self.evaluate([
+            policy(users={
+                "includeUsers": ["All"],
+                "excludeUsers": ["break-glass-user"],
+                "excludeGroups": [],
+                "excludeRoles": [],
+            }),
+        ])
+
+        self.assertFalse(
+            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+        )
+
+    def test_application_exclusion_does_not_prove_defender_is_protected(self):
+        response = self.evaluate([
+            policy(applications={
+                "includeApplications": ["All"],
+                "excludeApplications": ["excluded-app"],
+            }),
+        ])
+
+        self.assertFalse(
+            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+        )
+
+    def test_or_policy_with_an_alternative_control_does_not_require_mfa(self):
+        response = self.evaluate([
+            policy(grant_controls={
+                "operator": "OR",
+                "builtInControls": ["mfa", "compliantDevice"],
+            }),
+        ])
+
+        self.assertFalse(
+            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+        )
+
+    def test_identity_provider_records_do_not_count_as_mfa_evidence(self):
+        response = self.evaluate([{
+            "id": "EmailOtpSignup-OAUTH",
+            "displayName": "Email One Time Passcode",
+        }])
+
+        self.assertFalse(
+            response["transformedResponse"]["isMFAEnforcedForEndpointAdmins"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_ismfaenforcedforendpointadmins.py
@@ -115,6 +115,49 @@ class EndpointAdministratorMfaTests(unittest.TestCase):
             response["transformedResponse"]["isSSOEnabled"]
         )
 
+    def test_empty_policy_list_is_a_valid_failed_evaluation(self):
+        response = self.evaluate([])
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+        self.assertEqual(
+            response["additionalInfo"]["dataCollection"]["status"],
+            "success",
+        )
+        self.assertEqual(
+            response["additionalInfo"]["transformation"]["status"],
+            "success",
+        )
+
+    def test_api_error_is_not_reported_as_a_valid_empty_policy_list(self):
+        response = self.transformation.transform({
+            "PSError": "403 Forbidden",
+        })
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+        self.assertEqual(
+            response["additionalInfo"]["dataCollection"]["status"],
+            "error",
+        )
+        self.assertTrue(response["additionalInfo"]["dataCollection"]["errors"])
+
+    def test_missing_policy_collection_is_a_transformation_error(self):
+        response = self.transformation.transform({})
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+        self.assertEqual(
+            response["additionalInfo"]["transformation"]["status"],
+            "error",
+        )
+
+    def test_malformed_json_is_a_transformation_error(self):
+        response = self.transformation.transform("{not-json")
+
+        self.assertFalse(response["transformedResponse"]["isSSOEnabled"])
+        self.assertEqual(
+            response["additionalInfo"]["transformation"]["status"],
+            "error",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/isantiphishingenabled_oneclick.py
+++ b/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/isantiphishingenabled_oneclick.py
@@ -195,7 +195,7 @@ def transform(input):
             recommendations.append("Enable anti-phishing policies in Microsoft Defender for Office 365")
 
         return create_response(
-            result={criteria_key: is_enabled, "policyDetails": enabled_policies},
+            result={criteria_key: is_enabled},
             validation=validation,
             pass_reasons=pass_reasons,
             fail_reasons=fail_reasons,

--- a/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/isantiphishingenabled_oneclick.py
+++ b/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/isantiphishingenabled_oneclick.py
@@ -1,0 +1,222 @@
+"""
+Transformation: isAntiPhishingEnabled (Microsoft One-Click)
+Vendor: Microsoft
+Category: Email Security
+
+Evaluates whether anti-phishing policies are enabled and reports the optional
+Exchange-access prerequisite precisely for the Microsoft One-Click flow.
+"""
+
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from enriched and legacy input shapes."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create a standardized transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "1.0",
+        "transformationId": "isAntiPhishingEnabled",
+        "vendor": "Microsoft",
+        "category": "Email Security",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if (api_errors or []) else "success",
+                "errors": api_errors or [],
+            },
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": "error" if (transformation_errors or []) else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def parse_api_error(raw_error: str, source: str = None) -> tuple:
+    """Parse a raw API error into the existing generic error contract."""
+    raw_lower = raw_error.lower() if raw_error else ""
+    src = source or "external service"
+
+    if "401" in raw_error:
+        return (f"Could not connect to {src}: Authentication failed (HTTP 401)",
+                f"Verify {src} credentials and permissions are valid")
+    if "403" in raw_error:
+        return (f"Could not connect to {src}: Access denied (HTTP 403)",
+                f"Verify the integration has required {src} permissions")
+    if "404" in raw_error:
+        return (f"Could not connect to {src}: Resource not found (HTTP 404)",
+                f"Verify the {src} resource and configuration exist")
+    if "429" in raw_error:
+        return (f"Could not connect to {src}: Rate limited (HTTP 429)",
+                "Retry the request after waiting")
+    if "500" in raw_error or "502" in raw_error or "503" in raw_error:
+        return (f"Could not connect to {src}: Service unavailable (HTTP 5xx)",
+                f"{src} may be temporarily unavailable, retry later")
+    if "timeout" in raw_lower:
+        return (f"Could not connect to {src}: Request timed out",
+                "Check network connectivity and retry")
+    if "connection" in raw_lower:
+        return (f"Could not connect to {src}: Connection failed",
+                "Check network connectivity and firewall settings")
+
+    clean = raw_error[:80] + "..." if len(raw_error) > 80 else raw_error
+    return (f"Could not connect to {src}: {clean}",
+            f"Check {src} credentials and configuration")
+
+
+def is_exchange_access_required_error(raw_error):
+    """Identify the EXO app-only role failure returned before Exchange completion."""
+    raw_lower = str(raw_error or "").lower()
+    return (
+        "failed to connect to exchange online" in raw_lower
+        and "exo app-only authentication" in raw_lower
+    )
+
+
+def transform(input):
+    """Evaluate whether anti-phishing policies are enabled in Microsoft 365."""
+    criteria_key = "isAntiPhishingEnabled"
+
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+
+        data, validation = extract_input(input)
+
+        if isinstance(data, dict) and "PSError" in data:
+            raw_error = data.get("PSError", "")
+            api_error, recommendation = parse_api_error(raw_error, source="Microsoft 365")
+            fail_reason = "Could not retrieve data from Microsoft 365"
+
+            if is_exchange_access_required_error(raw_error):
+                fail_reason = "Exchange access is required for this check."
+                recommendation = (
+                    "Complete Exchange access in Microsoft One-Click, "
+                    "then re-evaluate this check."
+                )
+
+            return create_response(
+                result={criteria_key: False},
+                validation={"status": "skipped", "errors": [], "warnings": ["API returned error"]},
+                api_errors=[api_error],
+                fail_reasons=[fail_reason],
+                recommendations=[recommendation],
+            )
+
+        if validation.get("status") == "failed":
+            return create_response(
+                result={criteria_key: False},
+                validation=validation,
+                fail_reasons=["Input validation failed: " + "; ".join(validation.get("errors", []))],
+                recommendations=["Verify the Microsoft integration is configured correctly"],
+            )
+
+        policies = data.get("policies", [])
+        if isinstance(policies, dict):
+            policies = [policies]
+
+        try:
+            enabled_policies = [
+                policy for policy in policies
+                if str(policy.get("Enabled", "false")).lower() == "true"
+                or str(policy.get("IsDefault", "false")).lower() == "true"
+            ]
+        except Exception:
+            enabled_policies = []
+
+        is_enabled = len(enabled_policies) > 0
+        pass_reasons = []
+        fail_reasons = []
+        recommendations = []
+
+        if is_enabled:
+            policy_names = [
+                policy.get("Name", policy.get("Identity", "unnamed"))
+                for policy in enabled_policies[:5]
+            ]
+            pass_reasons.append(
+                f"{len(enabled_policies)} anti-phishing policy/policies enabled: "
+                f"{', '.join(policy_names)}"
+            )
+        else:
+            fail_reasons.append("No anti-phishing policies are enabled")
+            recommendations.append("Enable anti-phishing policies in Microsoft Defender for Office 365")
+
+        return create_response(
+            result={criteria_key: is_enabled, "policyDetails": enabled_policies},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary={
+                "totalPolicies": len(policies),
+                "enabledPolicies": len(enabled_policies),
+                "hasPolicyData": len(policies) > 0,
+            },
+        )
+
+    except json.JSONDecodeError as error:
+        return create_response(
+            result={criteria_key: False},
+            validation={"status": "error", "errors": [f"Invalid JSON: {str(error)}"], "warnings": []},
+            fail_reasons=["Could not parse input as valid JSON"],
+        )
+    except Exception as error:
+        return create_response(
+            result={criteria_key: False},
+            validation={"status": "error", "errors": [], "warnings": []},
+            transformation_errors=[str(error)],
+            fail_reasons=[f"Transformation error: {str(error)}"],
+        )

--- a/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/isantiphishingenabled_oneclick.py
+++ b/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/isantiphishingenabled_oneclick.py
@@ -46,7 +46,7 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
 
     response_metadata = {
         "evaluatedAt": datetime.utcnow().isoformat() + "Z",
-        "schemaVersion": "1.0",
+        "schemaVersion": "2.0",
         "transformationId": "isAntiPhishingEnabled",
         "vendor": "Microsoft",
         "category": "Email Security",
@@ -149,7 +149,7 @@ def transform(input):
 
             return create_response(
                 result={criteria_key: False},
-                validation={"status": "skipped", "errors": [], "warnings": ["API returned error"]},
+                validation={"status": "unknown", "errors": [], "warnings": ["API returned error"]},
                 api_errors=[api_error],
                 fail_reasons=[fail_reason],
                 recommendations=[recommendation],
@@ -210,13 +210,13 @@ def transform(input):
     except json.JSONDecodeError as error:
         return create_response(
             result={criteria_key: False},
-            validation={"status": "error", "errors": [f"Invalid JSON: {str(error)}"], "warnings": []},
+            validation={"status": "unknown", "errors": [f"Invalid JSON: {str(error)}"], "warnings": []},
             fail_reasons=["Could not parse input as valid JSON"],
         )
     except Exception as error:
         return create_response(
             result={criteria_key: False},
-            validation={"status": "error", "errors": [], "warnings": []},
+            validation={"status": "unknown", "errors": [], "warnings": []},
             transformation_errors=[str(error)],
             fail_reasons=[f"Transformation error: {str(error)}"],
         )

--- a/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/test_isantiphishingenabled_oneclick.py
+++ b/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/test_isantiphishingenabled_oneclick.py
@@ -1,0 +1,96 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+TRANSFORMATION_PATH = Path(__file__).with_name("isantiphishingenabled_oneclick.py")
+LEGACY_TRANSFORMATION_PATH = Path(__file__).with_name("isantiphishingenabled.py")
+
+
+def load_transformation(path, module_name):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def without_timestamp(response):
+    response["additionalInfo"]["metadata"].pop("evaluatedAt", None)
+    return response
+
+
+class MicrosoftOneClickAntiPhishingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.transformation = load_transformation(
+            TRANSFORMATION_PATH,
+            "isantiphishingenabled_oneclick",
+        )
+        cls.legacy_transformation = load_transformation(
+            LEGACY_TRANSFORMATION_PATH,
+            "isantiphishingenabled",
+        )
+
+    def test_exchange_role_failure_explains_optional_completion(self):
+        response = self.transformation.transform({
+            "Success": True,
+            "Output": {
+                "success": False,
+                "PSError": (
+                    "Failed to connect to Exchange Online: The role assigned to application "
+                    "example-client isn't supported in this scenario. Please check online "
+                    "documentation for assigning correct Directory Roles to Azure AD Application "
+                    "for EXO App-Only Authentication."
+                ),
+            },
+            "Error": "",
+        })
+
+        evaluation = response["additionalInfo"]["evaluation"]
+        self.assertEqual(
+            evaluation["failReasons"],
+            ["Exchange access is required for this check."],
+        )
+        self.assertEqual(
+            evaluation["recommendations"],
+            ["Complete Exchange access in Microsoft One-Click, then re-evaluate this check."],
+        )
+        self.assertFalse(response["transformedResponse"]["isAntiPhishingEnabled"])
+
+    def test_unrelated_error_keeps_generic_existing_copy(self):
+        input_data = {"Output": {"PSError": "Request timed out"}}
+        response = self.transformation.transform(input_data)
+
+        evaluation = response["additionalInfo"]["evaluation"]
+        self.assertEqual(
+            evaluation["failReasons"],
+            ["Could not retrieve data from Microsoft 365"],
+        )
+        self.assertEqual(
+            evaluation["recommendations"],
+            ["Check Microsoft 365 credentials and configuration"],
+        )
+        self.assertEqual(
+            without_timestamp(response),
+            without_timestamp(self.legacy_transformation.transform(input_data)),
+        )
+
+    def test_enabled_policy_behavior_is_unchanged(self):
+        input_data = {
+            "Output": {"policies": [{"Name": "Default", "Enabled": True}]},
+        }
+        response = self.transformation.transform(input_data)
+
+        self.assertTrue(response["transformedResponse"]["isAntiPhishingEnabled"])
+        self.assertEqual(
+            response["additionalInfo"]["evaluation"]["passReasons"],
+            ["1 anti-phishing policy/policies enabled: Default"],
+        )
+        self.assertEqual(
+            without_timestamp(response),
+            without_timestamp(self.legacy_transformation.transform(input_data)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/test_isantiphishingenabled_oneclick.py
+++ b/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/test_isantiphishingenabled_oneclick.py
@@ -87,7 +87,11 @@ class MicrosoftOneClickAntiPhishingTests(unittest.TestCase):
             ["1 anti-phishing policy/policies enabled: Default"],
         )
         legacy = self.legacy_transformation.transform(input_data)
-        self.assertEqual(response["transformedResponse"], legacy["transformedResponse"])
+        self.assertEqual(
+            response["transformedResponse"]["isAntiPhishingEnabled"],
+            legacy["transformedResponse"]["isAntiPhishingEnabled"],
+        )
+        self.assertNotIn("policyDetails", response["transformedResponse"])
 
     def test_disabled_policy_returns_a_valid_failure(self):
         response = self.transformation.transform({

--- a/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/test_isantiphishingenabled_oneclick.py
+++ b/safeguards/874a78ff-2ca3-4c0e-ab86-19277536ac87/test_isantiphishingenabled_oneclick.py
@@ -56,6 +56,8 @@ class MicrosoftOneClickAntiPhishingTests(unittest.TestCase):
             ["Complete Exchange access in Microsoft One-Click, then re-evaluate this check."],
         )
         self.assertFalse(response["transformedResponse"]["isAntiPhishingEnabled"])
+        self.assertEqual(response["additionalInfo"]["validation"]["status"], "unknown")
+        self.assertEqual(response["additionalInfo"]["metadata"]["schemaVersion"], "2.0")
 
     def test_unrelated_error_keeps_generic_existing_copy(self):
         input_data = {"Output": {"PSError": "Request timed out"}}
@@ -70,10 +72,8 @@ class MicrosoftOneClickAntiPhishingTests(unittest.TestCase):
             evaluation["recommendations"],
             ["Check Microsoft 365 credentials and configuration"],
         )
-        self.assertEqual(
-            without_timestamp(response),
-            without_timestamp(self.legacy_transformation.transform(input_data)),
-        )
+        legacy = self.legacy_transformation.transform(input_data)
+        self.assertEqual(response["transformedResponse"], legacy["transformedResponse"])
 
     def test_enabled_policy_behavior_is_unchanged(self):
         input_data = {
@@ -86,10 +86,35 @@ class MicrosoftOneClickAntiPhishingTests(unittest.TestCase):
             response["additionalInfo"]["evaluation"]["passReasons"],
             ["1 anti-phishing policy/policies enabled: Default"],
         )
+        legacy = self.legacy_transformation.transform(input_data)
+        self.assertEqual(response["transformedResponse"], legacy["transformedResponse"])
+
+    def test_disabled_policy_returns_a_valid_failure(self):
+        response = self.transformation.transform({
+            "Output": {"policies": [{"Name": "Disabled", "Enabled": False}]},
+        })
+
+        self.assertFalse(response["transformedResponse"]["isAntiPhishingEnabled"])
         self.assertEqual(
-            without_timestamp(response),
-            without_timestamp(self.legacy_transformation.transform(input_data)),
+            response["additionalInfo"]["evaluation"]["failReasons"],
+            ["No anti-phishing policies are enabled"],
         )
+
+    def test_empty_data_returns_a_valid_failure(self):
+        response = self.transformation.transform({"Output": {}})
+
+        self.assertFalse(response["transformedResponse"]["isAntiPhishingEnabled"])
+        self.assertEqual(
+            response["additionalInfo"]["transformation"]["inputSummary"]["totalPolicies"],
+            0,
+        )
+
+    def test_malformed_json_returns_unknown_validation(self):
+        response = self.transformation.transform("{not-json")
+
+        self.assertFalse(response["transformedResponse"]["isAntiPhishingEnabled"])
+        self.assertEqual(response["additionalInfo"]["validation"]["status"], "unknown")
+        self.assertTrue(response["additionalInfo"]["validation"]["errors"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds a one-click-only anti-phishing transformer that distinguishes missing Exchange access from unrelated Microsoft/API failures.
- Adds a one-click-only Endpoint administrator MFA transformer backed by Conditional Access policy evidence while preserving the existing `isSSOEnabled` requirement key for compatibility.
- Recognizes enabled policies that cover all users or the complete known Defender Entra administrator-role set and target all resources, Microsoft Admin Portals, or the Defender portal.
- Recognizes required MFA grant controls and documented MFA authentication strengths while failing closed on exclusions, conditional coverage, malformed evidence, report-only policies, and unknown custom strengths.
- Treats a valid empty Conditional Access policy list as a normal failed evaluation, while API, validation, missing-evidence, and malformed-input failures remain explicit errors.
- Keeps transformed responses limited to boolean/numeric evaluation values and does not return raw anti-phishing policy objects.

## Safety boundaries

- No existing legacy transformation file is modified.
- No shared transformation helper or unrelated safeguard is changed.
- Integration-Service alone routes the two one-click definitions to these new files by immutable commit SHA.
- Conditional Access evidence cannot prove coverage of custom Defender unified-RBAC assignments or prove excluded identities are safe emergency accounts. Ambiguous cases remain red instead of producing a false green.

## Verification

- Full Transformations suite: 32 passed.
- Endpoint evaluator slice: 26 passed.
- Compile check and `git diff --check` passed.
- Covers all-user and role-targeted policies, supported resource targets, MFA controls and strengths, AND/OR semantics, exclusions, malformed scalar shapes, report-only state, valid empty evidence, and explicit API errors.
- Immutable commit: `cd2b328e045eca264f9cdfc409f58791daa0e3fc`.
- Both pinned raw GitHub URLs return HTTP 200.

## Coordinated release

- Companion PRs: [Integration-Service #480](https://github.com/spektrum-labs/Integration-Service/pull/480) and [Flux #356](https://github.com/spektrum-labs/flux/pull/356).
- Merge this PR with commit history preserved before Integration-Service so the exact pinned commit remains reachable. If it is squashed or rebased, Integration-Service must be repinned to the resulting immutable commit before merge.
