### PR TITLE
Fix Microsoft one-click Endpoint machine evaluation

### DIFF
--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/microsoft_endpoint_oneclick.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/microsoft_endpoint_oneclick.py
@@ -12,11 +12,11 @@ from datetime import datetime
 HEALTHY_SENSOR_STATES = {"active"}
 
 
-def _is_true(value):
+def is_true(value):
     return value is True or (isinstance(value, str) and value.lower() == "true")
 
 
-def _extract(value):
+def extract_input(value):
     if isinstance(value, (str, bytes)):
         value = json.loads(value.decode("utf-8") if isinstance(value, bytes) else value)
     if isinstance(value, dict) and "data" in value and "validation" in value:
@@ -25,18 +25,18 @@ def _extract(value):
     for _ in range(3):
         if not isinstance(data, dict):
             break
-        nested = next(
-            (data[key] for key in ("api_response", "response", "result", "apiResponse", "Output")
-             if isinstance(data.get(key), (dict, list))),
-            None,
-        )
+        nested = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nested = data[key]
+                break
         if nested is None:
             break
         data = nested
     return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
 
 
-def _response(result, validation, *, errors=(), summary=None):
+def create_response(result, validation, *, errors=(), summary=None):
     passed = [key for key, value in result.items() if isinstance(value, bool) and value]
     failed = [key for key, value in result.items() if isinstance(value, bool) and not value]
     return {
@@ -66,13 +66,13 @@ def _response(result, validation, *, errors=(), summary=None):
     }
 
 
-def _machines(data):
+def evaluate_machines(data):
     machines = data.get("value") if isinstance(data, dict) else None
     if not isinstance(machines, list):
         raise ValueError("MDE machines response must contain a value array")
     if any(not isinstance(machine, dict) for machine in machines):
         raise ValueError("MDE machines response contains an invalid machine record")
