### PR TITLE
feat: add Crowdstrike transformations (epp)

### DIFF
--- a/safeguards/epp/crowdstrike/requiredCoveragePercentage.py
+++ b/safeguards/epp/crowdstrike/requiredCoveragePercentage.py
@@ -1,0 +1,144 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    resources = data.get("resources") or []
+    if not isinstance(resources, list):
+        resources = []
+
+    meta = data.get("meta") or {}
+    if not isinstance(meta, dict):
+        meta = {}
+    pagination = meta.get("pagination") or {}
+    if not isinstance(pagination, dict):
+        pagination = {}
+
+    total = pagination.get("total")
+    if not isinstance(total, (int, float)):
+        total = len(resources)
+
+    resource_count = len(resources)
+
+    transformation_errors = []
+    if total and total > 0:
+        coverage = (float(resource_count) / float(total)) * 100.0
+        if coverage > 100.0:
+            coverage = 100.0
+    else:
+        coverage = 0.0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if total and total > 0:
+        pass_reasons.append(
+            f"queryDevicesScroll reports {resource_count} device IDs enrolled with the CrowdStrike Falcon "
+            f"sensor (EDR/XDR agent) out of meta.pagination.total={int(total)} devices tracked in this "
+            f"endpoint inventory, yielding a coverage of {coverage:.1f}%."
+        )
+    else:
+        fail_reasons.append(
+            "queryDevicesScroll returned meta.pagination.total=0 (or missing), indicating no devices are "
+            "enrolled with a Falcon sensor in this tenant, so EDR/XDR coverage cannot be confirmed."
+        )
+        recommendations.append(
+            "Deploy the CrowdStrike Falcon sensor to endpoints and re-run device enumeration; no devices "
+            "were found in the devices-scroll inventory."
+        )
+
+    if coverage < 100.0 and total and total > 0:
+        recommendations.append(
+            f"Only {resource_count} of {int(total)} tracked devices were returned in this scroll page; "
+            "verify pagination is followed to completion so the full fleet's Falcon sensor coverage is captured."
+        )
+
+    result = {
+        "requiredCoveragePercentage": coverage,
+        "enrolledDeviceCount": resource_count,
+        "totalDeviceCount": int(total) if total else 0,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"resourceCount": resource_count, "total": total},
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "Crowdstrike",
+            "category": "epp",
+        },
+        transformation_errors=transformation_errors,
+    )

--- a/safeguards/epp/crowdstrike/schemas/__init__.py
+++ b/safeguards/epp/crowdstrike/schemas/__init__.py
@@ -1,7 +1,11 @@
-"""Pydantic schemas for transformation inputs."""
+"""Schema registry for this vendor's transformations."""
 
 from .epp_transform import EppTransformInput
 
+__all__
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
 __all__ = [
     "EppTransformInput",
+    "RequiredCoveragePercentageInput",
 ]

