### PR TITLE
ENG-257 Fix AWS Security Hub Cloud Security criteria transforms

### DIFF
--- a/safeguards/cloudsecurity/awssecurityhub/compliancepercentage.py
+++ b/safeguards/cloudsecurity/awssecurityhub/compliancepercentage.py
@@ -1,0 +1,88 @@
+"""
+Transformation: compliancePercentage
+Vendor: AWS Security Hub  |  Category: Cloud Security
+
+Control-level compliance score (matches AWS Security Hub's own methodology): findings are
+deduplicated by SecurityControlId, a control passes unless any active finding for it is
+FAILED, and the score is passing_controls / total_controls. Sets both compliancePercentage
+and CIScompliancePercentage from the findings provided (the method determines the standard).
+"""
+
+import json
+from datetime import datetime
+
+TRANSFORM_ID = "compliancepercentage"
+
+
+def extract_findings(input_data):
+    data = input_data
+    if isinstance(data, str):
+        data = json.loads(data)
+    elif isinstance(data, bytes):
+        data = json.loads(data.decode("utf-8"))
+    if isinstance(data, dict) and "data" in data and "validation" in data:
+        data = data["data"]
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        nxt = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nxt = data[key]
+                break
+        if nxt is None:
+            break
+        data = nxt
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_response(result, pass_reasons=None, fail_reasons=None, errors=None):
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (errors or []) else "success", "errors": errors or []},
+            "validation": {"status": "unknown", "errors": [], "warnings": []},
+            "transformation": {"status": "error" if (errors or []) else "success", "errors": errors or [], "inputSummary": {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": [], "additionalFindings": []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0",
+                         "transformationId": TRANSFORM_ID, "vendor": "AWS Security Hub", "category": "Cloud Security"},
+        },
+    }
+
+
+def transform(input):
+    try:
+        findings = extract_findings(input)
+        control_failed = {}
+        for f in findings:
+            if not isinstance(f, dict):
+                continue
+            comp = f.get("Compliance") or {}
+            cid = comp.get("SecurityControlId")
+            status = str(comp.get("Status") or "").upper()
+            if not cid or status not in ("PASSED", "FAILED"):
+                continue
+            if cid not in control_failed:
+                control_failed[cid] = False
+            if status == "FAILED":
+                control_failed[cid] = True
+        total = len(control_failed)
+        passing = 0
+        for cid in control_failed:
+            if not control_failed[cid]:
+                passing += 1
+        percentage = int(round(100 * passing / total)) if total > 0 else 0
+        result = {
+            "compliancePercentage": percentage,
+            "CIScompliancePercentage": percentage,
+            "passingControls": passing,
+            "totalControls": total,
+        }
+        return build_response(result,
+                              pass_reasons=[str(percentage) + "% of controls passing (" + str(passing) + "/" + str(total) + ")"])
+    except Exception as error:
+        return build_response({"compliancePercentage": 0, "CIScompliancePercentage": 0}, errors=[str(error)])