-    non_excluded = [machine for machine in machines if not _is_true(machine.get("isExcluded"))]
+    non_excluded = [machine for machine in machines if not is_true(machine.get("isExcluded"))]
     eligible = [
         machine for machine in non_excluded
         if str(machine.get("onboardingStatus") or "").lower() not in {"unsupported", "insufficientinfo"}
@@ -103,19 +103,19 @@ def _machines(data):
 
 def transform(input):
     try:
-        data, validation = _extract(input)
+        data, validation = extract_input(input)
         if validation.get("status") == "failed":
             raise ValueError("Input validation failed")
         if not isinstance(data, dict) or "error" in data or "PSError" in data:
             raise ValueError("Microsoft did not return usable Endpoint evidence")
 
         if isinstance(data.get("value"), list):
-            result = _machines(data)
+            result = evaluate_machines(data)
         else:
             raise ValueError("Unrecognized Microsoft Endpoint response shape")
-        return _response(result, validation, summary={"returnedKeys": sorted(result)})
+        return create_response(result, validation, summary={"returnedKeys": sorted(result)})
     except Exception as error:
-        return _response(
+        return create_response(
             {},
             {"status": "failed", "errors": [str(error)], "warnings": []},
             errors=[str(error)],

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/microsoft_endpoint_oneclick.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/microsoft_endpoint_oneclick.py
@@ -1,0 +1,122 @@
+"""Microsoft one-click Endpoint evaluation from MDE machine inventory.
+
+This stays separate from the legacy transforms so existing Endpoint customers
+keep their current verdicts. Valid empty Microsoft responses evaluate to false/0;
+API and validation errors remain collection errors instead of false positives.
+"""
+
+import json
+from datetime import datetime
+
+
+HEALTHY_SENSOR_STATES = {"active"}
+
+
+def _is_true(value):
+    return value is True or (isinstance(value, str) and value.lower() == "true")
+
+
+def _extract(value):
+    if isinstance(value, (str, bytes)):
+        value = json.loads(value.decode("utf-8") if isinstance(value, bytes) else value)
+    if isinstance(value, dict) and "data" in value and "validation" in value:
+        return value["data"], value["validation"]
+    data = value
+    for _ in range(3):
+        if not isinstance(data, dict):
+            break
+        nested = next(
+            (data[key] for key in ("api_response", "response", "result", "apiResponse", "Output")
+             if isinstance(data.get(key), (dict, list))),
+            None,
+        )
+        if nested is None:
+            break
+        data = nested
+    return data, {"status": "unknown", "errors": [], "warnings": ["Legacy input format"]}
+
+
+def _response(result, validation, *, errors=(), summary=None):
+    passed = [key for key, value in result.items() if isinstance(value, bool) and value]
+    failed = [key for key, value in result.items() if isinstance(value, bool) and not value]
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if errors else "success", "errors": list(errors)},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {"status": "success", "errors": [], "inputSummary": summary or {}},
+            "evaluation": {
+                "passReasons": [key + " passed" for key in passed],
+                "failReasons": [key + " failed" for key in failed] + list(errors),
+                "recommendations": [],
+                "additionalFindings": [],
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "2.0",
+                "transformationId": "microsoft_endpoint_oneclick",
+                "vendor": "Microsoft Defender for Endpoint",
+                "category": "Endpoint Security",
+            },
+        },
+    }
+
+
+def _machines(data):
+    machines = data.get("value") if isinstance(data, dict) else None
+    if not isinstance(machines, list):
+        raise ValueError("MDE machines response must contain a value array")
+    if any(not isinstance(machine, dict) for machine in machines):
+        raise ValueError("MDE machines response contains an invalid machine record")
+    non_excluded = [machine for machine in machines if not _is_true(machine.get("isExcluded"))]
+    eligible = [
+        machine for machine in non_excluded
+        if str(machine.get("onboardingStatus") or "").lower() not in {"unsupported", "insufficientinfo"}
+    ]
+    onboarded = [machine for machine in eligible if str(machine.get("onboardingStatus") or "").lower() == "onboarded"]
+    reporting = [
+        machine for machine in onboarded
+        if machine.get("lastSeen")
+        and str(machine.get("healthStatus") or "").lower() in HEALTHY_SENSOR_STATES
+    ]
+    servers = [machine for machine in eligible if "server" in str(machine.get("osPlatform") or "").lower()]
+    protected_servers = [machine for machine in servers if str(machine.get("onboardingStatus") or "").lower() == "onboarded"]
+    coverage = round(100 * len(onboarded) / len(eligible)) if eligible else 0
+    server_coverage = round(100 * len(protected_servers) / len(servers)) if servers else 0
+    return {
+        "isEPPEnabled": bool(onboarded),
+        "isEPPConfigured": bool(eligible) and len(onboarded) == len(eligible),
+        "isEPPLoggingEnabled": bool(onboarded) and len(reporting) == len(onboarded),
+        "requiredCoveragePercentage": coverage,
+        "serverCoveragePercentage": server_coverage,
+        "totalEndpointCount": len(eligible),
+        "totalServerCount": len(servers),
+        "eligibleDevices": len(eligible),
+        "protectedDevices": len(onboarded),
+        "reportingDevices": len(reporting),
+    }
+
+
+def transform(input):
+    try:
+        data, validation = _extract(input)
+        if validation.get("status") == "failed":
+            raise ValueError("Input validation failed")
+        if not isinstance(data, dict) or "error" in data or "PSError" in data:
+            raise ValueError("Microsoft did not return usable Endpoint evidence")
+
+        if isinstance(data.get("value"), list):
+            result = _machines(data)
+        else:
+            raise ValueError("Unrecognized Microsoft Endpoint response shape")
+        return _response(result, validation, summary={"returnedKeys": sorted(result)})
+    except Exception as error:
+        return _response(
+            {},
+            {"status": "failed", "errors": [str(error)], "warnings": []},
+            errors=[str(error)],
+        )

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_microsoft_endpoint_oneclick.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_microsoft_endpoint_oneclick.py
@@ -1,0 +1,74 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("microsoft_endpoint_oneclick.py")
+SPEC = importlib.util.spec_from_file_location("microsoft_endpoint_oneclick", MODULE_PATH)
+TRANSFORM = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TRANSFORM)
+
+
+def _result(payload):
+    return TRANSFORM.transform(payload)["transformedResponse"]
+
+
+def test_empty_machine_inventory_never_reports_coverage_or_epp_pass():
+    result = _result({"value": []})
+    assert result["requiredCoveragePercentage"] == 0
+    assert result["serverCoveragePercentage"] == 0
+    assert result["totalEndpointCount"] == 0
+    assert result["isEPPEnabled"] is False
+    assert result["isEPPConfigured"] is False
+    assert result["isEPPLoggingEnabled"] is False
+
+
+def test_machine_inventory_uses_onboarding_and_reporting_evidence():
+    result = _result({"value": [
+        {"onboardingStatus": "Onboarded", "healthStatus": "Active", "lastSeen": "2026-07-27", "osPlatform": "Windows11"},
+        {"onboardingStatus": "CanBeOnboarded", "healthStatus": "NoSensorData", "osPlatform": "WindowsServer2022"},
+    ]})
+    assert result["isEPPEnabled"] is True
+    assert result["isEPPConfigured"] is False
+    assert result["isEPPLoggingEnabled"] is True
+    assert result["requiredCoveragePercentage"] == 50
+    assert result["serverCoveragePercentage"] == 0
+
+
+def test_inactive_sensor_does_not_pass_logging_check():
+    result = _result({"value": [{
+        "onboardingStatus": "Onboarded",
+        "healthStatus": "Inactive",
+        "lastSeen": "2026-07-27",
+        "osPlatform": "Windows11",
+    }]})
+    assert result["isEPPEnabled"] is True
+    assert result["isEPPLoggingEnabled"] is False
+
+
+def test_string_false_does_not_exclude_machine():
+    result = _result({"value": [{
+        "isExcluded": "false",
+        "onboardingStatus": "Onboarded",
+        "healthStatus": "Active",
+        "lastSeen": "2026-07-27",
+        "osPlatform": "Windows11",
+    }]})
+    assert result["totalEndpointCount"] == 1
+    assert result["requiredCoveragePercentage"] == 100
+
+
+def test_empty_collection_fails_closed_for_machine_checks():
+    result = _result({"value": []})
+    assert result["totalEndpointCount"] == 0
+
+
+def test_unrecognized_payload_is_a_collection_error():
+    response = TRANSFORM.transform({"unexpected": []})
+    assert response["transformedResponse"] == {}
+    assert response["additionalInfo"]["dataCollection"]["status"] == "error"
+
+
+def test_invalid_machine_record_is_a_collection_error():
+    response = TRANSFORM.transform({"value": ["not-a-machine"]})
+    assert response["transformedResponse"] == {}
+    assert response["additionalInfo"]["dataCollection"]["status"] == "error"

