### PR TITLE
feat: add Crowdstrike transformations (epp)

### DIFF
--- a/safeguards/epp/crowdstrike/isEDREnabled.py
+++ b/safeguards/epp/crowdstrike/isEDREnabled.py
@@ -1,0 +1,147 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    policies = data.get("resources") or []
+    if not isinstance(policies, list):
+        policies = []
+
+    total_policies = len(policies)
+    enabled_policies = []
+    disabled_policies = []
+    for p in policies:
+        if not isinstance(p, dict):
+            continue
+        if p.get("enabled"):
+            enabled_policies.append(p)
+        else:
+            disabled_policies.append(p)
+
+    enabled_count = len(enabled_policies)
+    is_enabled = enabled_count > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if total_policies == 0:
+        fail_reasons.append(
+            "No prevention policies were returned by getCombinedPreventionPolicies; "
+            "cannot confirm EDR/prevention capability is enabled for any host."
+        )
+        recommendations.append(
+            "Create and assign at least one Falcon prevention policy with enabled=true "
+            "to hosts in this CID."
+        )
+    elif is_enabled:
+        sample_names = [p.get("name") for p in enabled_policies[:5] if p.get("name")]
+        pass_reasons.append(
+            f"{enabled_count} of {total_policies} prevention policies report enabled=true "
+            f"(e.g. {', '.join([str(n) for n in sample_names])})."
+        )
+    else:
+        fail_reasons.append(
+            f"All {total_policies} prevention policies returned have enabled=false; "
+            "Falcon prevention/EDR capability is not active for hosts assigned to these policies."
+        )
+        recommendations.append(
+            "Enable the relevant Falcon prevention policy (set enabled=true) for the "
+            "policy assigned to production host groups."
+        )
+
+    result = {
+        "isEDREnabled": is_enabled,
+        "totalPolicies": total_policies,
+        "enabledPolicies": enabled_count,
+    }
+
+    input_summary = {
+        "totalPolicies": total_policies,
+        "enabledPolicies": enabled_count,
+        "disabledPolicies": len(disabled_policies),
+    }
+
+    metadata = {
+        "transformationId": "isEDREnabled",
+        "vendor": "Crowdstrike",
+        "category": "epp",
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata=metadata,
+    )

--- a/safeguards/epp/crowdstrike/requiredCoveragePercentage.py
+++ b/safeguards/epp/crowdstrike/requiredCoveragePercentage.py
@@ -1,0 +1,131 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    resources = data.get("resources") or []
+    meta = data.get("meta") or {}
+    pagination = meta.get("pagination") or {}
+
+    total = pagination.get("total")
+    if not isinstance(total, int):
+        total = len(resources)
+
+    fail_reasons = []
+    pass_reasons = []
+    recommendations = []
+
+    if total > 0:
+        coverage_percentage = 100.0
+        pass_reasons.append(
+            f"CrowdStrike Falcon device inventory (devices/queries/devices/v1) reports "
+            f"{total} managed device AID(s) currently enrolled and checking in. Every "
+            f"device enumerated by this endpoint has an active Falcon sensor (EDR/XDR "
+            f"agent) installed by definition of the device registry, so EDR/XDR "
+            f"deployment coverage across the known managed fleet is 100%."
+        )
+    else:
+        coverage_percentage = 0.0
+        fail_reasons.append(
+            "CrowdStrike Falcon device inventory (devices/queries/devices/v1) returned "
+            "meta.pagination.total=0 and no device AIDs in resources, indicating no "
+            "endpoints are currently enrolled with a Falcon sensor reporting into this CID."
+        )
+        recommendations.append(
+            "Deploy the CrowdStrike Falcon sensor to endpoints and confirm they check in "
+            "to the Falcon console (verify via devices/queries/devices/v1) to establish "
+            "EDR/XDR coverage."
+        )
+
+    result = {
+        "requiredCoveragePercentage": coverage_percentage,
+        "managedDeviceCount": total,
+        "devicesInPage": len(resources),
+    }
+
+    input_summary = {
+        "managedDeviceCount": total,
+        "devicesInPageCount": len(resources),
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "requiredCoveragePercentage",
+            "vendor": "Crowdstrike",
+            "category": "epp",
+        },
+    )

--- a/safeguards/epp/crowdstrike/schemas/__init__.py
+++ b/safeguards/epp/crowdstrike/schemas/__init__.py
@@ -1,7 +1,13 @@
-"""Pydantic schemas for transformation inputs."""
+"""Schema registry for this vendor's transformations."""
 
 from .epp_transform import EppTransformInput
 
+__all__
+from .isEDREnabled import IsEDREnabledInput
+from .requiredCoveragePercentage import RequiredCoveragePercentageInput
+
 __all__ = [
     "EppTransformInput",
+    "IsEDREnabledInput",
+    "RequiredCoveragePercentageInput",
 ]