--- a/safeguards/cloudsecurity/awssecurityhub/criticalopenfindingscount.py
+++ b/safeguards/cloudsecurity/awssecurityhub/criticalopenfindingscount.py
@@ -1,0 +1,82 @@
+import json
+from datetime import datetime
+
+
+def extract_findings(input_data):
+    data = input_data
+    if isinstance(data, str):
+        data = json.loads(data)
+    elif isinstance(data, bytes):
+        data = json.loads(data.decode("utf-8"))
+    if isinstance(data, dict) and "data" in data and "validation" in data:
+        data = data["data"]
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        nxt = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nxt = data[key]
+                break
+        if nxt is None:
+            break
+        data = nxt
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_response(result, transform_id, pass_reasons=None, fail_reasons=None, errors=None):
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (errors or []) else "success", "errors": errors or []},
+            "validation": {"status": "unknown", "errors": [], "warnings": []},
+            "transformation": {"status": "error" if (errors or []) else "success", "errors": errors or [], "inputSummary": {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": [], "additionalFindings": []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0",
+                         "transformationId": transform_id, "vendor": "AWS Security Hub", "category": "Cloud Security"},
+        },
+    }
+
+
+def control_status_map(findings, control_ids):
+    statuses = {}
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        comp = f.get("Compliance") or {}
+        cid = comp.get("SecurityControlId")
+        if cid not in control_ids:
+            continue
+        status = str(comp.get("Status") or "").upper()
+        if status in ("PASSED", "FAILED"):
+            prev = statuses.get(cid)
+            statuses[cid] = "FAILED" if (status == "FAILED" or prev == "FAILED") else "PASSED"
+    return statuses
+
+
+CRITERIA_KEY = "criticalOpenFindingsCount"
+TRANSFORM_ID = "criticalopenfindingscount"
+
+
+def transform(input):
+    try:
+        findings = extract_findings(input)
+        critical = 0
+        for f in findings:
+            if not isinstance(f, dict):
+                continue
+            comp = f.get("Compliance") or {}
+            severity = str((f.get("Severity") or {}).get("Label") or "").upper()
+            status = str(comp.get("Status") or "").upper()
+            if severity == "CRITICAL" and status == "FAILED":
+                critical += 1
+        acceptable = critical == 0
+        return build_response({CRITERIA_KEY: acceptable, "openCriticalFindings": critical}, TRANSFORM_ID,
+                              pass_reasons=["No open critical findings"] if acceptable else [],
+                              fail_reasons=[] if acceptable else [str(critical) + " open critical findings"])
+    except Exception as error:
+        return build_response({CRITERIA_KEY: False, "openCriticalFindings": -1}, TRANSFORM_ID, errors=[str(error)])

--- a/safeguards/cloudsecurity/awssecurityhub/isguarddutyenabled.py
+++ b/safeguards/cloudsecurity/awssecurityhub/isguarddutyenabled.py
@@ -1,0 +1,87 @@
+"""
+Transformation: isGuardDutyEnabled
+Vendor: AWS Security Hub  |  Category: Cloud Security
+
+Evaluates AWS Security Hub control(s) GuardDuty.1 from the getSecurityHubComplianceAWS
+findings. A control passes unless it has an active FAILED finding; the criterion passes
+only when every checked control that is present is passing. Fails closed if no active
+finding for these controls is returned.
+"""
+
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "isGuardDutyEnabled"
+CONTROL_IDS = ['GuardDuty.1']
+TRANSFORM_ID = "isguarddutyenabled"
+
+
+def extract_findings(input_data):
+    data = input_data
+    if isinstance(data, str):
+        data = json.loads(data)
+    elif isinstance(data, bytes):
+        data = json.loads(data.decode("utf-8"))
+    if isinstance(data, dict) and "data" in data and "validation" in data:
+        data = data["data"]
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        nxt = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nxt = data[key]
+                break
+        if nxt is None:
+            break
+        data = nxt
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_response(result, pass_reasons=None, fail_reasons=None, errors=None):
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (errors or []) else "success", "errors": errors or []},
+            "validation": {"status": "unknown", "errors": [], "warnings": []},
+            "transformation": {"status": "error" if (errors or []) else "success", "errors": errors or [], "inputSummary": {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": [], "additionalFindings": []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0",
+                         "transformationId": TRANSFORM_ID, "vendor": "AWS Security Hub", "category": "Cloud Security"},
+        },
+    }
+
+
+def transform(input):
+    try:
+        findings = extract_findings(input)
+        statuses = []
+        failed_controls = []
+        for f in findings:
+            if not isinstance(f, dict):
+                continue
+            comp = f.get("Compliance") or {}
+            if comp.get("SecurityControlId") not in CONTROL_IDS:
+                continue
+            status = str(comp.get("Status") or "").upper()
+            if status in ("PASSED", "FAILED"):
+                statuses.append(status)
+                if status == "FAILED":
+                    cid = comp.get("SecurityControlId")
+                    if cid not in failed_controls:
+                        failed_controls.append(cid)
+        if not statuses:
+            return build_response({CRITERIA_KEY: False},
+                                  fail_reasons=["No active Security Hub findings for control(s): " + ", ".join(CONTROL_IDS)])
+        passed = "FAILED" not in statuses
+        if passed:
+            return build_response({CRITERIA_KEY: True},
+                                  pass_reasons=["All checked controls passing: " + ", ".join(CONTROL_IDS)])
+        return build_response({CRITERIA_KEY: False},
+                              fail_reasons=["Failing control(s): " + ", ".join(failed_controls)])
+    except Exception as error:
+        return build_response({CRITERIA_KEY: False}, errors=[str(error)])

