### PR TITLE
feat: add CrowdStrike Falcon transformations (epp)

### DIFF
--- a/safeguards/epp/crowdstrike-falcon/isBehavioralMonitoringValid.py
+++ b/safeguards/epp/crowdstrike-falcon/isBehavioralMonitoringValid.py
@@ -1,0 +1,183 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+BEHAVIORAL_KEYWORDS = [
+    "ioa", "behavior", "interprocess", "indicatorofattack", "customioa",
+    "extendeduser", "exploit", "cloudantimalware", "adwarepup", "malware"
+]
+
+
+def is_behavioral_setting(setting_id, setting_name):
+    text = ((setting_id or "") + " " + (setting_name or "")).lower().replace(" ", "").replace("_", "")
+    for kw in BEHAVIORAL_KEYWORDS:
+        if kw in text:
+            return True
+    return False
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") or data.get("errorType") or (data.get("statusCode") and data.get("statusCode") != 200):
+        msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"Vendor API returned an error: {msg}")
+
+    resources = data.get("resources") or []
+    if not isinstance(resources, list):
+        resources = []
+
+    enabled_policies_with_groups = []
+    behavioral_findings = []
+    total_policies = 0
+
+    for policy in resources:
+        if not isinstance(policy, dict):
+            continue
+        total_policies = total_policies + 1
+        policy_name = policy.get("name") or policy.get("id") or "unnamed-policy"
+        policy_enabled = bool(policy.get("enabled"))
+        groups = policy.get("groups") or []
+        has_groups = len(groups) > 0
+        prevention_settings = policy.get("prevention_settings") or []
+        if not isinstance(prevention_settings, list):
+            prevention_settings = []
+
+        policy_behavioral_settings = []
+        for group in prevention_settings:
+            if not isinstance(group, dict):
+                continue
+            settings = group.get("settings") or []
+            if not isinstance(settings, list):
+                settings = []
+            for setting in settings:
+                if not isinstance(setting, dict):
+                    continue
+                setting_id = setting.get("id")
+                setting_name = setting.get("name")
+                if is_behavioral_setting(setting_id, setting_name):
+                    value = setting.get("value") or {}
+                    setting_enabled = False
+                    if isinstance(value, dict):
+                        setting_enabled = bool(value.get("enabled"))
+                    elif isinstance(value, bool):
+                        setting_enabled = value
+                    if setting_enabled:
+                        policy_behavioral_settings.append(setting_name or setting_id)
+
+        if policy_enabled and has_groups and len(policy_behavioral_settings) > 0:
+            enabled_policies_with_groups.append(policy_name)
+            behavioral_findings.append(
+                f"Policy '{policy_name}' (enabled=True, assigned to {len(groups)} group(s)) has behavioral settings enabled: {', '.join(policy_behavioral_settings)}."
+            )
+
+    is_valid = len(enabled_policies_with_groups) > 0
+
+    input_summary = {
+        "totalPolicies": total_policies,
+        "validBehavioralPolicies": len(enabled_policies_with_groups),
+    }
+
+    if is_valid:
+        pass_reasons = behavioral_findings
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        if total_policies == 0:
+            fail_reasons = ["No prevention policies were returned by getCombinedPreventionPolicies; unable to confirm behavioral/IOA detection configuration."]
+        else:
+            fail_reasons = [
+                f"None of the {total_policies} prevention polic(y/ies) returned have an enabled=True policy assigned to a host group with a behavior-based (IOA/ML) detection setting turned on."
+            ]
+        recommendations = [
+            "Enable the applicable prevention policy and turn on behavior-based detection settings (e.g. Cloud/On-sensor ML, Custom IOA, Adware/PUP detection) and assign the policy to the relevant host group(s)."
+        ]
+
+    result = {
+        "isBehavioralMonitoringValid": is_valid,
+        "totalPolicies": total_policies,
+        "validBehavioralPolicies": len(enabled_policies_with_groups),
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isBehavioralMonitoringValid",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/epp/crowdstrike-falcon/isEDRDeployed.py
+++ b/safeguards/epp/crowdstrike-falcon/isEDRDeployed.py
@@ -1,0 +1,167 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("errorType"):
+        err_msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"getDeviceDetails API error: {err_msg}")
+
+    resources = data.get("resources") or []
+    if not isinstance(resources, list):
+        resources = []
+
+    total_devices = len(resources)
+    deployed_count = 0
+    rfm_count = 0
+    stale_count = 0
+    sample_hosts = []
+
+    for device in resources:
+        if not isinstance(device, dict):
+            continue
+        rfm = device.get("reduced_functionality_mode")
+        rfm_is_true = rfm is True or (isinstance(rfm, str) and rfm.strip().lower() == "true")
+        device_policies = device.get("device_policies") or {}
+        has_sensor_update_policy = isinstance(device_policies, dict) and bool(device_policies.get("sensor_update"))
+        agent_version = device.get("agent_version")
+        last_seen = device.get("last_seen")
+
+        if rfm_is_true:
+            rfm_count = rfm_count + 1
+
+        is_deployed_and_streaming = (not rfm_is_true) and bool(agent_version) and has_sensor_update_policy
+        if is_deployed_and_streaming:
+            deployed_count = deployed_count + 1
+            if len(sample_hosts) < 5:
+                sample_hosts.append(device.get("hostname") or device.get("device_id") or "unknown")
+        elif not last_seen:
+            stale_count = stale_count + 1
+
+    is_edr_deployed = total_devices > 0 and deployed_count > 0
+
+    input_summary = {
+        "totalDevices": total_devices,
+        "deployedCount": deployed_count,
+        "rfmCount": rfm_count,
+    }
+
+    if api_errors:
+        return create_response(
+            result={"isEDRDeployed": False, "totalDevices": 0, "deployedCount": 0},
+            validation=validation,
+            fail_reasons=[f"Unable to evaluate EDR deployment because the getDeviceDetails API call failed: {api_errors[0]}"],
+            recommendations=["Verify CrowdStrike API credentials (clientId/clientSecret) and OAuth scopes for the Hosts collection, then re-run the scan."],
+            input_summary=input_summary,
+            api_errors=api_errors,
+            metadata={"transformationId": "isEDRDeployed", "vendor": "CrowdStrike Falcon", "category": "epp"},
+        )
+
+    if total_devices == 0:
+        return create_response(
+            result={"isEDRDeployed": False, "totalDevices": 0, "deployedCount": 0},
+            validation=validation,
+            fail_reasons=["No device records were returned by getDeviceDetails, so no Falcon sensor deployment could be confirmed."],
+            recommendations=["Confirm devices are enrolled in the CrowdStrike Falcon tenant and that the API client has access to the Hosts collection."],
+            input_summary=input_summary,
+            metadata={"transformationId": "isEDRDeployed", "vendor": "CrowdStrike Falcon", "category": "epp"},
+        )
+
+    if is_edr_deployed:
+        pass_reasons = [
+            f"{deployed_count} of {total_devices} devices report reduced_functionality_mode=false, a populated agent_version, and an assigned sensor_update policy (e.g. {', '.join([str(h) for h in sample_hosts])}), confirming the Falcon sensor is installed and actively streaming EDR telemetry."
+        ]
+        fail_reasons = []
+        recommendations = []
+        if rfm_count > 0:
+            recommendations.append(f"{rfm_count} device(s) are in Reduced Functionality Mode; investigate connectivity/licensing issues for those hosts to restore full EDR telemetry.")
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"None of the {total_devices} devices returned by getDeviceDetails have both reduced_functionality_mode=false and an assigned sensor_update policy with a populated agent_version, so EDR telemetry cannot be confirmed as active."
+        ]
+        recommendations = ["Investigate why Falcon sensors are reporting Reduced Functionality Mode or missing sensor_update policy assignment; reinstall or re-license affected sensors to restore full EDR streaming."]
+
+    return create_response(
+        result={
+            "isEDRDeployed": is_edr_deployed,
+            "totalDevices": total_devices,
+            "deployedCount": deployed_count,
+            "reducedFunctionalityModeCount": rfm_count,
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={"transformationId": "isEDRDeployed", "vendor": "CrowdStrike Falcon", "category": "epp"},
+    )

--- a/safeguards/epp/crowdstrike-falcon/isEPPConfigured.py
+++ b/safeguards/epp/crowdstrike-falcon/isEPPConfigured.py
@@ -1,0 +1,165 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 500 or data.get("status") == "Error":
+        msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"Vendor API returned an error: {msg}")
+
+    resources = data.get("resources") or []
+    if not isinstance(resources, list):
+        resources = []
+
+    total_policies = len(resources)
+    configured_policies = []
+    for p in resources:
+        if not isinstance(p, dict):
+            continue
+        enabled = bool(p.get("enabled"))
+        groups = p.get("groups") or []
+        prevention_settings = p.get("prevention_settings") or []
+        has_groups = isinstance(groups, list) and len(groups) > 0
+        has_settings = isinstance(prevention_settings, list) and len(prevention_settings) > 0
+        if enabled and has_groups and has_settings:
+            configured_policies.append(p)
+
+    is_configured = len(configured_policies) > 0
+
+    input_summary = {
+        "totalPreventionPolicies": total_policies,
+        "configuredPreventionPolicies": len(configured_policies),
+    }
+
+    if api_errors:
+        return create_response(
+            result={"isEPPConfigured": False},
+            validation=validation,
+            fail_reasons=[
+                "Unable to retrieve prevention policy data from CrowdStrike Falcon API; "
+                "cannot confirm an enabled prevention policy assigned to a host group."
+            ],
+            recommendations=[
+                "Investigate the getCombinedPreventionPolicies API integration error and re-run "
+                "the scan once the vendor API responds successfully."
+            ],
+            input_summary=input_summary,
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isEPPConfigured",
+                "vendor": "CrowdStrike Falcon",
+                "category": "epp",
+            },
+        )
+
+    if is_configured:
+        names = [p.get("name") for p in configured_policies if p.get("name")]
+        sample_names = ", ".join([str(n) for n in names[:3]]) if names else "unnamed policy"
+        pass_reasons = [
+            f"Found {len(configured_policies)} of {total_policies} prevention policy(ies) with "
+            f"enabled=true, non-empty prevention_settings, and assigned host groups "
+            f"(e.g. {sample_names}), confirming EPP is configured and assigned to a host group "
+            f"covering the endpoint population."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        if total_policies == 0:
+            fail_reasons = [
+                "No prevention policies were returned by getCombinedPreventionPolicies; "
+                "there is no Prevention Policy record to confirm EPP configuration."
+            ]
+        else:
+            fail_reasons = [
+                f"Found {total_policies} prevention policy(ies), but none had enabled=true "
+                f"together with non-empty prevention_settings and at least one assigned host group."
+            ]
+        recommendations = [
+            "Create or enable a CrowdStrike Falcon Prevention Policy, configure its "
+            "prevention_settings (NGAV/ML detection toggles), and assign it to the host group "
+            "covering this endpoint population."
+        ]
+
+    return create_response(
+        result={"isEPPConfigured": is_configured},
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isEPPConfigured",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/crowdstrike-falcon/isEPPDeployed.py
+++ b/safeguards/epp/crowdstrike-falcon/isEPPDeployed.py
@@ -1,0 +1,128 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 500:
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+
+    resources = data.get("resources") or []
+    meta = data.get("meta") or {}
+    pagination = meta.get("pagination") or {}
+    total = pagination.get("total")
+    if total is None:
+        total = len(resources)
+
+    is_deployed = bool(total and total > 0)
+
+    input_summary = {"totalDevices": total, "resourcesInPage": len(resources)}
+
+    if api_errors:
+        result = {"isEPPDeployed": False, "totalDevices": 0}
+        return create_response(
+            result=result,
+            validation=validation,
+            fail_reasons=[
+                "The queryDevicesScroll API call returned an error: %s. Unable to confirm sensor enrollment." % api_errors[0]
+            ],
+            recommendations=[
+                "Verify CrowdStrike API credentials/scopes and retry the devices-scroll query to confirm sensor deployment."
+            ],
+            input_summary=input_summary,
+            metadata={"transformationId": "isEPPDeployed", "vendor": "CrowdStrike Falcon", "category": "epp"},
+            api_errors=api_errors,
+        )
+
+    result = {"isEPPDeployed": is_deployed, "totalDevices": total}
+
+    if is_deployed:
+        pass_reasons = [
+            "meta.pagination.total reports %d enrolled devices in the tenant, confirming Falcon sensors are installed and reporting." % total
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            "meta.pagination.total is %s, indicating no devices are currently enrolled/reporting via the Falcon sensor." % str(total)
+        ]
+        recommendations = [
+            "Deploy the Falcon sensor to endpoints and confirm they check in via the devices-scroll query."
+        ]
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={"transformationId": "isEPPDeployed", "vendor": "CrowdStrike Falcon", "category": "epp"},
+    )

--- a/safeguards/epp/crowdstrike-falcon/isEPPEnabled.py
+++ b/safeguards/epp/crowdstrike-falcon/isEPPEnabled.py
@@ -1,0 +1,150 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error"):
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+
+    policies = data.get("resources") or []
+    if not isinstance(policies, list):
+        policies = []
+
+    total_policies = len(policies)
+    assigned_policies = []
+    for p in policies:
+        if not isinstance(p, dict):
+            continue
+        groups = p.get("groups") or []
+        if isinstance(groups, list) and len(groups) > 0:
+            assigned_policies.append(p)
+
+    enabled_assigned = [p for p in assigned_policies if p.get("enabled") is True]
+    disabled_assigned = [p for p in assigned_policies if p.get("enabled") is not True]
+
+    total_assigned = len(assigned_policies)
+    total_enabled_assigned = len(enabled_assigned)
+
+    is_epp_enabled = total_assigned > 0 and total_enabled_assigned == total_assigned
+
+    input_summary = {
+        "totalPolicies": total_policies,
+        "assignedPolicies": total_assigned,
+        "enabledAssignedPolicies": total_enabled_assigned,
+        "disabledAssignedPolicies": len(disabled_assigned),
+    }
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if total_assigned == 0:
+        fail_reasons.append(
+            "No prevention policies with host-group assignments were found among %d total policies; cannot confirm enforcement." % total_policies
+        )
+        recommendations.append(
+            "Assign at least one prevention policy to a host group and ensure its top-level 'enabled' flag is set to true."
+        )
+    elif is_epp_enabled:
+        names = ", ".join([str(p.get("name")) for p in enabled_assigned][:5])
+        pass_reasons.append(
+            "All %d host-group-assigned prevention policies have enabled=true (e.g. %s)." % (total_enabled_assigned, names)
+        )
+    else:
+        names = ", ".join([str(p.get("name")) for p in disabled_assigned][:5])
+        fail_reasons.append(
+            "%d of %d host-group-assigned prevention policies have enabled=false (e.g. %s), meaning prevention is defined but not actively enforced on those host groups." % (len(disabled_assigned), total_assigned, names)
+        )
+        recommendations.append(
+            "Enable the top-level 'enabled' flag on all prevention policies assigned to host groups so prevention actions are actively enforced."
+        )
+
+    result = {
+        "isEPPEnabled": is_epp_enabled,
+        "totalAssignedPolicies": total_assigned,
+        "enabledAssignedPolicies": total_enabled_assigned,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isEPPEnabled",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/crowdstrike-falcon/isEPPEnabledForCriticalSystems.py
+++ b/safeguards/epp/crowdstrike-falcon/isEPPEnabledForCriticalSystems.py
@@ -1,0 +1,190 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+CRITICAL_KEYWORDS = [
+    "critical", "server", "domain controller", "domain-controller",
+    "dc", "tier0", "tier 0", "tier-0",
+]
+
+
+def is_critical_group_name(name):
+    if not name:
+        return False
+    lower_name = name.lower()
+    for kw in CRITICAL_KEYWORDS:
+        if kw in lower_name:
+            return True
+    return False
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error"):
+        err_msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"CrowdStrike API returned an error: {err_msg}")
+
+    policies = data.get("resources") or []
+    if not isinstance(policies, list):
+        policies = []
+
+    critical_group_names = set()
+    covered_critical_group_names = set()
+    inspected_policies = []
+
+    for policy in policies:
+        if not isinstance(policy, dict):
+            continue
+        policy_enabled = bool(policy.get("enabled"))
+        policy_name = policy.get("name") or policy.get("id") or "unnamed-policy"
+        groups = policy.get("groups") or []
+        if not isinstance(groups, list):
+            groups = []
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            group_name = group.get("name") or group.get("id") or ""
+            if is_critical_group_name(group_name):
+                critical_group_names.add(group_name)
+                if policy_enabled:
+                    covered_critical_group_names.add(group_name)
+                    inspected_policies.append(f"{policy_name} (enabled) -> {group_name}")
+
+    total_critical = len(critical_group_names)
+    total_covered = len(covered_critical_group_names)
+
+    if total_critical > 0:
+        is_enabled_for_critical = total_covered == total_critical
+    else:
+        is_enabled_for_critical = False
+
+    input_summary = {
+        "totalPolicies": len(policies),
+        "criticalHostGroupsFound": total_critical,
+        "criticalHostGroupsCovered": total_covered,
+    }
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if api_errors:
+        fail_reasons.append(
+            "The getCombinedPreventionPolicies API call returned an error; no prevention policy data was available to evaluate critical system coverage."
+        )
+        recommendations.append(
+            "Verify CrowdStrike API credentials and connectivity, then re-run the scan to retrieve prevention policy assignments."
+        )
+    elif total_critical == 0:
+        fail_reasons.append(
+            "No host groups matching critical-system naming patterns (e.g. 'server', 'domain controller', 'tier0', 'critical') were found across the "
+            f"{len(policies)} prevention policies retrieved, so critical-system EPP coverage could not be confirmed."
+        )
+        recommendations.append(
+            "Tag critical host groups (servers, domain controllers, tier-0 systems) with identifiable names and assign an enabled Prevention Policy to them."
+        )
+    elif is_enabled_for_critical:
+        pass_reasons.append(
+            f"All {total_critical} critical-tagged host group(s) ({', '.join(sorted(covered_critical_group_names))}) are assigned to a Prevention Policy with enabled=true."
+        )
+        if inspected_policies:
+            pass_reasons.append(
+                "Cross-referenced policy-to-group assignments: " + "; ".join(inspected_policies[:5])
+            )
+    else:
+        uncovered = sorted(critical_group_names - covered_critical_group_names)
+        fail_reasons.append(
+            f"{total_critical - total_covered} of {total_critical} critical host group(s) ({', '.join(uncovered)}) are not covered by any Prevention Policy with enabled=true."
+        )
+        recommendations.append(
+            f"Assign an enabled Prevention Policy to the following critical host groups: {', '.join(uncovered)}."
+        )
+
+    result = {
+        "isEPPEnabledForCriticalSystems": is_enabled_for_critical,
+        "criticalHostGroupsFound": total_critical,
+        "criticalHostGroupsCovered": total_covered,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isEPPEnabledForCriticalSystems",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/epp/crowdstrike-falcon/isEPPLoggingEnabled.py
+++ b/safeguards/epp/crowdstrike-falcon/isEPPLoggingEnabled.py
@@ -1,0 +1,143 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 500:
+        msg = data.get("errorMessage") or data.get("message") or "Unknown vendor API error"
+        api_errors.append(f"Vendor API returned an error: {msg}")
+
+    resources = data.get("resources") or []
+    if not isinstance(resources, list):
+        resources = []
+
+    meta = data.get("meta") or {}
+    pagination = meta.get("pagination") or {}
+    total = pagination.get("total")
+    if total is None:
+        total = len(resources)
+    try:
+        total = int(total)
+    except (TypeError, ValueError):
+        total = 0
+
+    is_logging_enabled = total > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if api_errors:
+        fail_reasons.append(
+            "Unable to confirm detection logging - the queryDetects API call failed: "
+            + "; ".join(api_errors)
+        )
+        recommendations.append(
+            "Verify Falcon API credentials and OAuth scopes (detects:read) and retry the "
+            "detection-events query to confirm the Event Streams / detections pipeline is active."
+        )
+    elif is_logging_enabled:
+        pass_reasons.append(
+            f"queryDetects returned meta.pagination.total={total} detection record(s), "
+            "confirming that prevention/detection events are being generated and are "
+            "retrievable via the Falcon detects API (equivalent to an active export/audit trail)."
+        )
+    else:
+        fail_reasons.append(
+            "queryDetects returned meta.pagination.total=0 detection records - no evidence "
+            "that prevention/detection events are being logged or exported for this tenant."
+        )
+        recommendations.append(
+            "Confirm that the Falcon Event Streams API (or an equivalent SIEM connector) is "
+            "configured and that prevention policies are generating detections, then re-run "
+            "the scan once detection telemetry is flowing."
+        )
+
+    result = {
+        "isEPPLoggingEnabled": is_logging_enabled,
+        "totalDetections": total,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"totalDetections": total, "resourceCount": len(resources)},
+        metadata={
+            "transformationId": "isEPPLoggingEnabled",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/epp/crowdstrike-falcon/isPatchManagementEnabled.py
+++ b/safeguards/epp/crowdstrike-falcon/isPatchManagementEnabled.py
@@ -1,0 +1,160 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error"):
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+
+    policies = data.get("resources") or []
+    if not isinstance(policies, list):
+        policies = []
+
+    total_policies = len(policies)
+    enabled_assigned_policies = []
+    enabled_unassigned_policies = []
+    disabled_policies = []
+
+    for p in policies:
+        if not isinstance(p, dict):
+            continue
+        is_enabled = bool(p.get("enabled"))
+        groups = p.get("groups") or []
+        has_groups = isinstance(groups, list) and len(groups) > 0
+        name = p.get("name") or p.get("id") or "unnamed policy"
+        if is_enabled and has_groups:
+            enabled_assigned_policies.append(name)
+        elif is_enabled and not has_groups:
+            enabled_unassigned_policies.append(name)
+        elif not is_enabled:
+            disabled_policies.append(name)
+
+    is_enabled_result = len(enabled_assigned_policies) > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    input_summary = {
+        "totalPolicies": total_policies,
+        "enabledAssignedCount": len(enabled_assigned_policies),
+        "enabledUnassignedCount": len(enabled_unassigned_policies),
+        "disabledCount": len(disabled_policies),
+    }
+
+    if api_errors:
+        fail_reasons.append(
+            f"Sensor update policy API returned an error: {api_errors[0]}"
+        )
+        recommendations.append(
+            "Verify CrowdStrike API credentials and scopes for the sensor-update-policies collection, then retry."
+        )
+    elif total_policies == 0:
+        fail_reasons.append(
+            "No sensor update policies were returned by getCombinedSensorUpdatePolicies; no policy is assigned to any host group."
+        )
+        recommendations.append(
+            "Create and assign a Sensor Update Policy to host groups in the Falcon console to govern sensor build updates."
+        )
+    elif is_enabled_result:
+        sample = ", ".join(enabled_assigned_policies[:5])
+        pass_reasons.append(
+            f"{len(enabled_assigned_policies)} of {total_policies} sensor update policies are enabled and assigned to host groups (e.g. {sample}), confirming sensor build updates are governed rather than left to manual installer choice."
+        )
+    else:
+        fail_reasons.append(
+            f"None of the {total_policies} sensor update policies found are both enabled=true and assigned to a host group (enabled-but-unassigned: {len(enabled_unassigned_policies)}, disabled: {len(disabled_policies)})."
+        )
+        recommendations.append(
+            "Enable the Sensor Update Policy and assign it to the relevant host groups so sensor build updates are governed."
+        )
+
+    result = {
+        "isPatchManagementEnabled": is_enabled_result,
+        "totalPolicies": total_policies,
+        "enabledAssignedPolicies": len(enabled_assigned_policies),
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isPatchManagementEnabled",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/crowdstrike-falcon/isPatchManagementValid.py
+++ b/safeguards/epp/crowdstrike-falcon/isPatchManagementValid.py
@@ -1,0 +1,163 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 500:
+        api_errors.append(
+            "Vendor API returned an error response: %s" % str(data.get("message") or data.get("errorMessage") or "unknown error")
+        )
+
+    resources = data.get("resources") or []
+    if not isinstance(resources, list):
+        resources = []
+
+    total = len(resources)
+    remediated_count = 0
+    open_without_remediation = 0
+
+    for item in resources:
+        if not isinstance(item, dict):
+            continue
+        status = item.get("status") or ""
+        remediation = item.get("remediation") or {}
+        remediation_ids = remediation.get("ids") if isinstance(remediation, dict) else None
+        has_remediation = bool(remediation_ids)
+        if has_remediation:
+            remediated_count = remediated_count + 1
+        if status.upper() == "OPEN" and not has_remediation:
+            open_without_remediation = open_without_remediation + 1
+
+    if total == 0:
+        is_valid = False
+        pass_reasons = []
+        fail_reasons = [
+            "No Spotlight vulnerability/remediation records were returned for this tenant, so patch remediation tracking could not be confirmed active."
+        ]
+        recommendations = [
+            "Verify Falcon Spotlight module is enabled and returning vulnerability data, and confirm the Sensor Update Policy build tag configuration separately."
+        ]
+        if api_errors:
+            fail_reasons.append(
+                "Underlying API call failed: %s" % api_errors[0]
+            )
+            recommendations.append(
+                "Investigate the Spotlight vulnerabilities API connectivity/error before re-evaluating patch management validity."
+            )
+    else:
+        remediation_rate = (remediated_count * 100.0) / total
+        is_valid = remediation_rate >= 50.0
+        if is_valid:
+            pass_reasons = [
+                f"{remediated_count} of {total} tracked vulnerabilities ({remediation_rate:.1f}%) have remediation.ids populated, indicating patch remediation tracking is active and effective across the host group."
+            ]
+            fail_reasons = []
+            recommendations = []
+        else:
+            pass_reasons = []
+            fail_reasons = [
+                f"Only {remediated_count} of {total} tracked vulnerabilities ({remediation_rate:.1f}%) have remediation.ids populated; {open_without_remediation} are OPEN with no remediation tracking, indicating the Sensor Update Policy build tag is not being consistently enforced against deployed agent_version."
+            ]
+            recommendations = [
+                "Review the Sensor Update Policy build tag (e.g. N-1/N-2) assignment for affected host groups and confirm agent_version reports match the configured tag.",
+                "Ensure OPEN vulnerabilities are linked to an active remediation/patch record."
+            ]
+
+    result = {
+        "isPatchManagementValid": is_valid,
+        "totalVulnerabilities": total,
+        "remediatedCount": remediated_count,
+        "openWithoutRemediationCount": open_without_remediation,
+    }
+
+    input_summary = {
+        "totalVulnerabilities": total,
+        "remediatedCount": remediated_count,
+        "openWithoutRemediationCount": open_without_remediation,
+    }
+
+    metadata = {
+        "transformationId": "isPatchManagementValid",
+        "vendor": "CrowdStrike Falcon",
+        "category": "epp",
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata=metadata,
+        api_errors=api_errors,
+    )

--- a/safeguards/epp/crowdstrike-falcon/isRemovableMediaControlled.py
+++ b/safeguards/epp/crowdstrike-falcon/isRemovableMediaControlled.py
@@ -1,0 +1,166 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 500:
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+
+    resources = data.get("resources") or data.get("data") or []
+    if not isinstance(resources, list):
+        resources = []
+
+    total_policies = len(resources)
+    enabled_controlling_policies = []
+    controlled_classes = ["BLOCK_ALL", "BLOCK", "READ_ONLY", "FULL_ACCESS_MASS_STORAGE_ONLY"]
+
+    for policy in resources:
+        if not isinstance(policy, dict):
+            continue
+        if not policy.get("enabled"):
+            continue
+        settings = policy.get("settings") or {}
+        if not isinstance(settings, dict):
+            settings = {}
+        usb_settings = settings.get("usb_device_control_settings") or {}
+        if not isinstance(usb_settings, dict):
+            usb_settings = {}
+        classes = usb_settings.get("classes") or []
+        if not isinstance(classes, list):
+            classes = []
+
+        controls_usb = False
+        for cls in classes:
+            if not isinstance(cls, dict):
+                continue
+            action = cls.get("action") or ""
+            if action and action != "FULL_ACCESS":
+                controls_usb = True
+                break
+
+        groups = policy.get("groups") or []
+        if controls_usb and (isinstance(groups, list) and len(groups) > 0):
+            enabled_controlling_policies.append(policy.get("name") or policy.get("id") or "unknown")
+
+    is_controlled = len(enabled_controlling_policies) > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_controlled:
+        pass_reasons.append(
+            f"Found {len(enabled_controlling_policies)} enabled device-control "
+            f"policy(ies) with restrictive USB class actions assigned to host groups: "
+            f"{', '.join(enabled_controlling_policies)} (out of {total_policies} total policies)."
+        )
+    else:
+        if total_policies == 0:
+            fail_reasons.append(
+                "No device-control policies were returned by getCombinedDeviceControlPolicies "
+                "(0 resources), so removable-media restrictions cannot be confirmed."
+            )
+        else:
+            fail_reasons.append(
+                f"None of the {total_policies} device-control policy(ies) returned are both "
+                f"enabled=true and assigned to a host group with a restrictive "
+                f"usb_device_control_settings.classes[].action (e.g. BLOCK_ALL); mass-storage "
+                f"devices are not being controlled."
+            )
+        recommendations.append(
+            "Create and enable a Device Control policy in Falcon with USB mass-storage class "
+            "actions set to BLOCK_ALL or READ_ONLY, and assign it to the relevant host groups."
+        )
+
+    result = {
+        "isRemovableMediaControlled": is_controlled,
+        "totalDeviceControlPolicies": total_policies,
+        "enabledControllingPolicies": len(enabled_controlling_policies),
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalPolicies": total_policies,
+            "enabledControllingPolicies": len(enabled_controlling_policies),
+        },
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isRemovableMediaControlled",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/crowdstrike-falcon/requiredCoveragePercentage.py
+++ b/safeguards/epp/crowdstrike-falcon/requiredCoveragePercentage.py
@@ -1,0 +1,154 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") or data.get("errorType") == "internal":
+        msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"CrowdStrike API returned an error: {msg}")
+
+    resources = data.get("resources")
+    if not isinstance(resources, list):
+        resources = []
+
+    total = len(resources)
+    active = 0
+    for device in resources:
+        if not isinstance(device, dict):
+            continue
+        status = device.get("status")
+        rfm = device.get("reduced_functionality_mode")
+        last_seen = device.get("last_seen")
+        agent_version = device.get("agent_version")
+        is_active = (
+            status == "normal"
+            and rfm is not True
+            and bool(agent_version)
+            and bool(last_seen)
+        )
+        if is_active:
+            active = active + 1
+
+    if total > 0:
+        percentage = round((active / total) * 100, 2)
+    else:
+        percentage = 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if total > 0:
+        pass_reasons.append(
+            f"{active} of {total} known Falcon-managed devices report status='normal', "
+            f"reduced_functionality_mode!=true, a populated agent_version, and a recent last_seen "
+            f"timestamp, yielding a sensor coverage of {percentage}%."
+        )
+        if percentage < 100:
+            fail_reasons.append(
+                f"{total - active} of {total} devices ({round(100 - percentage, 2)}%) do not have "
+                f"an actively-reporting Falcon sensor (missing/rfm/stale)."
+            )
+            recommendations.append(
+                "Investigate devices with status != 'normal' or reduced_functionality_mode=true "
+                "and reinstall or repair the Falcon sensor to restore full coverage."
+            )
+    else:
+        fail_reasons.append(
+            "No device records were returned by getDeviceDetails; coverage percentage could not be computed "
+            "(total known devices = 0)."
+        )
+        recommendations.append(
+            "Verify the CrowdStrike Falcon API credentials and device inventory query returned results before "
+            "recomputing sensor coverage."
+        )
+
+    result = {
+        "requiredCoveragePercentage": percentage,
+        "activeDevices": active,
+        "totalDevices": total,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"totalDevices": total, "activeDevices": active},
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "CrowdStrike Falcon",
+            "category": "epp",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/epp/crowdstrike-falcon/schemas/__init__.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/__init__.py
@@ -1,0 +1,27 @@
+"""Schema registry for this vendor's transformations."""
+
+from .isBehavioralMonitoringValid import IsBehavioralMonitoringValidInput
+from .isEDRDeployed import IsEDRDeployedInput
+from .isEPPConfigured import IsEPPConfiguredInput
+from .isEPPDeployed import IsEPPDeployedInput
+from .isEPPEnabled import IsEPPEnabledInput
+from .isEPPEnabledForCriticalSystems import IsEPPEnabledForCriticalSystemsInput
+from .isEPPLoggingEnabled import IsEPPLoggingEnabledInput
+from .isPatchManagementEnabled import IsPatchManagementEnabledInput
+from .isPatchManagementValid import IsPatchManagementValidInput
+from .isRemovableMediaControlled import IsRemovableMediaControlledInput
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
+__all__ = [
+    "IsBehavioralMonitoringValidInput",
+    "IsEDRDeployedInput",
+    "IsEPPConfiguredInput",
+    "IsEPPDeployedInput",
+    "IsEPPEnabledForCriticalSystemsInput",
+    "IsEPPEnabledInput",
+    "IsEPPLoggingEnabledInput",
+    "IsPatchManagementEnabledInput",
+    "IsPatchManagementValidInput",
+    "IsRemovableMediaControlledInput",
+    "RequiredCoveragePercentageInput",
+]

--- a/safeguards/epp/crowdstrike-falcon/schemas/isBehavioralMonitoringValid.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isBehavioralMonitoringValid.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsBehavioralMonitoringValidInput(BaseModel):
+    """Input schema for the isBehavioralMonitoringValid transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isEDRDeployed.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isEDRDeployed.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEDRDeployedInput(BaseModel):
+    """Input schema for the isEDRDeployed transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isEPPConfigured.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isEPPConfigured.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEPPConfiguredInput(BaseModel):
+    """Input schema for the isEPPConfigured transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isEPPDeployed.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isEPPDeployed.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEPPDeployedInput(BaseModel):
+    """Input schema for the isEPPDeployed transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isEPPEnabled.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isEPPEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEPPEnabledInput(BaseModel):
+    """Input schema for the isEPPEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isEPPEnabledForCriticalSystems.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isEPPEnabledForCriticalSystems.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEPPEnabledForCriticalSystemsInput(BaseModel):
+    """Input schema for the isEPPEnabledForCriticalSystems transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isEPPLoggingEnabled.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isEPPLoggingEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEPPLoggingEnabledInput(BaseModel):
+    """Input schema for the isEPPLoggingEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isPatchManagementEnabled.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isPatchManagementEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsPatchManagementEnabledInput(BaseModel):
+    """Input schema for the isPatchManagementEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isPatchManagementValid.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isPatchManagementValid.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsPatchManagementValidInput(BaseModel):
+    """Input schema for the isPatchManagementValid transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/isRemovableMediaControlled.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/isRemovableMediaControlled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsRemovableMediaControlledInput(BaseModel):
+    """Input schema for the isRemovableMediaControlled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike-falcon/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/crowdstrike-falcon/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation."""
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary

This PR adds 11 Python transformation scripts for CrowdStrike Falcon (EPP category), covering endpoint prevention, EDR/sensor deployment, patch/sensor-update management, removable-media (device control), and detection-logging controls. These scripts implement the CrowdStrike Falcon onboarding pipeline's safeguard evaluation logic, translating raw CrowdStrike API responses (policy, device, vulnerability, and detection endpoints) into pass/fail safeguard results for the EPP security domain.

**Context:** CrowdStrike Falcon is being onboarded as a new EPP vendor integration; these transformations fill the evaluation gap for endpoint-protection safeguard criteria that previously had no automated vendor-backed evidence source.

## What each transformation does

### `isBehavioralMonitoringValid.py`
Confirms behavioral/IOA (indicator-of-attack) detection settings are turned on and actually assigned to a host group, not just present in policy config.
- **Consumes:** CrowdStrike `GET /policy/combined/prevention/v1` (getCombinedPreventionPolicies) — live-validated HTTP 200 against tenant.
- **Pass criteria:** At least one prevention policy has `enabled=True` AND `groups` non-empty AND at least one `prevention_settings[].settings[]` entry matches a behavioral keyword list (ioa, behavior, exploit, malware, adwarepup, etc.) with `value.enabled=True`.
- **Key edge cases handled:**
  - Non-dict/malformed `prevention_settings` or `settings` entries are skipped rather than raising.
  - Zero policies returned yields a distinct fail reason ("unable to confirm") vs. policies present but none qualifying.
  - Vendor API error flags (`error`, `errorType`, non-200 `statusCode`) are surfaced as `api_errors` but do not crash the transform.

### `isEDRDeployed.py`
Confirms the Falcon sensor is not just installed but actively streaming EDR telemetry (i.e., not stuck in Reduced Functionality Mode).
- **Consumes:** CrowdStrike `POST /devices/entities/devices/v2` (getDeviceDetails) — live-validated HTTP 200.
- **Pass criteria:** `total_devices > 0` AND at least one device has `reduced_functionality_mode` not true, a populated `agent_version`, AND a `device_policies.sensor_update` assignment.
- **Key edge cases handled:**
  - Handles `reduced_functionality_mode` as either boolean `True` or string `"true"`.
  - Zero devices returns an explicit fail branch distinct from the no-qualifying-device branch.
  - API error path (`error is True` or `errorType`) short-circuits to a dedicated fail response with credential/scope remediation advice rather than silently reporting 0 devices.

### `isEPPConfigured.py`
Confirms a prevention policy exists that is actually enabled and assigned to a host group with non-empty settings — the baseline "EPP is set up at all" check.
- **Consumes:** CrowdStrike `GET /policy/combined/prevention/v1` (getCombinedPreventionPolicies) — live-validated HTTP 200.
- **Pass criteria:** At least one policy has `enabled=True` AND `groups` non-empty AND `prevention_settings` non-empty.
- **Key edge cases handled:**
  - Distinguishes "0 policies returned" from "policies exist but none qualify" in fail reasoning.
  - Treats `statusCode == 500` or `status == "Error"` as an API error and skips policy evaluation entirely rather than treating it as "0 configured".

### `isEPPDeployed.py`
Confirms Falcon sensors are enrolled and reporting at the fleet level (a lighter-weight deployment check than isEDRDeployed).
- **Consumes:** CrowdStrike `GET /devices/queries/devices-scroll/v1` (queryDevicesScroll) — live-validated HTTP 200.
- **Pass criteria:** `meta.pagination.total > 0` (falls back to `len(resources)` if pagination total is missing).
- **Key edge cases handled:**
  - Falls back to page-level resource count when `meta.pagination.total` is absent, avoiding a false fail on a paginated first page.
  - API error (`error is True` or `statusCode == 500`) forces `total=0`/fail rather than reporting a misleading pass.

### `isEPPEnabled.py`
Confirms that every prevention policy actually assigned to a host group is enforcing (enabled), not just configured.
- **Consumes:** CrowdStrike `GET /policy/combined/prevention/v1` (getCombinedPreventionPolicies) — live-validated HTTP 200.
- **Pass criteria:** At least one host-group-assigned policy exists AND ALL host-group-assigned policies have `enabled=True` (a strict "no disabled assigned policy" rule, stricter than isEPPConfigured's "at least one").
- **Key edge cases handled:**
  - Explicitly separates "no assigned policies at all" (fail, different message) from "some assigned policies disabled" (fail, names the disabled ones).
  - Names up to 5 offending/qualifying policies in reasons for reviewer legibility.

### `isEPPEnabledForCriticalSystems.py`
Confirms EPP enforcement specifically covers host groups tagged as critical (servers, domain controllers, tier-0).
- **Consumes:** CrowdStrike `GET /policy/combined/prevention/v1` (getCombinedPreventionPolicies) — live-validated HTTP 200; required 2 onboarding iterations to land the critical-group keyword heuristic.
- **Pass criteria:** At least one critical-named host group is found (keyword match on "critical", "server", "domain controller", "tier0", etc.) AND every discovered critical group is covered by an `enabled=True` policy.
- **Key edge cases handled:**
  - Zero critical groups found is treated as an explicit fail ("could not confirm") rather than a vacuous pass — this is a deliberate conservative design choice worth flagging to reviewers since it means tenants without identifiable naming conventions will always fail this check.
  - Lists the specific uncovered critical groups by name in fail reasons/recommendations.

### `isEPPLoggingEnabled.py`
Confirms an active detection/audit trail exists fleet-wide (evidence the detection pipeline, not just prevention config, is functioning).
- **Consumes:** CrowdStrike `GET /detects/queries/detects/v1` (queryDetects) — live-validated HTTP 200.
- **Pass criteria:** `meta.pagination.total > 0` (falls back to `len(resources)`).
- **Key edge cases handled:**
  - `int()` cast on `total` wrapped in try/except to guard against unexpected non-numeric pagination values, defaulting to 0.
  - API error path (`error is True` or `statusCode == 500`) returns a dedicated fail reason naming the `detects:read` OAuth scope as a likely root cause.

### `isPatchManagementEnabled.py`
Confirms sensor build/version updates are governed by policy rather than left to manual installation.
- **Consumes:** CrowdStrike `GET /policy/combined/sensor-update/v2` (getCombinedSensorUpdatePolicies) — live-validated HTTP 200; required 2 onboarding iterations.
- **Pass criteria:** At least one sensor-update policy has `enabled=True` AND `groups` non-empty.
- **Key edge cases handled:**
  - Three-way bucketing of policies (enabled+assigned, enabled+unassigned, disabled) gives precise fail messaging distinguishing "policy exists but not assigned" from "policy disabled".
  - Zero policies returns a distinct "no policy at all" fail reason.

### `isPatchManagementValid.py`
Confirms identified vulnerabilities are actually being remediated/tracked, not just detected (patch management effectiveness, not just existence).
- **Consumes:** CrowdStrike `GET /spotlight/combined/vulnerabilities/v1` (getSpotlightVulnerabilitiesCombined) — live-validated HTTP 200; required 2 onboarding iterations.
- **Pass criteria:** `remediated_count / total >= 50%`, where remediated = `remediation.ids` populated on a vulnerability record.
- **Key edge cases handled:**
  - Zero vulnerability records is an explicit fail ("could not confirm active") rather than a vacuous pass.
  - The 50% threshold is a hardcoded heuristic and not derived from any documented CrowdStrike SLA — flag this to reviewers as a business-logic assumption worth confirming with compliance/policy owners rather than a vendor-documented fact.

### `isRemovableMediaControlled.py`
Confirms USB mass-storage devices are actively restricted, not just that a device-control policy exists.
- **Consumes:** CrowdStrike `GET /policy/combined/device-control/v1` (getCombinedDeviceControlPolicies) — live-validated HTTP 200.
- **Pass criteria:** At least one policy has `enabled=True` AND `groups` non-empty AND at least one `settings.usb_device_control_settings.classes[]` entry has an `action` other than `"FULL_ACCESS"`.
- **Key edge cases handled:**
  - Falls back to `data.get("data")` if `resources` key is absent, tolerating a slightly different response envelope.
  - Distinguishes zero policies returned vs. policies present but none restrictive in fail messaging.

### `requiredCoveragePercentage.py`
Computes the percentage of the known device fleet with an actively-reporting Falcon sensor (denominator = all known devices, not just enrolled ones).
- **Consumes:** CrowdStrike `POST /devices/entities/devices/v2` (getDeviceDetails) — live-validated HTTP 200.
- **Pass criteria:** No hard pass/fail boolean gate; reports `percentage = active/total * 100` where `active` requires `status == "normal"` AND `reduced_functionality_mode is not True` AND populated `agent_version` AND populated `last_seen`. Fail reasons are only emitted when percentage < 100%.
- **Key edge cases handled:**
  - Zero total devices yields `percentage = 0` with an explicit "could not be computed" fail reason rather than a misleading 0% "failure".
  - Uses `status == "normal"` in addition to RFM/agent_version/last_seen checks, a stricter bar than `isEDRDeployed`'s equivalent logic — worth double-checking this is intentional since the two scripts use slightly different device-health criteria against the same endpoint.

## Architecture notes

All 11 scripts share an identical structural contract: `extract_input()` unwraps enriched (`data`/`validation`) or legacy-wrapped API payloads, `transform()` (the evaluate step) applies pass/fail boolean logic against `resources`/`meta` fields, and `create_response()` packages the result into the standard 5-section schema (`dataCollection`, `validation`, `transformation`, `evaluation` with `passReasons`/`failReasons`/`recommendations`/`additionalFindings`, and `metadata`). All scripts declare `schemaVersion: "2.0"` and tag `vendor: "CrowdStrike Falcon"` / `category: "epp"` in metadata. No RestrictedPython-incompatible constructs (no imports beyond `json`/`datetime`, no file/network I/O) were observed.

## Test plan

- [ ] Each script passes `PyCodeExecutor` sandbox validation
- [ ] Verify `evaluate()`/`transform()` returns correct result for: valid data, missing fields, API error responses (`error`/`statusCode`/`errorType` variants — field names differ slightly across scripts, see per-script findings)
- [ ] Confirm field names in `data.get("...")` match CrowdStrike API documentation for each endpoint (prevention policy `groups`/`prevention_settings`/`enabled`; device `reduced_functionality_mode`/`agent_version`/`last_seen`/`status`/`device_policies`; device-control `settings.usb_device_control_settings.classes[].action`; Spotlight `status`/`remediation.ids`; detects `meta.pagination.total`)
- [ ] Confirm `isEPPEnabledForCriticalSystems` keyword-based critical-group detection is validated against the customer's actual host-group naming conventions before go-live, since it fails closed (zero critical groups found = fail) when naming doesn't match the keyword list
- [ ] Confirm the 50% remediation threshold in `isPatchManagementValid.py` is the intended compliance bar, not a placeholder
- [ ] Spot-check `create_response()` output matches expected schema version 2.0 (note: schemaVersion is 2.0 here, not 1.0 — confirm this is the current platform contract version)

🤖 Generated by Spektrum integration onboarding pipeline