### PR TITLE
fix: rename _as_bool helper — RestrictedPython rejects underscore-prefixed names

### DIFF
--- a/safeguards/epp/sentinelone/requiredCoveragePercentage.py
+++ b/safeguards/epp/sentinelone/requiredCoveragePercentage.py
@@ -18,12 +18,15 @@ import json
 from datetime import datetime
 
 
-def _as_bool(value):
+def coerce_bool(value):
     """Coerce a SentinelOne boolean-ish field to a real bool.
 
     The agent payload may carry native booleans or the strings 'true'/'false'
     depending on the collection path; naive truthiness treats the string
     'False' as True, so normalize explicitly.
+
+    NOTE: must not be named with a leading underscore — RestrictedPython (the
+    transformation sandbox) rejects all underscore-prefixed identifiers.
     """
     if isinstance(value, bool):
         return value
@@ -123,10 +126,10 @@ def transform(input):
     for agent in items:
         if not isinstance(agent, dict):
             continue
-        if _as_bool(agent.get("isUninstalled")):
+        if coerce_bool(agent.get("isUninstalled")):
             uninstalled_count = uninstalled_count + 1
             continue
-        if _as_bool(agent.get("isDecommissioned")):
+        if coerce_bool(agent.get("isDecommissioned")):
             decommissioned_count = decommissioned_count + 1
             continue
         # Enrolled and neither uninstalled nor decommissioned => Endpoint
@@ -136,7 +139,7 @@ def transform(input):
         # still-protected endpoints.
         installed_count = installed_count + 1
         is_active = agent.get("isActive")
-        if is_active is not None and not _as_bool(is_active):
+        if is_active is not None and not coerce_bool(is_active):
             inactive_installed_count = inactive_installed_count + 1
 
     covered_count = installed_count


### PR DESCRIPTION
## Problem

The coverage fix in #479 added a helper named `_as_bool` to `safeguards/epp/sentinelone/requiredCoveragePercentage.py`. Transformation code runs inside **RestrictedPython**, which rejects **all** underscore-prefixed identifiers (`codeexecutor.py` normalizes only a small whitelist). As a result, every evaluation of the SentinelOne Endpoint Security safeguard now errors out instead of returning a coverage number:

```
requiredCoveragePercentage
Actual: {'error': True, 'message': 'Transformation error: Execution failed:
  ("Line 21: \"_as_bool\" is an invalid variable name because it starts with \"_\"",
   "Line 126 ...", "Line 129 ...", "Line 139 ...")'}
```

This is a hard regression — the safeguard went from a false *failure* (28.84%) to a transformation *error*.

## Fix

- Renamed `_as_bool` → `coerce_bool` (no leading underscore) at the definition and all three call sites.
- Added a comment on the helper so the constraint isn't reintroduced.

No behavioural change beyond the rename; the coverage logic from #479 is untouched.

## Verification

- **Real sandbox compile:** installed `RestrictedPython>=5.2` and ran `compile_restricted(src, '<transform>', 'exec')` → compiles clean, no forbidden-name error.
- **No underscore identifiers remain:** `grep -nE '(^|[^A-Za-z0-9_])_[A-Za-z]'` returns nothing.
- **Functional:** all-installed fleet with a mix of `isActive` true/false still yields `requiredCoveragePercentage: 100.0` with `inactiveAgents` reported informationally (e.g. 27 agents, 8 inactive → 100%).

## Follow-up

Once merged, this should be **promoted to whatever branch prod evaluate pulls from** (`TRANSFORMATIONS_BASE_BRANCH`) together with #479 so prod evaluations of SentinelOne EPP both stop erroring and report correct coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)