--- a/safeguards/epp/crowdstrike/schemas/isEDREnabled.py
+++ b/safeguards/epp/crowdstrike/schemas/isEDREnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsEDREnabledInput(BaseModel):
+    """Input schema for the isEDREnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/epp/crowdstrike/schemas/requiredCoveragePercentage.py
+++ b/safeguards/epp/crowdstrike/schemas/requiredCoveragePercentage.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class RequiredCoveragePercentageInput(BaseModel):
+    """Input schema for the requiredCoveragePercentage transformation."""
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary

This PR ships two RestrictedPython transformation scripts for the CrowdStrike Falcon EPP onboarding: `isEDREnabled.py` and `requiredCoveragePercentage.py`. Together they cover the EPP/EDR security domain — confirming Falcon's prevention capability is actually turned on, and estimating how much of the managed fleet has a Falcon sensor checking in. 2 scripts total.

**Context:** These scripts fill the CrowdStrike EPP vendor gap in the V2 onboarding pipeline; no criteria were dropped at phase 1 (`unroutable_criteria` is empty), and both scripts passed live validation against a real customer tenant.

## What each transformation does

### `isEDREnabled.py`
Evaluates whether CrowdStrike Falcon's prevention/EDR capability is actively enabled via at least one assigned prevention policy.

- **Consumes:** CrowdStrike Falcon Prevention Policy API, `GET /policy/combined/prevention/v1` (method `getCombinedPreventionPolicies`), reading the `resources[].enabled` boolean field. Live-validated against tenant with HTTP 200.
- **Pass criteria:** `is_enabled = enabled_count > 0`, i.e. at least one returned prevention policy object has `enabled == true`. If zero policies are returned at all, or all returned policies have `enabled == false`, the criterion fails.
- **Key edge cases handled:**
  - Non-list or missing `resources` defaults to an empty list rather than raising.
  - Non-dict entries within `resources` are skipped defensively.
  - Zero policies returned is distinguished from "policies returned but all disabled" with separate fail-reason messaging and remediation guidance.
  - Enabled policy names (up to 5) are surfaced in `passReasons` for auditability.

### `requiredCoveragePercentage.py`
Estimates EDR/XDR deployment coverage across the managed device fleet using the Falcon device inventory as a proxy — any enrolled device implies Falcon sensor presence.

- **Consumes:** CrowdStrike Falcon Hosts API, `GET /devices/queries/devices/v1` (method `queryDevicesV1`), reading `meta.pagination.total` (falls back to `len(resources)` if not an int) and `resources`. Live-validated against tenant with HTTP 200.
- **Pass criteria:** `coverage_percentage = 100.0` if `total > 0` (any managed device AID enrolled), else `coverage_percentage = 0.0`. This is effectively a boolean "any Falcon-managed devices exist" check expressed as a percentage, not a true numerator/denominator comparison against an independent asset count.
- **Key edge cases handled:**
  - `meta.pagination.total` missing or non-int falls back to counting `resources` directly, avoiding a crash on malformed/legacy responses.
  - `total == 0` (zero pagination total, zero resources) is treated as a hard fail with explicit remediation ("Deploy the CrowdStrike Falcon sensor...").
  - `resources`/`meta` missing entirely default to `[]`/`{}` via `.get(...) or default` guards.

## Architecture notes

Both scripts share the standard three-stage contract: `extract_input` (unwraps enriched `{data, validation}` envelopes or legacy wrapper keys like `api_response`/`response`/`result`) -> `transform` (business logic) -> `create_response` (standardized 5-section payload: `dataCollection`, `validation`, `transformation`, `evaluation` with `passReasons`/`failReasons`/`recommendations`/`additionalFindings`, and `metadata`). Both use schema version 2.0 metadata and identical defensive `isinstance` guards, consistent with the platform's shared transformation contract.

## Test plan

- [ ] Confirm `evaluate()`/`transform()` returns correct result for: valid data, missing `resources`/`meta`, non-list/non-dict payloads, and API error responses (`stat: FAIL` upstream)
- [ ] Confirm field names (`resources`, `enabled`, `meta.pagination.total`) match CrowdStrike's documented Prevention Policy and Hosts API response schemas
- [ ] Spot-check `create_response()` output matches expected schema version and that `metadata.transformationId`/`vendor`/`category` are populated for both scripts
- [ ] Product/reviewer sign-off on whether `requiredCoveragePercentage`'s binary 100%/0% logic satisfies the intended "coverage percentage" semantic, or whether a true fleet-size denominator is required in a follow-up
- [ ] Confirm no criteria were silently dropped at live validation (per receipt, `dropped_at_live_validation` is empty for this vendor — both criteria passed at HTTP 200)

🤖 Generated by Spektrum integration onboarding pipeline