### PR TITLE
LABS-3278: Fix Cloudflare DNS result evaluation

### DIFF
--- a/safeguards/emailsecurity/cloudflare/isdnsconfigured.py
+++ b/safeguards/emailsecurity/cloudflare/isdnsconfigured.py
@@ -68,6 +68,16 @@ def create_response(result, validation=None, pass_reasons=None, fail_reasons=Non
     }
 
 
+def get_protocol(data, name):
+    """Return a protocol value without depending on key casing."""
+    if name in data:
+        return data.get(name)
+    for key, value in data.items():
+        if isinstance(key, str) and key.lower() == name.lower():
+            return value
+    return False
+
+
 def transform(input):
     criteriaKey = "isDNSConfigured"
 
@@ -81,7 +91,15 @@ def transform(input):
 
         if validation.get("status") == "failed":
             return create_response(
-                result={criteriaKey: False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
+                result={
+                    criteriaKey: False,
+                    "spfConfigured": False,
+                    "dkimConfigured": False,
+                    "dmarcConfigured": False,
+                    "isSPFConfigured": False,
+                    "isDKIMConfigured": False,
+                    "isDMARCConfigured": False
+                },
                 validation=validation,
                 fail_reasons=["Input validation failed"]
             )
@@ -124,14 +142,11 @@ def transform(input):
 
                 dns_configured = spf_configured or dkim_configured or dmarc_configured
 
-            # Direct boolean fields
+            # Direct boolean or record-string fields from the DNS helper.
             if not dns_configured:
-                if 'spf' in data:
-                    spf_configured = bool(data['spf'])
-                if 'dkim' in data:
-                    dkim_configured = bool(data['dkim'])
-                if 'dmarc' in data:
-                    dmarc_configured = bool(data['dmarc'])
+                spf_configured = bool(get_protocol(data, "SPF"))
+                dkim_configured = bool(get_protocol(data, "DKIM"))
+                dmarc_configured = bool(get_protocol(data, "DMARC"))
                 dns_configured = spf_configured or dkim_configured or dmarc_configured
 
             # Check DNS records list (from Cloudflare zones DNS endpoint)
@@ -152,7 +167,10 @@ def transform(input):
                                 dmarc_configured = True
                         elif rtype == 'CNAME' and 'dkim' in record.get('name', '').lower():
                             dkim_configured = True
-                    dns_configured = spf_configured or dkim_configured or dmarc_configured
+
+        # The requirement passes only when all three records exist. The earlier
+        # OR checks are retained solely to preserve the legacy source fallback.
+        dns_configured = spf_configured and dkim_configured and dmarc_configured
 
         # Build additional findings for sub-criteria
         if spf_configured:
@@ -181,7 +199,10 @@ def transform(input):
                 criteriaKey: dns_configured,
                 "spfConfigured": spf_configured,
                 "dkimConfigured": dkim_configured,
-                "dmarcConfigured": dmarc_configured
+                "dmarcConfigured": dmarc_configured,
+                "isSPFConfigured": spf_configured,
+                "isDKIMConfigured": dkim_configured,
+                "isDMARCConfigured": dmarc_configured
             },
             validation=validation,
             pass_reasons=pass_reasons,