--- a/safeguards/epp/crowdstrike/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/crowdstrike/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation."""
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary

This PR ships one transformation script for the CrowdStrike EPP integration: `requiredCoveragePercentage.py`. It covers EDR/XDR sensor deployment coverage, the primary safeguard question for an EPP vendor ("what fraction of the known device fleet has the Falcon sensor enrolled and reporting"). CrowdStrike is being onboarded as a new EPP vendor, and this script is the first (and currently only) criterion shipped as part of that onboarding.

**Context:** This transformation was generated by the Spektrum V2 onboarding pipeline for CrowdStrike EPP; a second target criterion (`isEDREnabled`) was dropped at phase-1 profiling because its only candidate endpoint probed dead on the live tenant, so it is intentionally absent from this PR (see Architecture notes).

## What each transformation does

### `requiredCoveragePercentage.py`
Evaluates what percentage of the customer's total tracked device fleet has the CrowdStrike Falcon sensor (EDR/XDR agent) enrolled, using the device inventory returned by the devices-scroll endpoint.

- **Consumes:** CrowdStrike Hosts API `GET {$baseURL}/devices/queries/devices-scroll/v1` (`queryDevicesScroll` method) -- reads `resources` (list of enrolled device IDs) and `meta.pagination.total` (total device count known to the tenant).
- **Pass criteria:** Not a strict boolean pass/fail -- the script always returns a numeric `requiredCoveragePercentage` computed as `len(resources) / meta.pagination.total * 100`, capped at 100%. It populates `passReasons` when `total > 0` (coverage computed and reported) and `failReasons` when `total` is zero or missing (treated as "no devices enrolled, coverage cannot be confirmed"), so the pass/fail signal is effectively `total > 0`.
- **Key edge cases handled:**
  - Missing/non-numeric `meta.pagination.total` falls back to `len(resources)` as the total, avoiding a divide-by-zero and defaulting coverage to 0.0% when both are absent (i.e., `total <= 0`).
  - Non-list `resources` or non-dict `meta`/`pagination` are coerced to safe empty defaults (`[]`/`{}`) rather than raising.
  - Coverage is explicitly clamped to a 100.0% ceiling in case `resources` momentarily outnumbers `total` (e.g., a race between pagination and the total counter).
  - When `total > 0` but the returned `resources` count is less than `total` (i.e., only a single scroll page was captured), a recommendation is emitted flagging that pagination should be followed to completion -- this is important because the shipped `queryDevicesScroll` config method does implement multi-page cursor pagination (`stopWhen: empty` on `resources`, keyed off `meta.pagination.offset`), so in production this warning should rarely fire, but it guards against a transformation being run against a single unpaginated snapshot.
  - Legacy/enriched input formats are both handled via `extract_input`, and unknown/legacy inputs get a `"Legacy input format"` warning rather than failing outright.
  - Live validation against the actual customer tenant returned HTTP 200 on `{$baseURL}/devices/queries/devices-scroll/v1` and the script ran cleanly end-to-end on real data (criterion status: produced, `queryDevicesScroll` picked on first iteration).

## Architecture notes

All scripts follow the standard three-stage contract: `extract_input` (unwraps enriched/legacy payloads and returns `(data, validation)`), `transform`/`evaluate` (the vendor-specific logic), and `create_response` (assembles the standardized `additionalInfo` envelope with `dataCollection`, `validation`, `transformation`, and `evaluation` sub-sections containing `passReasons`/`failReasons`/`recommendations`/`additionalFindings`). This script uses `schemaVersion: 2.0` in its metadata rather than 1.0 -- worth confirming this is the intended current schema version for new EPP transformations rather than a copy-paste inconsistency. No RestrictedPython-incompatible constructs (no imports beyond `json`/`datetime`, no file/network I/O) were observed.

Note on scope: `isEDREnabled` was identified as a target criterion for this vendor but was dropped during phase-1 profiling -- the only candidate method (`getDeviceDetails`, `{$baseURL}/devices/entities/devices/v2`) probed dead (4xx, non-auth) on the live tenant with no working alternative found, so no transformation script for it is included in this PR. This is an intentional coverage gap, not an oversight, and should be tracked as a follow-up onboarding item once a viable endpoint is identified.

## Test plan

- [ ] Verify `evaluate()`/`transform()` returns correct result for: valid data with `resources` + `meta.pagination.total` populated, missing/empty `resources`, missing `meta.pagination.total`, and non-dict/malformed `meta`/`pagination` shapes
- [ ] Confirm `resources` and `meta.pagination.total` field names match the current CrowdStrike devices-scroll response schema (confirmed against vendor documentation during this review)
- [ ] Spot-check `create_response()` output shape -- confirm whether `schemaVersion: 2.0` is intentional for this vendor/category vs. the 1.0 baseline used elsewhere
- [ ] Confirm the 100%-coverage clamp and the "partial page returned" recommendation do not misfire against a fully-paginated multi-page `queryDevicesScroll` response in a large tenant
- [ ] Track `isEDREnabled` as a follow-up onboarding task once a live endpoint is identified

🤖 Generated by Spektrum integration onboarding pipeline