### PR TITLE
feat: add Check Point Software Technologies Email Security transformations (emailsecurity)

### DIFF
--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isAntiPhishingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isAntiPhishingEnabled.py
@@ -1,0 +1,141 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    transformation_errors = []
+
+    # Detect vendor-level error envelope (auth failure, etc.)
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("status") == "Error":
+        err_msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"queryEvents returned an error: {err_msg}")
+        return create_response(
+            result={"isAntiPhishingEnabled": False},
+            validation=validation,
+            fail_reasons=[
+                f"queryEvents API call failed ({err_msg}); unable to confirm anti-phishing detection activity."
+            ],
+            recommendations=[
+                "Verify Check Point HEC API credentials (clientId/clientSecret) are valid and re-run the scan to obtain event data."
+            ],
+            input_summary={"error": True, "errorMessage": err_msg},
+            api_errors=api_errors,
+            metadata={"transformationId": "isAntiPhishingEnabled", "vendor": "Check Point Software Technologies Email Security", "category": "emailsecurity"},
+        )
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    phishing_events = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        event_types = ev.get("eventTypes") or []
+        if not isinstance(event_types, list):
+            event_types = [event_types]
+        for et in event_types:
+            if isinstance(et, str) and "phish" in et.lower():
+                phishing_events.append(ev)
+                break
+
+    total_events = len(events)
+    phishing_count = len(phishing_events)
+    is_enabled = phishing_count > 0
+
+    input_summary = {"totalEvents": total_events, "phishingEvents": phishing_count}
+
+    if is_enabled:
+        sample_ids = [e.get("eventId") for e in phishing_events[:3] if isinstance(e, dict)]
+        pass_reasons = [
+            f"Found {phishing_count} of {total_events} queried security events with an eventTypes entry containing 'Phishing' (sample eventIds: {sample_ids}), indicating the anti-phishing detection engine is actively scanning and flagging mail."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"No phishing-category detections found among {total_events} queried security events (eventTypes field); cannot confirm the anti-phishing engine is actively scanning mail."
+        ]
+        recommendations = [
+            "Confirm the Harmony Email and Collaboration anti-phishing policy/engine is enabled for this tenant and widen the event query lookback window to capture detections."
+        ]
+
+    return create_response(
+        result={"isAntiPhishingEnabled": is_enabled},
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        transformation_errors=transformation_errors,
+        api_errors=api_errors,
+        metadata={"transformationId": "isAntiPhishingEnabled", "vendor": "Check Point Software Technologies Email Security", "category": "emailsecurity"},
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isEmailSecurityLoggingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isEmailSecurityLoggingEnabled.py
@@ -1,0 +1,147 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    is_error = bool(data.get("error")) or data.get("status") == "Error" or data.get("statusCode") == 401
+
+    if is_error:
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "Unknown error from queryEvents"))
+        is_logging_enabled = False
+        fail_reasons.append(
+            "queryEvents returned an error (errorType=%s, statusCode=%s, message=%s); unable to confirm email security event logging is active."
+            % (str(data.get("errorType")), str(data.get("statusCode")), str(data.get("errorMessage") or data.get("message")))
+        )
+        recommendations.append(
+            "Verify the clientId/clientSecret credentials configured for the Check Point Harmony Email Security integration and re-authenticate so that /event/query can retrieve security event telemetry."
+        )
+        input_summary = {"error": True, "statusCode": data.get("statusCode")}
+
+        return create_response(
+            result={"isEmailSecurityLoggingEnabled": is_logging_enabled},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_summary,
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isEmailSecurityLoggingEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "emailsecurity",
+            },
+        )
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+    total_events = len(events)
+
+    fields_present = 0
+    for ev in events:
+        if isinstance(ev, dict) and ev.get("eventId") and ev.get("eventTypes"):
+            fields_present = fields_present + 1
+
+    is_logging_enabled = total_events > 0
+
+    if is_logging_enabled:
+        pass_reasons.append(
+            "queryEvents (/event/query) returned %d security event record(s), of which %d carry populated eventId/eventTypes fields, indicating the email security event logging pipeline is actively capturing threat detections, actions taken, and policy violations."
+            % (total_events, fields_present)
+        )
+    else:
+        fail_reasons.append(
+            "queryEvents (/event/query) returned zero records in responseData for the queried window, so no evidence of active email security event logging (threats detected, actions taken, policy violations) could be confirmed."
+        )
+        recommendations.append(
+            "Confirm the Harmony Email and Collaboration event logging pipeline is enabled and that the queried time window/filters actually include recent mail traffic; re-run /event/query with a broader lookback."
+        )
+
+    input_summary = {"totalEvents": total_events, "eventsWithCoreFields": fields_present}
+
+    return create_response(
+        result={"isEmailSecurityLoggingEnabled": is_logging_enabled, "totalEvents": total_events},
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isEmailSecurityLoggingEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isSafeAttachmentsEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isSafeAttachmentsEnabled.py
@@ -1,0 +1,183 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+ATTACHMENT_KEYWORDS = ["attachment", "malware", "sandbox", "detonation", "malicious file"]
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("errorType") == "authentication" or data.get("statusCode") == 401:
+        api_errors.append(
+            "queryEvents returned an authentication/error response: %s"
+            % data.get("errorMessage", data.get("message", "unknown error"))
+        )
+        result = {
+            "isSafeAttachmentsEnabled": False,
+            "eventsInspected": 0,
+            "attachmentDetections": 0,
+        }
+        return create_response(
+            result=result,
+            validation=validation,
+            fail_reasons=[
+                "queryEvents API call failed with error: %s. Unable to confirm Safe Attachments detonation activity."
+                % data.get("errorMessage", data.get("message", "unknown error"))
+            ],
+            recommendations=[
+                "Verify clientId/clientSecret credentials and re-run the /event/query scan to confirm Safe Attachments detection activity."
+            ],
+            input_summary={"eventsInspected": 0, "attachmentDetections": 0},
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isSafeAttachmentsEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "emailsecurity",
+            },
+        )
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    attachment_detections = 0
+    sample_event_ids = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        event_types = ev.get("eventTypes") or []
+        if not isinstance(event_types, list):
+            event_types = [event_types]
+        attachments = ev.get("attachments") or []
+        has_attachment_type = False
+        for et in event_types:
+            et_str = str(et).lower()
+            for kw in ATTACHMENT_KEYWORDS:
+                if kw in et_str:
+                    has_attachment_type = True
+                    break
+            if has_attachment_type:
+                break
+        if has_attachment_type and isinstance(attachments, list) and len(attachments) > 0:
+            attachment_detections = attachment_detections + 1
+            if len(sample_event_ids) < 3:
+                sample_event_ids.append(ev.get("eventId"))
+
+    total_events = len(events)
+    enabled = attachment_detections > 0
+
+    input_summary = {
+        "eventsInspected": total_events,
+        "attachmentDetections": attachment_detections,
+    }
+
+    result = {
+        "isSafeAttachmentsEnabled": enabled,
+        "eventsInspected": total_events,
+        "attachmentDetections": attachment_detections,
+    }
+
+    if enabled:
+        pass_reasons = [
+            "Found %d of %d queried security events with attachment-related eventTypes (e.g. malware/sandbox/detonation keywords) and non-empty attachments arrays; sample eventIds: %s. This indicates the attachment-sandboxing/detonation engine is actively scanning and flagging malicious attachments."
+            % (attachment_detections, total_events, sample_event_ids)
+        ]
+        return create_response(
+            result=result,
+            validation=validation,
+            pass_reasons=pass_reasons,
+            input_summary=input_summary,
+            metadata={
+                "transformationId": "isSafeAttachmentsEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "emailsecurity",
+            },
+        )
+    else:
+        fail_reasons = [
+            "Queried %d security events from /event/query and found 0 events with attachment-related eventTypes and populated attachments arrays. No evidence of active Safe Attachments detonation/blocking activity in this response window."
+            % total_events
+        ]
+        recommendations = [
+            "Confirm Safe Attachments / attachment-sandboxing policy is enabled in the Harmony Email & Collaboration console, and re-query /event/query over a longer lookback window to capture detonation events."
+        ]
+        return create_response(
+            result=result,
+            validation=validation,
+            fail_reasons=fail_reasons,
+            recommendations=recommendations,
+            input_summary=input_summary,
+            metadata={
+                "transformationId": "isSafeAttachmentsEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "emailsecurity",
+            },
+        )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isSafeLinksEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isSafeLinksEnabled.py
@@ -1,0 +1,149 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 401:
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+        return create_response(
+            result={"isSafeLinksEnabled": False},
+            validation=validation,
+            fail_reasons=["queryEvents call returned an authentication/API error: %s" % (data.get("errorMessage") or data.get("message") or "unknown error")],
+            recommendations=["Verify clientId/clientSecret credentials and re-authenticate to the Harmony Email and Collaboration API so event telemetry can be retrieved."],
+            input_summary={"error": True, "statusCode": data.get("statusCode")},
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isSafeLinksEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "emailsecurity",
+            },
+        )
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    link_event_count = 0
+    total_events = len(events)
+    sample_event_ids = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        event_types = ev.get("eventTypes") or []
+        links = ev.get("links") or []
+        is_link_related = False
+        for et in event_types:
+            if isinstance(et, str) and ("link" in et.lower() or "url" in et.lower() or "phish" in et.lower()):
+                is_link_related = True
+                break
+        if not is_link_related and links:
+            is_link_related = True
+        if is_link_related:
+            link_event_count = link_event_count + 1
+            if len(sample_event_ids) < 5:
+                sample_event_ids.append(ev.get("eventId"))
+
+    is_enabled = link_event_count > 0
+
+    input_summary = {
+        "totalEvents": total_events,
+        "linkRelatedEventCount": link_event_count,
+    }
+
+    if is_enabled:
+        pass_reasons = [
+            "Found %d of %d queried security events with link-related eventTypes or populated links fields (sample eventIds: %s), indicating the Safe Links / URL scanning engine is actively detecting and acting on malicious links." % (link_event_count, total_events, sample_event_ids)
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            "No link-related detections found among %d queried security events (no eventTypes containing 'link'/'url'/'phish' and no populated links arrays), so no evidence the Safe Links / URL scanning engine is enabled or generating detections." % total_events
+        ]
+        recommendations = [
+            "Confirm Safe Links / URL protection is enabled in the Harmony Email and Collaboration policy configuration and widen the event query lookback window to capture link-based detections."
+        ]
+
+    return create_response(
+        result={"isSafeLinksEnabled": is_enabled},
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isSafeLinksEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/__init__.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/__init__.py
@@ -1,0 +1,13 @@
+"""Schema registry for this vendor's transformations."""
+
+from .isAntiPhishingEnabled import IsAntiPhishingEnabledInput
+from .isEmailSecurityLoggingEnabled import IsEmailSecurityLoggingEnabledInput
+from .isSafeAttachmentsEnabled import IsSafeAttachmentsEnabledInput
+from .isSafeLinksEnabled import IsSafeLinksEnabledInput
+
+__all__ = [
+    "IsAntiPhishingEnabledInput",
+    "IsEmailSecurityLoggingEnabledInput",
+    "IsSafeAttachmentsEnabledInput",
+    "IsSafeLinksEnabledInput",
+]

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAntiPhishingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAntiPhishingEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsAntiPhishingEnabledInput(BaseModel):
+    """Input schema for the isAntiPhishingEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isEmailSecurityLoggingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isEmailSecurityLoggingEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEmailSecurityLoggingEnabledInput(BaseModel):
+    """Input schema for the isEmailSecurityLoggingEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSafeAttachmentsEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSafeAttachmentsEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsSafeAttachmentsEnabledInput(BaseModel):
+    """Input schema for the isSafeAttachmentsEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSafeLinksEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSafeLinksEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsSafeLinksEnabledInput(BaseModel):
+    """Input schema for the isSafeLinksEnabled transformation."""
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary

This PR adds 4 transformation scripts for Check Point Software Technologies Email Security (Harmony Email & Collaboration / HEC / Avanan), an emailsecurity-category vendor. All 4 scripts consume the same `queryEvents` (`POST /event/query`) response and evaluate different indirect signals of email-security engine activity — anti-phishing, general event logging, safe attachments (malicious attachment sandboxing), and safe links (malicious URL scanning) — since HEC's API exposes no direct "engine enabled" boolean for any of these controls.

**Context:** This onboarding fills the emailsecurity gap for Check Point HEC customers; 4 of 12 target criteria were routable through the vendor's event-query API, while 8 (license, auto-forward, DKIM/DMARC/SPF, legacy auth, mailbox auditing, SMTP auth) were correctly flagged unroutable at phase 1 as they belong to the underlying mail platform (M365/Google Workspace) or DNS, not HEC.

## What each transformation does

### `isAntiPhishingEnabled.py`
Detects whether the anti-phishing detection engine is actively scanning and flagging mail.

- **Consumes:** Check Point HEC `queryEvents` — `POST {$serverUrl}/event/query`, reads `responseData` (array of security events).
- **Pass criteria:** `True` if at least one queried event has an `eventTypes` entry (string, case-insensitive) containing `"phish"`.
- **Key edge cases handled:**
  - Vendor error envelope (`error is True`, `statusCode == 401`, or `status == "Error"`) short-circuits to `False` with an explicit fail reason and a credential-check recommendation, without treating a zero-event auth failure as a legitimate "not enabled" result.
  - `responseData` missing or non-list defaults to an empty list rather than raising.
  - `eventTypes` normalized to a list even if the vendor returns a bare string.
  - Live-validated against the tenant: HTTP 200 on `/event/query`.

### `isEmailSecurityLoggingEnabled.py`
Confirms the email security event logging pipeline is actively capturing threat/action/policy-violation telemetry.

- **Consumes:** Check Point HEC `queryEvents` — `POST {$serverUrl}/event/query`, reads `responseData`.
- **Pass criteria:** `True` if `len(responseData) > 0` (any events returned in the queried window).
- **Key edge cases handled:**
  - API error (`error`, `status == "Error"`, `statusCode == 401`) returns `False` with the vendor's `errorType`/`statusCode`/`message` echoed into the fail reason for debuggability, plus a credential-verification recommendation.
  - Empty `responseData` (zero events) is treated as a fail, with a recommendation to widen the lookback window rather than assuming logging is broken.
  - **Finding:** the script computes `fields_present` (count of events with populated `eventId`/`eventTypes`) and reports it in `inputSummary`/`result`, but does **not** gate the pass/fail decision on it — any non-empty `responseData`, even with malformed/incomplete event records, passes. This is a looser bar than the description implies ("populated threat/action/policy-violation records"); reviewers should confirm this is intentional.

### `isSafeAttachmentsEnabled.py`
Detects whether the attachment-sandboxing/detonation engine is actively catching malicious attachments.

- **Consumes:** Check Point HEC `queryEvents` — `POST {$serverUrl}/event/query`, reads `responseData`, and per-event `eventTypes`/`attachments` fields.
- **Pass criteria:** `True` if at least one event has an `eventTypes` value matching one of the keywords `attachment`, `malware`, `sandbox`, `detonation`, `malicious file` (case-insensitive substring match) AND a non-empty `attachments` array on that same event.
- **Key edge cases handled:**
  - Auth/error response (`error is True`, `errorType == "authentication"`, `statusCode == 401`) returns `False` with `eventsInspected: 0` and a credential-verification recommendation.
  - Requires both the keyword match and a populated `attachments` list — an event merely mentioning malware in its type without an attachments array does not count, reducing false positives.
  - Non-dict events and missing `attachments`/`eventTypes` default safely to empty structures.

### `isSafeLinksEnabled.py`
Detects whether Safe Links / URL scanning is actively generating detections.

- **Consumes:** Check Point HEC `queryEvents` — `POST {$serverUrl}/event/query`, reads `responseData`, and per-event `eventTypes`/`links` fields.
- **Pass criteria:** `True` if at least one event has an `eventTypes` value containing `link`, `url`, or `phish` (case-insensitive), OR — if no such eventType match — the event has a non-empty `links` field.
- **Key edge cases handled:**
  - Auth/error response (`error is True` or `statusCode == 401`) returns `False` with a credential-recheck recommendation.
  - Falls back to the `links` field presence when `eventTypes` doesn't carry a link-specific label, widening detection coverage for vendor schema variance.
  - **Finding:** the `"phish"` keyword is shared with `isAntiPhishingEnabled.py`'s matching logic, so a single phishing event can independently satisfy both criteria. This is reasonable (phishing often involves malicious links) but reviewers should be aware the two criteria are not fully independent signals.

## Architecture notes

All 4 scripts share an identical `extract_input -> transform -> create_response` contract: `extract_input` unwraps legacy/enriched envelopes and attaches a validation block; `transform` runs the pass/fail logic and calls `create_response`, which returns the standard `transformedResponse` + `additionalInfo` (dataCollection, validation, transformation, evaluation with passReasons/failReasons/recommendations/additionalFindings, metadata) shape. **Finding:** metadata declares `schemaVersion: "2.0"` in all 4 scripts — confirm this matches the platform's currently expected schema version before merge, since the standard test-plan checklist references version 1.0.

## Test plan

- [ ] Confirm `schemaVersion: "2.0"` in `create_response()` metadata is the intended/current schema version for this pipeline.
- [ ] Verify `isEmailSecurityLoggingEnabled` pass condition (any non-empty `responseData`) is the intended bar vs. gating on the unused `fields_present` (populated `eventId`/`eventTypes`) count.
- [ ] Confirm field names `eventTypes`, `attachments`, `links`, `eventId` in `data.get(...)` calls align with the current HEC `/event/query` response schema (per the vendor's Event-query reference, responses are structured as `responseEnvelope` + `responseData` array of events).
- [ ] Spot-check behavior when `responseData` contains events with `eventTypes` as a bare string rather than a list, across all 4 scripts.
- [ ] Live-validation evidence: all 4 criteria (`isAntiPhishingEnabled`, `isEmailSecurityLoggingEnabled`, `isSafeAttachmentsEnabled`, `isSafeLinksEnabled`) passed against the real tenant with HTTP 200 on `/event/query` and no runtime errors.

🤖 Generated by Spektrum integration onboarding pipeline