@@ -197,7 +218,15 @@ def transform(input):
 
     except Exception as e:
         return create_response(
-            result={criteriaKey: False, "spfConfigured": False, "dkimConfigured": False, "dmarcConfigured": False},
+            result={
+                criteriaKey: False,
+                "spfConfigured": False,
+                "dkimConfigured": False,
+                "dmarcConfigured": False,
+                "isSPFConfigured": False,
+                "isDKIMConfigured": False,
+                "isDMARCConfigured": False
+            },
             validation={"status": "error", "errors": [], "warnings": []},
             transformation_errors=[str(e)],
             fail_reasons=[f"Transformation error: {str(e)}"]

--- a/safeguards/emailsecurity/cloudflare/schemas/isdnsconfigured.py
+++ b/safeguards/emailsecurity/cloudflare/schemas/isdnsconfigured.py
@@ -45,6 +45,11 @@ class IsdnsconfiguredInput(BaseModel):
     via the Spektrum DNS check tool or Cloudflare zones DNS endpoint.
     """
 
+    # The shared DNS helper uses uppercase keys. Lowercase fields remain for
+    # compatibility with the original Cloudflare transformation contract.
+    SPF: Optional[Any] = None
+    DKIM: Optional[Any] = None
+    DMARC: Optional[Any] = None
     spf: Optional[Any] = None
     dkim: Optional[Any] = None
     dmarc: Optional[Any] = None

--- a/safeguards/emailsecurity/cloudflare/test_isdnsconfigured.py
+++ b/safeguards/emailsecurity/cloudflare/test_isdnsconfigured.py
@@ -1,0 +1,103 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+TRANSFORMATION_PATH = Path(__file__).with_name("isdnsconfigured.py")
+
+
+def load_transformation():
+    spec = importlib.util.spec_from_file_location(
+        "cloudflare_isdnsconfigured",
+        TRANSFORMATION_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CloudflareDnsConfigurationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.transformation = load_transformation()
+
+    def assert_dns_state(self, response, *, spf, dkim, dmarc):
+        transformed = response["transformedResponse"]
+        self.assertEqual(transformed["isSPFConfigured"], spf)
+        self.assertEqual(transformed["isDKIMConfigured"], dkim)
+        self.assertEqual(transformed["isDMARCConfigured"], dmarc)
+        self.assertEqual(
+            transformed["isDNSConfigured"],
+            spf and dkim and dmarc,
+        )
+        self.assertEqual(transformed["spfConfigured"], spf)
+        self.assertEqual(transformed["dkimConfigured"], dkim)
+        self.assertEqual(transformed["dmarcConfigured"], dmarc)
+
+    def test_reads_actual_dns_helper_response(self):
+        response = self.transformation.transform({
+            "result": {
+                "SPF": "v=spf1 -all",
+                "DKIM": "v=DKIM1; p=public-key",
+                "DMARC": "v=DMARC1; p=reject",
+                "SMTPBanner": "No banner found",
+            },
+        })
+
+        self.assert_dns_state(response, spf=True, dkim=True, dmarc=True)
+
+    def test_partial_helper_response_does_not_pass_aggregate(self):
+        response = self.transformation.transform({
+            "result": {
+                "SPF": "v=spf1 -all",
+                "DKIM": False,
+                "DMARC": "v=DMARC1; p=reject",
+            },
+        })
+
+        self.assert_dns_state(response, spf=True, dkim=False, dmarc=True)
+
+    def test_preserves_lowercase_direct_input(self):
+        response = self.transformation.transform({
+            "spf": True,
+            "dkim": True,
+            "dmarc": True,
+        })
+
+        self.assert_dns_state(response, spf=True, dkim=True, dmarc=True)
+
+    def test_preserves_nested_email_authentication_input(self):
+        response = self.transformation.transform({
+            "settings": {
+                "emailAuthentication": {
+                    "spf": {"enabled": True},
+                    "dkim": {"configured": True},
+                    "dmarc": True,
+                },
+            },
+        })
+
+        self.assert_dns_state(response, spf=True, dkim=True, dmarc=True)
+
+    def test_preserves_cloudflare_dns_record_input(self):
+        response = self.transformation.transform({
+            "records": [
+                {"type": "TXT", "name": "example.com", "content": "v=spf1 -all"},
+                {
+                    "type": "TXT",
+                    "name": "selector._domainkey.example.com",
+                    "content": "v=DKIM1; p=public-key",
+                },
+                {
+                    "type": "TXT",
+                    "name": "_dmarc.example.com",
+                    "content": "v=DMARC1; p=reject",
+                },
+            ],
+        })
+
+        self.assert_dns_state(response, spf=True, dkim=True, dmarc=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Read direct SPF, DKIM, and DMARC results without depending on key casing, so Cloudflare can consume the shared DNS helper's uppercase response fields.
- Require SPF, DKIM, and DMARC to all be configured before `isDNSConfigured` passes.
- Emit the canonical `isSPFConfigured`, `isDKIMConfigured`, and `isDMARCConfigured` criteria while retaining the existing lowercase aliases.
- Extend the Cloudflare input schema to accept the helper's uppercase fields.
- Add focused coverage for actual helper output, partial results, and all supported legacy input shapes.

## Why

The shared DNS helper returns `SPF`, `DKIM`, and `DMARC`. The existing Cloudflare transformation only read lowercase direct fields, so valid helper results could be transformed into all-false outcomes. The aggregate check also used OR semantics, allowing a partial configuration to pass `isDNSConfigured`.

This is a pre-existing Cloudflare transformation defect; it was not introduced by the DNS timeout/evaluator work.

## Compatibility and intentional behavior change

The transformation continues to accept:

- lowercase direct fields
- nested email-authentication settings
- Cloudflare DNS record lists

It also retains `spfConfigured`, `dkimConfigured`, and `dmarcConfigured` for existing consumers. The intentional correctness change is that the aggregate result now passes only when all three protocols are configured.

## Deployment dependency

This PR does **not** change Cloudflare's endpoint or any Integration Service configuration/database definition. It should be deployed before the separate Cloudflare Integration Service routing and database update. Until that follow-up is deployed, Cloudflare remains on its existing endpoint.

The existing Integration Service PR #687 covers Abnormal, Google Workspace, Mimecast, and legacy Microsoft 365; it intentionally does not include Cloudflare.

## Validation

- 37/37 repository tests passed:
  - 26 endpoint-administrator tests
  - 6 Microsoft One-Click tests
  - 5 Cloudflare DNS transformation tests
- Uppercase helper payload validated against the exact schema with Pydantic 2.11.7.
- Python compilation passed for the transformer, schema, and tests.
- `git diff --check` passed.