--- a/safeguards/cloudsecurity/awssecurityhub/isiamloggingenabled.py
+++ b/safeguards/cloudsecurity/awssecurityhub/isiamloggingenabled.py
@@ -1,0 +1,78 @@
+import json
+from datetime import datetime
+
+
+def extract_findings(input_data):
+    data = input_data
+    if isinstance(data, str):
+        data = json.loads(data)
+    elif isinstance(data, bytes):
+        data = json.loads(data.decode("utf-8"))
+    if isinstance(data, dict) and "data" in data and "validation" in data:
+        data = data["data"]
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        nxt = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nxt = data[key]
+                break
+        if nxt is None:
+            break
+        data = nxt
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_response(result, transform_id, pass_reasons=None, fail_reasons=None, errors=None):
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (errors or []) else "success", "errors": errors or []},
+            "validation": {"status": "unknown", "errors": [], "warnings": []},
+            "transformation": {"status": "error" if (errors or []) else "success", "errors": errors or [], "inputSummary": {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": [], "additionalFindings": []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0",
+                         "transformationId": transform_id, "vendor": "AWS Security Hub", "category": "Cloud Security"},
+        },
+    }
+
+
+def control_status_map(findings, control_ids):
+    statuses = {}
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        comp = f.get("Compliance") or {}
+        cid = comp.get("SecurityControlId")
+        if cid not in control_ids:
+            continue
+        status = str(comp.get("Status") or "").upper()
+        if status in ("PASSED", "FAILED"):
+            prev = statuses.get(cid)
+            statuses[cid] = "FAILED" if (status == "FAILED" or prev == "FAILED") else "PASSED"
+    return statuses
+
+
+CRITERIA_KEY = "isIAMLoggingEnabled"
+CONTROL_IDS = ["CloudTrail.1"]
+TRANSFORM_ID = "isiamloggingenabled"
+
+
+def transform(input):
+    try:
+        findings = extract_findings(input)
+        statuses = control_status_map(findings, CONTROL_IDS)
+        if not statuses:
+            return build_response({CRITERIA_KEY: False}, TRANSFORM_ID,
+                                  fail_reasons=["No CloudTrail logging control findings"])
+        enabled = "FAILED" not in statuses.values()
+        return build_response({CRITERIA_KEY: enabled}, TRANSFORM_ID,
+                              pass_reasons=["CloudTrail logging enabled"] if enabled else [],
+                              fail_reasons=[] if enabled else ["CloudTrail logging control failing"])
+    except Exception as error:
+        return build_response({CRITERIA_KEY: False}, TRANSFORM_ID, errors=[str(error)])