--- a/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_microsoft_endpoint_oneclick.py
+++ b/safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_microsoft_endpoint_oneclick.py
@@ -57,6 +57,17 @@ def test_string_false_does_not_exclude_machine():
     assert result["requiredCoveragePercentage"] == 100
 
 
+def test_nested_response_wrapper_is_unwrapped():
+    result = _result({"response": {"value": [{
+        "onboardingStatus": "Onboarded",
+        "healthStatus": "Active",
+        "lastSeen": "2026-07-27",
+        "osPlatform": "Windows11",
+    }]}})
+    assert result["totalEndpointCount"] == 1
+    assert result["isEPPEnabled"] is True
+
+
 def test_empty_collection_fails_closed_for_machine_checks():
     result = _result({"value": []})
     assert result["totalEndpointCount"] == 0


### PR DESCRIPTION
## Summary

- add a Microsoft one-click-only Endpoint transformer backed by Defender machine inventory
- evaluate EPP enabled/configured/logging plus endpoint and server coverage/counts from the same response
- treat malformed or failed Microsoft responses as collection errors and valid empty inventory as false/zero
- leave every legacy transformation unchanged

## Why

The one-click Endpoint definition was still routing machine checks through legacy transformations that do not interpret Microsoft Defender machine inventory reliably.

## Tests

- `python3 -m pytest -q safeguards/7BC425FA-0638-4BF1-8194-19E7E4F2F43C/test_microsoft_endpoint_oneclick.py` — 7 passed

## Rollout

Integration-Service pins this exact commit SHA. Merge this PR before or together with the coordinated Integration-Service and Flux PRs.