--- a/safeguards/cloudsecurity/awssecurityhub/ismfaenforcedforusers.py
+++ b/safeguards/cloudsecurity/awssecurityhub/ismfaenforcedforusers.py
@@ -1,0 +1,87 @@
+"""
+Transformation: isMFAEnforcedForUsers
+Vendor: AWS Security Hub  |  Category: Cloud Security
+
+Evaluates AWS Security Hub control(s) IAM.5 from the getSecurityHubComplianceAWS
+findings. A control passes unless it has an active FAILED finding; the criterion passes
+only when every checked control that is present is passing. Fails closed if no active
+finding for these controls is returned.
+"""
+
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "isMFAEnforcedForUsers"
+CONTROL_IDS = ['IAM.5']
+TRANSFORM_ID = "ismfaenforcedforusers"
+
+
+def extract_findings(input_data):
+    data = input_data
+    if isinstance(data, str):
+        data = json.loads(data)
+    elif isinstance(data, bytes):
+        data = json.loads(data.decode("utf-8"))
+    if isinstance(data, dict) and "data" in data and "validation" in data:
+        data = data["data"]
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        nxt = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nxt = data[key]
+                break
+        if nxt is None:
+            break
+        data = nxt
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_response(result, pass_reasons=None, fail_reasons=None, errors=None):
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (errors or []) else "success", "errors": errors or []},
+            "validation": {"status": "unknown", "errors": [], "warnings": []},
+            "transformation": {"status": "error" if (errors or []) else "success", "errors": errors or [], "inputSummary": {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": [], "additionalFindings": []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0",
+                         "transformationId": TRANSFORM_ID, "vendor": "AWS Security Hub", "category": "Cloud Security"},
+        },
+    }
+
+
+def transform(input):
+    try:
+        findings = extract_findings(input)
+        statuses = []
+        failed_controls = []
+        for f in findings:
+            if not isinstance(f, dict):
+                continue
+            comp = f.get("Compliance") or {}
+            if comp.get("SecurityControlId") not in CONTROL_IDS:
+                continue
+            status = str(comp.get("Status") or "").upper()
+            if status in ("PASSED", "FAILED"):
+                statuses.append(status)
+                if status == "FAILED":
+                    cid = comp.get("SecurityControlId")
+                    if cid not in failed_controls:
+                        failed_controls.append(cid)
+        if not statuses:
+            return build_response({CRITERIA_KEY: False},
+                                  fail_reasons=["No active Security Hub findings for control(s): " + ", ".join(CONTROL_IDS)])
+        passed = "FAILED" not in statuses
+        if passed:
+            return build_response({CRITERIA_KEY: True},
+                                  pass_reasons=["All checked controls passing: " + ", ".join(CONTROL_IDS)])
+        return build_response({CRITERIA_KEY: False},
+                              fail_reasons=["Failing control(s): " + ", ".join(failed_controls)])
+    except Exception as error:
+        return build_response({CRITERIA_KEY: False}, errors=[str(error)])

--- a/safeguards/cloudsecurity/awssecurityhub/ispublicstoragebucketexposed.py
+++ b/safeguards/cloudsecurity/awssecurityhub/ispublicstoragebucketexposed.py
@@ -1,0 +1,76 @@
+import json
+from datetime import datetime
+
+
+def extract_findings(input_data):
+    data = input_data
+    if isinstance(data, str):
+        data = json.loads(data)
+    elif isinstance(data, bytes):
+        data = json.loads(data.decode("utf-8"))
+    if isinstance(data, dict) and "data" in data and "validation" in data:
+        data = data["data"]
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        nxt = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nxt = data[key]
+                break
+        if nxt is None:
+            break
+        data = nxt
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_response(result, transform_id, pass_reasons=None, fail_reasons=None, errors=None):
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (errors or []) else "success", "errors": errors or []},
+            "validation": {"status": "unknown", "errors": [], "warnings": []},
+            "transformation": {"status": "error" if (errors or []) else "success", "errors": errors or [], "inputSummary": {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": [], "additionalFindings": []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0",
+                         "transformationId": transform_id, "vendor": "AWS Security Hub", "category": "Cloud Security"},
+        },
+    }
+
+
+def control_status_map(findings, control_ids):
+    statuses = {}
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        comp = f.get("Compliance") or {}
+        cid = comp.get("SecurityControlId")
+        if cid not in control_ids:
+            continue
+        status = str(comp.get("Status") or "").upper()
+        if status in ("PASSED", "FAILED"):
+            prev = statuses.get(cid)
+            statuses[cid] = "FAILED" if (status == "FAILED" or prev == "FAILED") else "PASSED"
+    return statuses
+
+
+CRITERIA_KEY = "isPublicStorageBucketExposed"
+CONTROL_IDS = ["S3.1", "S3.2", "S3.3", "S3.8"]
+TRANSFORM_ID = "ispublicstoragebucketexposed"
+
+
+def transform(input):
+    try:
+        findings = extract_findings(input)
+        statuses = control_status_map(findings, CONTROL_IDS)
+        failed = [cid for cid, st in statuses.items() if st == "FAILED"]
+        exposed = len(failed) > 0
+        return build_response({CRITERIA_KEY: exposed}, TRANSFORM_ID,
+                              fail_reasons=["Public S3 exposure: " + ", ".join(failed)] if exposed else [],
+                              pass_reasons=[] if exposed else ["No public S3 bucket exposure detected"])
+    except Exception as error:
+        return build_response({CRITERIA_KEY: True}, TRANSFORM_ID, errors=[str(error)])

--- a/safeguards/cloudsecurity/awssecurityhub/unencryptedstorageresourcecount.py
+++ b/safeguards/cloudsecurity/awssecurityhub/unencryptedstorageresourcecount.py
@@ -1,0 +1,81 @@
+import json
+from datetime import datetime
+
+
+def extract_findings(input_data):
+    data = input_data
+    if isinstance(data, str):
+        data = json.loads(data)
+    elif isinstance(data, bytes):
+        data = json.loads(data.decode("utf-8"))
+    if isinstance(data, dict) and "data" in data and "validation" in data:
+        data = data["data"]
+    for _ in range(4):
+        if not isinstance(data, dict):
+            break
+        nxt = None
+        for key in ("api_response", "response", "result", "apiResponse", "Output"):
+            if isinstance(data.get(key), (dict, list)):
+                nxt = data[key]
+                break
+        if nxt is None:
+            break
+        data = nxt
+    if isinstance(data, dict) and "Findings" in data:
+        return data["Findings"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def build_response(result, transform_id, pass_reasons=None, fail_reasons=None, errors=None):
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": "error" if (errors or []) else "success", "errors": errors or []},
+            "validation": {"status": "unknown", "errors": [], "warnings": []},
+            "transformation": {"status": "error" if (errors or []) else "success", "errors": errors or [], "inputSummary": {}},
+            "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": [], "additionalFindings": []},
+            "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "1.0",
+                         "transformationId": transform_id, "vendor": "AWS Security Hub", "category": "Cloud Security"},
+        },
+    }
+
+
+def control_status_map(findings, control_ids):
+    statuses = {}
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        comp = f.get("Compliance") or {}
+        cid = comp.get("SecurityControlId")
+        if cid not in control_ids:
+            continue
+        status = str(comp.get("Status") or "").upper()
+        if status in ("PASSED", "FAILED"):
+            prev = statuses.get(cid)
+            statuses[cid] = "FAILED" if (status == "FAILED" or prev == "FAILED") else "PASSED"
+    return statuses
+
+
+CRITERIA_KEY = "unencryptedStorageResourceCount"
+CONTROL_IDS = ["EC2.7", "RDS.3", "EFS.1"]
+TRANSFORM_ID = "unencryptedstorageresourcecount"
+
+
+def transform(input):
+    try:
+        findings = extract_findings(input)
+        unencrypted = 0
+        for f in findings:
+            if not isinstance(f, dict):
+                continue
+            comp = f.get("Compliance") or {}
+            if comp.get("SecurityControlId") in CONTROL_IDS and str(comp.get("Status") or "").upper() == "FAILED":
+                unencrypted += 1
+        acceptable = unencrypted == 0
+        return build_response({CRITERIA_KEY: acceptable, "unencryptedResources": unencrypted}, TRANSFORM_ID,
+                              pass_reasons=["No unencrypted storage resources"] if acceptable else [],
+                              fail_reasons=[] if acceptable else [str(unencrypted) + " unencrypted storage resource findings"])
+    except Exception as error:
+        return build_response({CRITERIA_KEY: False, "unencryptedResources": -1}, TRANSFORM_ID, errors=[str(error)])


### PR DESCRIPTION
The AWS Cloud Security safeguard only evaluated one criterion. Adds the missing Security Hub transforms.

- Adds 7 transforms: compliancePercentage, isMFAEnforcedForUsers, isGuardDutyEnabled, isIAMLoggingEnabled, isPublicStorageBucketExposed, unencryptedStorageResourceCount, criticalOpenFindingsCount
- Fixes compliancePercentage to compute control-level (matches AWS) instead of finding-level
- All source from Security Hub findings (getSecurityHubComplianceAWS / CIS) — no new API scopes
- Validated against the live Spektrum Labs tenant via local_tester
- RestrictedPython-clean