### PR TITLE
feat: add Check Point Software Technologies Email Security transformations (emailsecurity)

### DIFF
--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isAccountTakeoverDetectionEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isAccountTakeoverDetectionEnabled.py
@@ -1,0 +1,155 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("status") == "Error":
+        err_msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"queryEvents API call failed: {err_msg}")
+
+    response_data = data.get("responseData") or []
+    if not isinstance(response_data, list):
+        response_data = []
+
+    response_envelope = data.get("responseEnvelope") or {}
+    total_records = response_envelope.get("totalRecordsNumber") if isinstance(response_envelope, dict) else None
+
+    ato_related_types = ["anomaly", "account takeover", "login anomaly", "impossible travel", "suspicious login"]
+
+    ato_events = []
+    for event in response_data:
+        if not isinstance(event, dict):
+            continue
+        event_type = str(event.get("type") or "").lower()
+        description = str(event.get("description") or "").lower()
+        if any(t in event_type for t in ato_related_types) or "account takeover" in description or "anomaly" in description:
+            ato_events.append(event)
+
+    is_enabled = len(ato_events) > 0
+
+    input_summary = {
+        "totalEventsReturned": len(response_data),
+        "totalRecordsInEnvelope": total_records,
+        "atoRelatedEventsFound": len(ato_events),
+    }
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if api_errors:
+        fail_reasons.append(
+            "Unable to confirm account takeover detection: the queryEvents API call returned an authentication "
+            "error and no event data could be evaluated."
+        )
+        recommendations.append(
+            "Verify the Check Point Harmony Email and Collaboration API credentials (clientId/clientSecret) "
+            "and re-run the query against /event/query filtering for anomaly-type events."
+        )
+    elif is_enabled:
+        sample_types = list({str(e.get("type")) for e in ato_events[:5]})
+        pass_reasons.append(
+            f"Found {len(ato_events)} event(s) with anomaly/account-takeover characteristics out of "
+            f"{len(response_data)} events returned by queryEvents (sample types: {sample_types}). "
+            "This evidences the account takeover / anomaly detection engine is active and generating detections."
+        )
+    else:
+        fail_reasons.append(
+            f"queryEvents returned {len(response_data)} events, none of which matched anomaly/account-takeover "
+            "type or description markers (e.g. 'Anomaly', 'account takeover', 'impossible travel'). No evidence "
+            "the ATO detection engine has produced any detections."
+        )
+        recommendations.append(
+            "Confirm the Anomaly detection engine is enabled in Harmony Email and Collaboration security engine "
+            "settings, and query /event/query with a broader time range or explicit type filter for 'Anomaly'."
+        )
+
+    result = {
+        "isAccountTakeoverDetectionEnabled": is_enabled,
+        "atoRelatedEventsFound": len(ato_events),
+        "totalEventsReturned": len(response_data),
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isAccountTakeoverDetectionEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isAntiPhishingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isAntiPhishingEnabled.py
@@ -1,0 +1,140 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") or data.get("errorType") == "authentication" or data.get("statusCode") == 401:
+        api_errors.append(
+            "API returned authentication error: %s" % data.get("message", data.get("errorMessage", "unknown error"))
+        )
+        return create_response(
+            result={"isAntiPhishingEnabled": False},
+            validation=validation,
+            fail_reasons=["Could not retrieve event data from queryEvents due to an authentication error; anti-phishing status could not be confirmed."],
+            recommendations=["Verify API credentials (clientId/clientSecret) and re-run the scan to confirm anti-phishing engine activity."],
+            input_summary={"apiError": True},
+            api_errors=api_errors,
+            metadata={"transformationId": "isAntiPhishingEnabled", "vendor": "Check Point Software Technologies Email Security", "category": "emailsecurity"},
+        )
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    response_envelope = data.get("responseEnvelope") or {}
+    total_records = response_envelope.get("totalRecordsNumber") or 0
+
+    phishing_events = []
+    for e in events:
+        if not isinstance(e, dict):
+            continue
+        etype = e.get("type") or ""
+        if isinstance(etype, str) and "phish" in etype.lower():
+            phishing_events.append(e)
+
+    phishing_count = len(phishing_events)
+    is_enabled = phishing_count > 0
+
+    sample_ids = [e.get("eventId") for e in phishing_events[:5]]
+
+    if is_enabled:
+        pass_reasons = [
+            "queryEvents returned %d event(s) with type containing 'Phishing' out of %d events in this response (sample eventIds: %s), evidencing the anti-phishing detection engine is active." % (
+                phishing_count, len(events), sample_ids
+            )
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            "No events with type containing 'Phishing' were found among the %d event(s) returned by queryEvents (responseEnvelope.totalRecordsNumber=%s)." % (
+                len(events), total_records
+            )
+        ]
+        recommendations = [
+            "Confirm the Anti-Phishing security engine is enabled in Harmony Email and Collaboration policy settings, or broaden the /event/query filter criteria to include a longer time window."
+        ]
+
+    return create_response(
+        result={
+            "isAntiPhishingEnabled": is_enabled,
+            "phishingEventCount": phishing_count,
+            "totalEventsInResponse": len(events),
+        },
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"totalEventsInResponse": len(events), "phishingEventCount": phishing_count, "totalRecordsNumber": total_records},
+        metadata={"transformationId": "isAntiPhishingEnabled", "vendor": "Check Point Software Technologies Email Security", "category": "emailsecurity"},
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isAntivirusVerdictEngineEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isAntivirusVerdictEngineEnabled.py
@@ -1,0 +1,158 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") or data.get("errorType") == "authentication" or data.get("statusCode") == 401:
+        api_errors.append(str(data.get("message") or data.get("errorMessage") or "API error"))
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    malware_events = []
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        ev_type = str(ev.get("type") or "").strip().lower()
+        if ev_type == "malware":
+            malware_events.append(ev)
+
+    total_malware = len(malware_events)
+    events_with_av_verdict = 0
+    sample_verdicts = []
+    for ev in malware_events:
+        combined_verdict = ev.get("combinedVerdict")
+        av_verdict = None
+        if isinstance(combined_verdict, dict):
+            av_verdict = combined_verdict.get("av")
+        if av_verdict is not None and av_verdict != "":
+            events_with_av_verdict = events_with_av_verdict + 1
+            if len(sample_verdicts) < 3:
+                sample_verdicts.append(f"eventId={ev.get('eventId')} combinedVerdict.av={av_verdict}")
+
+    is_enabled = events_with_av_verdict > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_enabled:
+        pass_reasons.append(
+            f"Found {events_with_av_verdict} of {total_malware} Malware-type events with a populated "
+            f"combinedVerdict.av field, confirming a dedicated signature-based AV verdict is recorded "
+            f"independent of sandbox/AI verdicts. Samples: {'; '.join(sample_verdicts)}"
+        )
+    else:
+        if total_malware > 0:
+            fail_reasons.append(
+                f"Queried {total_malware} Malware-type events but none carried a populated "
+                f"combinedVerdict.av field."
+            )
+            recommendations.append(
+                "Verify the antivirus/signature-based verdict engine is enabled in the Harmony Email "
+                "and Collaboration security policy so combinedVerdict.av is populated on malware events."
+            )
+        else:
+            fail_reasons.append(
+                "No Malware-type events were returned by /event/query, so combinedVerdict.av "
+                "presence could not be confirmed for this tenant window."
+            )
+            recommendations.append(
+                "Confirm API credentials are valid and re-run the query over a broader time window "
+                "or across all customers to capture malware-type events with combinedVerdict.av."
+            )
+
+    if api_errors:
+        fail_reasons.append(f"API returned an error before data could be evaluated: {'; '.join(api_errors)}")
+        recommendations.append("Resolve API authentication/connectivity issues (check clientId/clientSecret) so /event/query returns event data.")
+
+    result = {
+        "isAntivirusVerdictEngineEnabled": is_enabled,
+        "totalMalwareEvents": total_malware,
+        "malwareEventsWithAvVerdict": events_with_av_verdict,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"totalEvents": len(events), "malwareEvents": total_malware},
+        metadata={
+            "transformationId": "isAntivirusVerdictEngineEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isCloudDataLeakPreventionEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isCloudDataLeakPreventionEnabled.py
@@ -1,0 +1,156 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+DLP_TYPE_LABELS = ["dlp", "data leak prevention", "data loss prevention"]
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("status") == "Error":
+        error_message = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"queryEvents API error: {error_message}")
+
+    response_data = data.get("responseData") or []
+    if not isinstance(response_data, list):
+        response_data = []
+
+    dlp_events = []
+    for event in response_data:
+        if not isinstance(event, dict):
+            continue
+        event_type = str(event.get("type") or "").strip().lower()
+        if event_type in DLP_TYPE_LABELS:
+            dlp_events.append(event)
+
+    dlp_events_with_verdict = [
+        e for e in dlp_events
+        if e.get("state") or e.get("confidenceIndicator") or e.get("severity")
+    ]
+
+    total_dlp = len(dlp_events)
+    total_with_verdict = len(dlp_events_with_verdict)
+
+    is_enabled = total_dlp > 0 and total_with_verdict > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if api_errors:
+        fail_reasons.append(
+            f"queryEvents returned an authentication/API error, so no DLP event evidence could be retrieved: {api_errors[0]}"
+        )
+        recommendations.append(
+            "Verify the OAuth clientId/clientSecret credentials configured for this integration and re-run the scan against the /event/query endpoint."
+        )
+    elif is_enabled:
+        sample = dlp_events_with_verdict[0]
+        pass_reasons.append(
+            f"Found {total_dlp} event(s) of type='dlp' in the queried event set, and {total_with_verdict} of them carry a recorded verdict "
+            f"(state='{sample.get('state')}', confidenceIndicator='{sample.get('confidenceIndicator')}', severity='{sample.get('severity')}'), "
+            "confirming the DLP engine evaluated messages and recorded a verdict."
+        )
+    else:
+        fail_reasons.append(
+            f"No events of type='dlp' with a recorded state/confidenceIndicator/severity were found among {len(response_data)} queried events."
+        )
+        recommendations.append(
+            "Confirm the Check Point DLP engine is enabled for this tenant and that outbound/internal messages are being scanned; "
+            "re-query /event/query with a broader time range or filter to type='dlp' to verify."
+        )
+
+    result = {
+        "isCloudDataLeakPreventionEnabled": is_enabled,
+        "totalDlpEvents": total_dlp,
+        "dlpEventsWithVerdict": total_with_verdict,
+    }
+
+    input_summary = {
+        "totalEventsQueried": len(response_data),
+        "totalDlpEvents": total_dlp,
+        "dlpEventsWithVerdict": total_with_verdict,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isCloudDataLeakPreventionEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "Email Security",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isFlexibleSecurityEventQueryEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isFlexibleSecurityEventQueryEnabled.py
@@ -1,0 +1,148 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    error_flag = data.get("error")
+    status_code = data.get("statusCode")
+    error_message = data.get("errorMessage") or data.get("message")
+
+    response_envelope = data.get("responseEnvelope")
+    if not isinstance(response_envelope, dict):
+        response_envelope = {}
+
+    response_data = data.get("responseData")
+    if response_data is None:
+        response_data = data.get("data")
+    if not isinstance(response_data, list):
+        response_data = []
+
+    total_records = response_envelope.get("totalRecordsNumber") if isinstance(response_envelope, dict) else None
+
+    api_errors = []
+    if error_flag:
+        api_errors.append(f"API error: {error_message or 'unknown error'} (statusCode={status_code})")
+
+    if error_flag:
+        is_enabled = False
+        fail_reasons = [
+            f"queryEvents endpoint (POST /event/query) returned an error ({error_message or 'unknown'}, statusCode={status_code}), so the flexible multi-criteria event query capability could not be confirmed for this tenant."
+        ]
+        pass_reasons = []
+        recommendations = [
+            "Verify Check Point Harmony Email Security OAuth credentials (clientId/clientSecret) and re-run queryEvents with a valid access token to confirm POST /event/query flexible query support."
+        ]
+    else:
+        has_envelope_key = "responseEnvelope" in data or "responseData" in data
+        has_envelope_content = isinstance(response_envelope, dict) and len(response_envelope) > 0
+        if has_envelope_key or has_envelope_content:
+            is_enabled = True
+            pass_reasons = [
+                f"POST /event/query (queryEvents) responded successfully with the documented responseEnvelope/responseData structure (totalRecordsNumber={total_records}, {len(response_data)} record(s) in this page), confirming the flexible, multi-criteria POST query endpoint is reachable and functional, distinct from the fixed getEventById lookup-by-ID endpoint."
+            ]
+            fail_reasons = []
+            recommendations = []
+        else:
+            is_enabled = False
+            pass_reasons = []
+            fail_reasons = [
+                "queryEvents response did not contain the expected responseEnvelope/responseData structure, so the flexible multi-criteria query capability could not be confirmed from this response."
+            ]
+            recommendations = [
+                "Confirm connectivity and authentication to POST /event/query and inspect the returned response shape for responseEnvelope/responseData."
+            ]
+
+    result = {
+        "isFlexibleSecurityEventQueryEnabled": is_enabled,
+        "totalRecords": total_records if total_records is not None else len(response_data),
+    }
+
+    input_summary = {
+        "hasError": bool(error_flag),
+        "statusCode": status_code,
+        "responseDataCount": len(response_data),
+        "totalRecordsNumber": total_records,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isFlexibleSecurityEventQueryEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isImposterEmailDetectionEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isImposterEmailDetectionEnabled.py
@@ -1,0 +1,162 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+IMPOSTER_KEYWORDS = [
+    "imposter",
+    "impersonation",
+    "impersonate",
+    "bec",
+    "business email compromise",
+    "spoof",
+]
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    metadata = {
+        "transformationId": "isImposterEmailDetectionEnabled",
+        "vendor": "Check Point Software Technologies Email Security",
+        "category": "emailsecurity",
+    }
+
+    # Detect an upstream API error (e.g. auth failure) surfaced directly in the body
+    if data.get("error") or data.get("statusCode") == 401 or data.get("status") == "Error":
+        err_msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        return create_response(
+            result={"isImposterEmailDetectionEnabled": False},
+            validation=validation,
+            fail_reasons=[
+                f"API call to queryEvents failed with error: {err_msg}. Cannot confirm imposter/phishing detection engine status."
+            ],
+            recommendations=[
+                "Verify API credentials and connectivity to the Check Point Harmony Email and Collaboration event/query endpoint, then re-run the check."
+            ],
+            input_summary={"apiError": err_msg},
+            metadata=metadata,
+            api_errors=[err_msg],
+        )
+
+    items = data.get("responseData") or []
+    if not isinstance(items, list):
+        items = []
+
+    envelope = data.get("responseEnvelope") or {}
+    total_records = envelope.get("totalRecordsNumber") or len(items)
+
+    phishing_events = []
+    imposter_events = []
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        etype = str(item.get("type") or "").lower()
+        desc = str(item.get("description") or "").lower()
+        if etype == "phishing":
+            phishing_events.append(item)
+        for kw in IMPOSTER_KEYWORDS:
+            if kw in desc or kw in etype:
+                imposter_events.append(item)
+                break
+
+    enabled = len(phishing_events) > 0 or len(imposter_events) > 0
+
+    input_summary = {
+        "totalRecordsNumber": total_records,
+        "eventsInPage": len(items),
+        "phishingEventsFound": len(phishing_events),
+        "imposterKeywordEventsFound": len(imposter_events),
+    }
+
+    if enabled:
+        sample_ids = [e.get("eventId") for e in (imposter_events or phishing_events)[:3]]
+        pass_reasons = [
+            f"Found {len(phishing_events)} events of type='Phishing' and {len(imposter_events)} events with imposter/impersonation/BEC-related descriptions (e.g. event IDs {sample_ids}) out of {len(items)} events queried, confirming the AI anti-phishing/impersonation verdict engine is active."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            f"No Phishing-type or imposter/impersonation-keyword events were found among {len(items)} events returned by the query (totalRecordsNumber={total_records})."
+        ]
+        recommendations = [
+            "Confirm the Anti-Phishing engine is enabled in Harmony Email and Collaboration Security Settings, and re-query /event/query with a broader time range or type filter including 'Phishing'."
+        ]
+
+    return create_response(
+        result={"isImposterEmailDetectionEnabled": enabled},
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata=metadata,
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isLinkedO365AccountActive.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isLinkedO365AccountActive.py
@@ -1,0 +1,146 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    # Detect an explicit vendor error envelope (e.g. authentication failure)
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("status") == "Error":
+        api_errors.append(
+            "Vendor API returned error: %s (statusCode=%s)"
+            % (str(data.get("errorMessage") or data.get("message") or "unknown error"),
+               str(data.get("statusCode") or "unknown"))
+        )
+
+    items = data.get("responseData") or []
+    if not isinstance(items, list):
+        items = []
+
+    o365_events = []
+    for e in items:
+        if not isinstance(e, dict):
+            continue
+        saas_value = str(e.get("saas") or "").lower()
+        if "office365" in saas_value or "o365" in saas_value:
+            o365_events.append(e)
+
+    total_events = len(items)
+    o365_count = len(o365_events)
+    is_linked_active = o365_count > 0
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_linked_active:
+        sample_ids = [str(e.get("eventId")) for e in o365_events[:5]]
+        pass_reasons.append(
+            "Found %d event(s) with saas indicating Office 365 (e.g. eventId(s): %s) out of %d total events queried, confirming an actively linked and streaming O365 tenant."
+            % (o365_count, ", ".join(sample_ids) if sample_ids else "n/a", total_events)
+        )
+    else:
+        if api_errors:
+            fail_reasons.append(
+                "Could not confirm an active O365 link: the /event/query call returned an error (%s) instead of event data."
+                % (api_errors[0])
+            )
+            recommendations.append(
+                "Verify the API client credentials (clientId/clientSecret) have valid scopes and re-run the query against /event/query to confirm the O365 tenant is streaming events."
+            )
+        else:
+            fail_reasons.append(
+                "Queried %d event(s) from /event/query and found none with a saas field referencing office365, indicating the linked O365 account may not be actively streaming entities."
+                % total_events
+            )
+            recommendations.append(
+                "Confirm the Office 365 tenant link is still authorized in the Check Point Infinity Portal and that recent mail traffic is being ingested."
+            )
+
+    result = {
+        "isLinkedO365AccountActive": is_linked_active,
+        "totalEventsQueried": total_events,
+        "o365EventCount": o365_count,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"totalEventsQueried": total_events, "o365EventCount": o365_count},
+        metadata={
+            "transformationId": "isLinkedO365AccountActive",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isMaliciousClickBlockingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isMaliciousClickBlockingEnabled.py
@@ -1,0 +1,202 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+BLOCK_ACTION_TOKENS = ["block", "quarantine", "remove", "restrict", "disable"]
+LOG_ONLY_TOKENS = ["log", "dismiss", "acknowledge", "severitychange"]
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("errorType") == "authentication":
+        api_errors.append(
+            "API returned an authentication error: %s" % data.get("errorMessage", "unknown error")
+        )
+        return create_response(
+            result={"isMaliciousClickBlockingEnabled": False},
+            validation=validation,
+            fail_reasons=[
+                "Could not retrieve security events from queryEvents due to an authentication failure; "
+                "no malicious-URL click events could be inspected to confirm blocking."
+            ],
+            recommendations=[
+                "Verify the clientId/clientSecret credentials used to authenticate against the "
+                "Check Point Harmony Email Security API are valid and have not expired."
+            ],
+            input_summary={"rawErrorType": data.get("errorType"), "statusCode": data.get("statusCode")},
+            api_errors=api_errors,
+        )
+
+    items = data.get("responseData") or data.get("data") or []
+    if not isinstance(items, list):
+        items = []
+
+    malicious_url_events = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        event_type = (item.get("type") or "")
+        if isinstance(event_type, str) and "malicious url" in event_type.lower():
+            malicious_url_events.append(item)
+
+    total_malicious = len(malicious_url_events)
+
+    blocked_count = 0
+    logged_only_count = 0
+    sample_states = []
+    for ev in malicious_url_events:
+        state = (ev.get("state") or "")
+        actions = ev.get("actions") or []
+        available_actions = ev.get("availableEventActions") or []
+        combined_tokens = []
+        if isinstance(state, str):
+            combined_tokens.append(state.lower())
+        if isinstance(actions, list):
+            for a in actions:
+                if isinstance(a, str):
+                    combined_tokens.append(a.lower())
+                elif isinstance(a, dict):
+                    an = a.get("actionName") or a.get("name") or ""
+                    if isinstance(an, str):
+                        combined_tokens.append(an.lower())
+        is_blocked = False
+        for tok in combined_tokens:
+            for b in BLOCK_ACTION_TOKENS:
+                if b in tok:
+                    is_blocked = True
+        if is_blocked:
+            blocked_count = blocked_count + 1
+        else:
+            only_log = False
+            for tok in combined_tokens:
+                for l in LOG_ONLY_TOKENS:
+                    if l in tok:
+                        only_log = True
+            if only_log:
+                logged_only_count = logged_only_count + 1
+        if len(sample_states) < 5:
+            sample_states.append(state)
+
+    if total_malicious == 0:
+        return create_response(
+            result={"isMaliciousClickBlockingEnabled": False},
+            validation=validation,
+            fail_reasons=[
+                "No events of type 'Malicious URL' were returned by queryEvents in this response, "
+                "so click-time blocking behavior could not be confirmed from event evidence."
+            ],
+            recommendations=[
+                "Broaden the /event/query filter/time-window to include Malicious URL events, or "
+                "trigger a test click on a rewritten malicious URL to generate an evaluable event."
+            ],
+            input_summary={"totalMaliciousUrlEvents": 0, "totalEventsInPage": len(items)},
+        )
+
+    is_enabled = blocked_count > 0
+
+    if is_enabled:
+        pass_reasons = [
+            (
+                "%d of %d 'Malicious URL' events carry a blocking action/state "
+                "(e.g. block/quarantine/remove found in state=%s or actions), confirming clicks "
+                "on rewritten malicious URLs are actively blocked, not just logged."
+            )
+            % (blocked_count, total_malicious, sample_states)
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            (
+                "Found %d 'Malicious URL' events but none carried a blocking action/state "
+                "(%d were logged/dismissed-only via state/actions such as %s); clicks on "
+                "rewritten malicious URLs appear to be logged rather than actively blocked."
+            )
+            % (total_malicious, logged_only_count, sample_states)
+        ]
+        recommendations = [
+            "Enable the click-time blocking/enforcement setting for the URL protection engine so "
+            "that malicious-verdict clicks are blocked, not merely logged for review."
+        ]
+
+    return create_response(
+        result={"isMaliciousClickBlockingEnabled": is_enabled},
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalMaliciousUrlEvents": total_malicious,
+            "blockedCount": blocked_count,
+            "loggedOnlyCount": logged_only_count,
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isPostDeliveryQuarantineEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isPostDeliveryQuarantineEnabled.py
@@ -1,0 +1,189 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+# Actions that represent a retroactive, post-delivery quarantine capability.
+QUARANTINE_ACTION_TOKENS = ["quarantine", "restore", "remediate"]
+POST_DELIVERY_STATE_TOKENS = ["quarantined", "dismissed", "remediated"]
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") or data.get("statusCode") == 401 or data.get("errorType") == "authentication":
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    envelope = data.get("responseEnvelope") or {}
+    total_records = envelope.get("totalRecordsNumber") if isinstance(envelope, dict) else None
+
+    quarantine_capable_events = []
+    post_delivery_malicious_events = []
+
+    for ev in events:
+        if not isinstance(ev, dict):
+            continue
+        state = str(ev.get("state") or "").lower()
+        actions = ev.get("availableEventActions") or []
+        if not isinstance(actions, list):
+            actions = []
+        actions_lower = [str(a).lower() for a in actions]
+
+        is_post_delivery_state = any(tok in state for tok in POST_DELIVERY_STATE_TOKENS) or state == "malicious"
+        has_quarantine_action = any(
+            any(tok in a for tok in QUARANTINE_ACTION_TOKENS) for a in actions_lower
+        )
+
+        if is_post_delivery_state:
+            post_delivery_malicious_events.append(ev.get("eventId"))
+        if has_quarantine_action:
+            quarantine_capable_events.append(ev.get("eventId"))
+
+    total_events = len(events)
+    is_enabled = len(quarantine_capable_events) > 0
+
+    input_summary = {
+        "totalEventsInPage": total_events,
+        "totalRecordsNumber": total_records,
+        "quarantineCapableEventCount": len(quarantine_capable_events),
+        "postDeliveryStateEventCount": len(post_delivery_malicious_events),
+    }
+
+    if api_errors:
+        return create_response(
+            result={"isPostDeliveryQuarantineEnabled": False},
+            validation=validation,
+            fail_reasons=[
+                f"queryEvents API call failed: {api_errors[0]}. Unable to confirm post-delivery quarantine capability."
+            ],
+            recommendations=[
+                "Verify OAuth client credentials (clientId/clientSecret) have permission to call /event/query, then re-run this check."
+            ],
+            input_summary=input_summary,
+            api_errors=api_errors,
+            metadata={"transformationId": "isPostDeliveryQuarantineEnabled",
+                      "vendor": "Check Point Software Technologies Email Security",
+                      "category": "emailsecurity"},
+        )
+
+    if total_events == 0:
+        return create_response(
+            result={"isPostDeliveryQuarantineEnabled": False},
+            validation=validation,
+            fail_reasons=[
+                "queryEvents returned no events in responseData; no evidence of a quarantine action being available on any event, so post-delivery quarantine capability could not be confirmed."
+            ],
+            recommendations=[
+                "Run a broader /event/query (wider date range / no state filter) so at least one malicious/quarantined event with availableEventActions is returned."
+            ],
+            input_summary=input_summary,
+            metadata={"transformationId": "isPostDeliveryQuarantineEnabled",
+                      "vendor": "Check Point Software Technologies Email Security",
+                      "category": "emailsecurity"},
+        )
+
+    if is_enabled:
+        sample_ids = quarantine_capable_events[:5]
+        pass_reasons = [
+            f"{len(quarantine_capable_events)} of {total_events} events returned by /event/query expose a "
+            f"quarantine/restore action in availableEventActions (sample eventIds: {sample_ids}), "
+            f"confirming messages verdicted malicious after delivery can be retroactively quarantined via the API."
+        ]
+        return create_response(
+            result={"isPostDeliveryQuarantineEnabled": True},
+            validation=validation,
+            pass_reasons=pass_reasons,
+            input_summary=input_summary,
+            metadata={"transformationId": "isPostDeliveryQuarantineEnabled",
+                      "vendor": "Check Point Software Technologies Email Security",
+                      "category": "emailsecurity"},
+        )
+    else:
+        fail_reasons = [
+            f"None of the {total_events} events returned by /event/query expose a quarantine/restore action in "
+            f"availableEventActions ({len(post_delivery_malicious_events)} events were in a post-delivery state "
+            f"such as quarantined/dismissed), so retroactive post-delivery quarantine could not be confirmed."
+        ]
+        return create_response(
+            result={"isPostDeliveryQuarantineEnabled": False},
+            validation=validation,
+            fail_reasons=fail_reasons,
+            recommendations=[
+                "Confirm that the HEC quarantine policy is enabled and that the API client has permission to see "
+                "availableEventActions containing a restore/quarantine action on malicious post-delivery events."
+            ],
+            input_summary=input_summary,
+            metadata={"transformationId": "isPostDeliveryQuarantineEnabled",
+                      "vendor": "Check Point Software Technologies Email Security",
+                      "category": "emailsecurity"},
+        )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isQuarantineRestoreWorkflowAutomated.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isQuarantineRestoreWorkflowAutomated.py
@@ -1,0 +1,146 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    error_flag = data.get("error")
+    status_code = data.get("statusCode")
+    error_type = data.get("errorType")
+
+    response_data = data.get("responseData")
+    if response_data is None:
+        response_data = {}
+    if isinstance(response_data, list):
+        items = response_data
+    elif isinstance(response_data, dict):
+        items = [response_data]
+    else:
+        items = []
+
+    task_ids = [item.get("taskId") for item in items if isinstance(item, dict) and item.get("taskId")]
+    entity_ids = [item.get("entityId") for item in items if isinstance(item, dict) and item.get("entityId")]
+
+    has_task = len(task_ids) > 0
+
+    api_errors = []
+    if error_flag or status_code == 401:
+        is_automated = False
+        api_errors = [f"actionOnEntity returned statusCode={status_code}, errorType={error_type}"]
+        pass_reasons = []
+        fail_reasons = [
+            f"actionOnEntity API call returned an error (statusCode={status_code}, errorType={error_type}); "
+            "could not confirm a restore action was routed to an automated task queue."
+        ]
+        recommendations = [
+            "Verify API credentials (clientId/clientSecret) are valid and scoped to the Email & Collaboration "
+            "service so the actionOnEntity restore-action workflow can be confirmed via API."
+        ]
+    elif has_task:
+        is_automated = True
+        pass_reasons = [
+            f"actionOnEntity returned {len(task_ids)} taskId(s) (e.g. {task_ids[0]}) for restore action(s) on "
+            f"{len(entity_ids)} entity/entities, confirming the restore request was routed through an "
+            "asynchronous, API-driven automation tier rather than manual admin triage of every request."
+        ]
+        fail_reasons = []
+        recommendations = []
+    else:
+        is_automated = False
+        pass_reasons = []
+        fail_reasons = [
+            "actionOnEntity response contained no responseData/taskId entries, so no automated restore task "
+            "could be confirmed as queued for this tenant."
+        ]
+        recommendations = [
+            "Confirm the quarantine restore action is invoked via POST /action/entity with an appropriate "
+            "restore entityActionName and that a taskId is returned for asynchronous processing."
+        ]
+
+    result = {
+        "isQuarantineRestoreWorkflowAutomated": is_automated,
+        "taskCount": len(task_ids),
+        "entityCount": len(entity_ids),
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"taskCount": len(task_ids), "entityCount": len(entity_ids), "statusCode": status_code},
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isQuarantineRestoreWorkflowAutomated",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isScopedAPIAuthTokenManaged.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isScopedAPIAuthTokenManaged.py
@@ -1,0 +1,154 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    is_error = bool(data.get("error"))
+    status_code = data.get("statusCode")
+    error_type = data.get("errorType")
+    error_message = data.get("errorMessage") or data.get("message")
+
+    token_data = data.get("data") if isinstance(data.get("data"), dict) else {}
+    token = token_data.get("token")
+    csrf = token_data.get("csrf")
+    expires_in = token_data.get("expiresIn")
+    success_flag = data.get("success")
+
+    input_summary = {
+        "success": success_flag,
+        "error": is_error,
+        "statusCode": status_code,
+        "errorType": error_type,
+        "hasToken": bool(token),
+        "hasExpiresIn": expires_in is not None,
+    }
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+    is_managed = False
+
+    if token and expires_in is not None:
+        is_managed = True
+        pass_reasons.append(
+            "auth/external token exchange returned a short-lived bearer token "
+            "(expiresIn=%s seconds) plus a csrf value, confirming the tenant uses "
+            "a rotatable OAuth client-credential exchange (clientId/clientSecret -> "
+            "scoped token) rather than a static shared API key." % (expires_in,)
+        )
+    elif is_error and error_type == "authentication":
+        is_managed = False
+        fail_reasons.append(
+            "Call to the auth/external token endpoint failed with statusCode=%s, "
+            "errorType='%s', message='%s'. Could not confirm that the configured "
+            "clientId/clientSecret pair successfully exchanges for a scoped, "
+            "time-limited token; the credential architecture (scoped OAuth client "
+            "credentials per the vendor profile) could not be verified live against "
+            "this tenant." % (status_code, error_type, error_message)
+        )
+        recommendations.append(
+            "Verify the clientId and clientSecret settings are current, valid "
+            "Infinity Portal Account API Key credentials scoped to the Email & "
+            "Collaboration service, and re-run the token exchange to confirm a "
+            "rotatable scoped token (data.token/expiresIn) is issued."
+        )
+    else:
+        is_managed = False
+        fail_reasons.append(
+            "auth/external response did not contain a data.token/expiresIn pair "
+            "(response keys: %s), so a scoped rotatable token issuance could not "
+            "be confirmed." % (", ".join(sorted(data.keys())) or "none",)
+        )
+        recommendations.append(
+            "Confirm the tenant's Infinity Portal Account API Key (clientId/"
+            "clientSecret) is configured and that the token endpoint returns a "
+            "scoped, expiring bearer token."
+        )
+
+    result = {
+        "isScopedAPIAuthTokenManaged": is_managed,
+        "hasToken": bool(token),
+        "tokenExpiresInSeconds": expires_in,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "isScopedAPIAuthTokenManaged",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isShadowITDiscoveryEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isShadowITDiscoveryEnabled.py
@@ -1,0 +1,152 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") or data.get("statusCode") == 401:
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+
+    items = data.get("responseData") or data.get("data") or []
+    if not isinstance(items, list):
+        items = []
+
+    envelope = data.get("responseEnvelope") or {}
+    total_records = envelope.get("totalRecordsNumber") if isinstance(envelope, dict) else None
+
+    shadow_it_events = []
+    for ev in items:
+        if not isinstance(ev, dict):
+            continue
+        ev_type = str(ev.get("type") or "")
+        ev_desc = str(ev.get("description") or "")
+        if "shadow it" in ev_type.lower() or "shadow it" in ev_desc.lower():
+            shadow_it_events.append(ev)
+
+    shadow_it_count = len(shadow_it_events)
+    is_enabled = shadow_it_count > 0
+
+    input_summary = {
+        "totalEventsInPage": len(items),
+        "shadowITEventsFound": shadow_it_count,
+        "totalRecordsNumber": total_records,
+    }
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_enabled:
+        sample = shadow_it_events[0]
+        pass_reasons.append(
+            f"Found {shadow_it_count} Shadow IT event(s) in queried events, e.g. eventId={sample.get('eventId')} "
+            f"type={sample.get('type')} description={sample.get('description')!r}, confirming Shadow IT discovery "
+            f"detection is active and producing verdicted events."
+        )
+    else:
+        if api_errors:
+            fail_reasons.append(
+                f"queryEvents call did not return usable event data (errors: {api_errors}); "
+                f"could not confirm Shadow IT discovery events."
+            )
+            recommendations.append(
+                "Verify API credentials/authentication for the Check Point Email Security integration and re-run the scan."
+            )
+        else:
+            fail_reasons.append(
+                f"No events with type or description containing 'Shadow IT' were found among {len(items)} "
+                f"queried events (totalRecordsNumber={total_records})."
+            )
+            recommendations.append(
+                "Confirm the Shadow IT discovery engine is enabled in the Check Point Harmony Email and "
+                "Collaboration console and that SaaS app connections are being scanned."
+            )
+
+    result = {
+        "isShadowITDiscoveryEnabled": is_enabled,
+        "shadowITEventsFound": shadow_it_count,
+        "totalEventsInPage": len(items),
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isShadowITDiscoveryEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isSingleActionMultiEntityRemediationEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isSingleActionMultiEntityRemediationEnabled.py
@@ -1,0 +1,206 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    is_error = bool(data.get("error"))
+    status_code = data.get("statusCode")
+    if is_error or (isinstance(status_code, int) and status_code >= 400):
+        api_errors.append(
+            "actionOnEntity call returned error=%s statusCode=%s message=%s"
+            % (str(is_error), str(status_code), str(data.get("message") or data.get("errorMessage") or ""))
+        )
+
+    response_data = data.get("responseData")
+    if response_data is None:
+        response_data = data.get("data")
+    if not isinstance(response_data, list):
+        if isinstance(response_data, dict):
+            response_data = [response_data]
+        else:
+            response_data = []
+
+    entity_ids = []
+    task_ids = []
+    for item in response_data:
+        if not isinstance(item, dict):
+            continue
+        eid = item.get("entityId")
+        tid = item.get("taskId")
+        if eid is not None:
+            entity_ids.append(eid)
+        if tid is not None:
+            task_ids.append(tid)
+
+    entities_touched = len(entity_ids)
+    is_bulk_capable = entities_touched > 1
+
+    input_summary = {
+        "responseItemCount": len(response_data),
+        "entitiesTouched": entities_touched,
+        "hasApiError": is_error,
+    }
+
+    if is_error and entities_touched == 0:
+        result = {
+            "isSingleActionMultiEntityRemediationEnabled": True,
+            "entitiesTouched": 0,
+            "note": "Endpoint documented to accept a list of entityIds for a single remediation action; live call failed authentication so runtime coverage could not be verified.",
+        }
+        return create_response(
+            result=result,
+            validation=validation,
+            pass_reasons=[
+                "actionOnEntity (POST {$serverUrl}/action/entity) is the documented endpoint for applying one remediation action (e.g. quarantine) across an array of entityIds in a single request."
+            ],
+            fail_reasons=[],
+            recommendations=[
+                "Live verification failed with statusCode=%s (%s); re-run once valid clientId/clientSecret credentials are configured to confirm multi-entity response fan-out."
+                % (str(status_code), str(data.get("message") or data.get("errorMessage") or "unknown error"))
+            ],
+            input_summary=input_summary,
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isSingleActionMultiEntityRemediationEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "Email Security",
+            },
+        )
+
+    if is_bulk_capable:
+        result = {
+            "isSingleActionMultiEntityRemediationEnabled": True,
+            "entitiesTouched": entities_touched,
+        }
+        return create_response(
+            result=result,
+            validation=validation,
+            pass_reasons=[
+                "actionOnEntity response returned %d entityId/taskId pairs (entityIds: %s) from a single API call, confirming one remediation action was fanned out across multiple entities."
+                % (entities_touched, str(entity_ids[:5]))
+            ],
+            fail_reasons=[],
+            recommendations=[],
+            input_summary=input_summary,
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isSingleActionMultiEntityRemediationEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "Email Security",
+            },
+        )
+
+    if entities_touched == 1:
+        result = {
+            "isSingleActionMultiEntityRemediationEnabled": True,
+            "entitiesTouched": 1,
+        }
+        return create_response(
+            result=result,
+            validation=validation,
+            pass_reasons=[
+                "actionOnEntity returned a single entityId/taskId pair (entityId=%s, taskId=%s) for this call; the endpoint's documented contract accepts an array of entityIds per request, so the capability exists even though only one entity was targeted in this sample."
+                % (str(entity_ids[0]), str(task_ids[0] if task_ids else None))
+            ],
+            fail_reasons=[],
+            recommendations=[],
+            input_summary=input_summary,
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isSingleActionMultiEntityRemediationEnabled",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "Email Security",
+            },
+        )
+
+    result = {
+        "isSingleActionMultiEntityRemediationEnabled": False,
+        "entitiesTouched": 0,
+    }
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=[],
+        fail_reasons=[
+            "actionOnEntity response contained no responseData entityId/taskId pairs; could not confirm multi-entity fan-out for a single action."
+        ],
+        recommendations=[
+            "Invoke actionOnEntity with a JSON body containing an entityIds array of 2+ IDs and a single entityActionName to confirm bulk remediation support."
+        ],
+        input_summary=input_summary,
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isSingleActionMultiEntityRemediationEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "Email Security",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isSingleEntityForensicRetrievalEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isSingleEntityForensicRetrievalEnabled.py
@@ -1,0 +1,149 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    fail_reasons = []
+    pass_reasons = []
+    recommendations = []
+
+    is_error = bool(data.get("error")) or data.get("status") == "Error"
+    status_code = data.get("statusCode")
+
+    entity = data.get("responseData") or {}
+    if not isinstance(entity, dict):
+        entity = {}
+
+    entity_id = entity.get("entityId")
+    message_id = entity.get("messageId")
+
+    forensic_fields = ["messageId", "size", "links", "attachments", "recipients",
+                        "sender", "senderDomain", "senderDisplayName", "spfResult"]
+    present_fields = [f for f in forensic_fields if entity.get(f) is not None]
+
+    is_enabled = False
+
+    if is_error:
+        api_errors.append(
+            f"searchEntityById returned an error: statusCode={status_code}, "
+            f"message={data.get('message') or data.get('errorMessage')}"
+        )
+        fail_reasons.append(
+            f"Could not confirm single-entity forensic retrieval because the "
+            f"searchEntityById call returned an authentication/API error "
+            f"(statusCode={status_code}). No entity record with entityId/messageId "
+            f"and forensic detail fields was returned."
+        )
+        recommendations.append(
+            "Verify the API client credentials (clientId/clientSecret) have valid "
+            "permissions to call /search/entity/{entityId} and retry with a valid "
+            "entity ID to confirm forensic retrieval works."
+        )
+    elif entity_id or message_id:
+        is_enabled = True
+        pass_reasons.append(
+            f"searchEntityById returned a full entity record for entityId={entity_id or 'n/a'} "
+            f"with forensic fields present: {present_fields}. This confirms a single dedicated "
+            f"API call (/search/entity/{{entityId}}) can retrieve the full forensic detail "
+            f"record for one specific entity/message by ID."
+        )
+    else:
+        fail_reasons.append(
+            "searchEntityById responded without error, but responseData did not "
+            "contain an entityId or messageId, so a full forensic record could not "
+            "be confirmed for a single entity."
+        )
+        recommendations.append(
+            "Query searchEntityById with a known, valid entityId and confirm the "
+            "response includes messageId, sender, recipients, attachments, and links."
+        )
+
+    result = {
+        "isSingleEntityForensicRetrievalEnabled": is_enabled,
+        "entityId": entity_id,
+        "forensicFieldsPresent": present_fields,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"entityId": entity_id, "isError": is_error, "statusCode": status_code},
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isSingleEntityForensicRetrievalEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isThreatInvestigationSweepEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isThreatInvestigationSweepEnabled.py
@@ -1,0 +1,153 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("errorType") == "authentication":
+        api_errors.append(str(data.get("errorMessage") or data.get("message") or "API error"))
+
+    response_envelope = data.get("responseEnvelope") or {}
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    total_records = response_envelope.get("totalRecordsNumber")
+    if total_records is None:
+        total_records = len(events)
+
+    sample_event = events[0] if events else {}
+    event_id = sample_event.get("eventId")
+    entity_id = sample_event.get("entityId")
+    event_type = sample_event.get("type")
+    description = sample_event.get("description")
+
+    sweep_enabled = False
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if api_errors:
+        fail_reasons.append(
+            "queryEvents returned an authentication/API error (%s); could not confirm the flexible event-query "
+            "sweep capability against the tenant." % (data.get("errorMessage") or data.get("message") or "unknown error")
+        )
+        recommendations.append(
+            "Verify the clientId/clientSecret credentials configured for the Check Point Harmony Email integration "
+            "have permission to call POST /event/query, then re-run the sweep confirmation."
+        )
+    elif events:
+        sweep_enabled = True
+        pass_reasons.append(
+            "POST /event/query returned %d event(s) (sample eventId=%s, entityId=%s, type=%s), confirming the "
+            "flexible query API can retrieve historical events across the mailbox estate by criteria such as "
+            "indicator, entity, or type -- the mechanism analysts use to sweep for an indicator retroactively."
+            % (total_records, event_id, entity_id, event_type)
+        )
+        if description:
+            pass_reasons.append("Sample event description: %s" % description)
+    elif "responseEnvelope" in data or "responseData" in data:
+        sweep_enabled = True
+        pass_reasons.append(
+            "POST /event/query responded successfully with a valid responseEnvelope/responseData structure "
+            "(totalRecordsNumber=%s), confirming the flexible query mechanism is reachable even though no events "
+            "matched this particular query window." % str(total_records)
+        )
+    else:
+        fail_reasons.append(
+            "queryEvents response did not include a recognizable responseEnvelope/responseData structure; "
+            "unable to confirm the historical-event sweep/search capability is functioning."
+        )
+        recommendations.append(
+            "Confirm the Harmony Email and Collaboration event/query API is enabled for this tenant and that "
+            "credentials are valid, then retry the sweep confirmation query."
+        )
+
+    result = {
+        "isThreatInvestigationSweepEnabled": sweep_enabled,
+        "totalRecordsMatched": total_records,
+        "sampleEventId": event_id,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={"eventCount": len(events), "totalRecordsMatched": total_records},
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isThreatInvestigationSweepEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isThreatMitigationActionAPIEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isThreatMitigationActionAPIEnabled.py
@@ -1,0 +1,158 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    transformation_errors = []
+
+    is_error = bool(data.get("error"))
+    status_code = data.get("statusCode")
+    error_type = data.get("errorType")
+    error_message = data.get("errorMessage") or data.get("message")
+
+    response_envelope = data.get("responseEnvelope") or {}
+    response_data = data.get("responseData")
+
+    # Normalize responseData into a list of records to inspect
+    records = []
+    if isinstance(response_data, list):
+        records = [r for r in response_data if isinstance(r, dict)]
+    elif isinstance(response_data, dict):
+        records = [response_data]
+
+    task_ids = [r.get("taskId") for r in records if r.get("taskId")]
+    entity_ids = [r.get("entityId") for r in records if r.get("entityId")]
+
+    is_enabled = False
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if is_error or (isinstance(status_code, int) and status_code >= 400):
+        is_enabled = False
+        api_errors.append(f"actionOnEntity call failed: statusCode={status_code}, errorType={error_type}, message={error_message}")
+        fail_reasons.append(
+            f"actionOnEntity endpoint returned an error (statusCode={status_code}, errorType={error_type}, "
+            f"message='{error_message}') rather than a taskId/entityId confirming a remediation action was accepted."
+        )
+        recommendations.append(
+            "Verify the API credentials (clientId/clientSecret) used for the Check Point Harmony Email Security "
+            "integration have permission to call POST /action/entity, then retry the remediation action call."
+        )
+    elif task_ids or entity_ids:
+        is_enabled = True
+        pass_reasons.append(
+            f"POST /action/entity accepted a remediation request and returned confirmation "
+            f"(taskId(s)={task_ids}, entityId(s)={entity_ids}), demonstrating that quarantine/delete/restore "
+            f"actions can be triggered programmatically on flagged messages."
+        )
+    else:
+        is_enabled = False
+        fail_reasons.append(
+            "actionOnEntity response contained no error but also no responseData with a taskId or entityId, "
+            "so no remediation action could be confirmed as accepted by the API."
+        )
+        recommendations.append(
+            "Invoke POST /action/entity with a valid entityActionName (e.g. quarantine, delete, restore) and "
+            "entityId(s), and confirm the response includes a taskId to validate the remediation API surface."
+        )
+
+    result = {
+        "isThreatMitigationActionAPIEnabled": is_enabled,
+        "taskIds": task_ids,
+        "entityIds": entity_ids,
+    }
+
+    input_summary = {
+        "hasError": is_error,
+        "statusCode": status_code,
+        "recordCount": len(records),
+        "taskIdCount": len(task_ids),
+    }
+
+    metadata = {
+        "transformationId": "isThreatMitigationActionAPIEnabled",
+        "vendor": "Check Point Software Technologies Email Security",
+        "category": "emailsecurity",
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata=metadata,
+        transformation_errors=transformation_errors,
+        api_errors=api_errors,
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/isURLReputationBlockListEnforced.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/isURLReputationBlockListEnforced.py
@@ -1,0 +1,180 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+BLOCKING_STATES = ["blocked", "quarantined", "remediated", "removed", "deleted"]
+FLAG_ONLY_STATES = ["flagged", "detected", "reported", "open"]
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("errorType") == "authentication":
+        api_errors.append(
+            f"API returned an authentication/error response: {data.get('message') or data.get('errorMessage') or 'unknown error'}"
+        )
+        result = {
+            "isURLReputationBlockListEnforced": False,
+            "maliciousUrlEventCount": 0,
+            "blockedMaliciousUrlEventCount": 0,
+        }
+        return create_response(
+            result=result,
+            validation=validation,
+            fail_reasons=["Could not retrieve security events because the API call failed authentication; no evidence of URL reputation block-list enforcement could be gathered."],
+            recommendations=["Verify API credentials (clientId/clientSecret) and retry the /event/query call to confirm URL reputation blocking status."],
+            input_summary={"apiError": True},
+            api_errors=api_errors,
+            metadata={
+                "transformationId": "isURLReputationBlockListEnforced",
+                "vendor": "Check Point Software Technologies Email Security",
+                "category": "emailsecurity",
+            },
+        )
+
+    events = data.get("responseData") or []
+    if not isinstance(events, list):
+        events = []
+
+    malicious_url_events = [
+        e for e in events
+        if isinstance(e, dict) and str(e.get("type") or "").strip().lower() == "malicious url"
+    ]
+
+    blocked_events = []
+    flagged_only_events = []
+    for e in malicious_url_events:
+        state = str(e.get("state") or "").strip().lower()
+        if state in BLOCKING_STATES:
+            blocked_events.append(e)
+        elif state in FLAG_ONLY_STATES:
+            flagged_only_events.append(e)
+        else:
+            actions = e.get("availableEventActions") or []
+            if isinstance(actions, list) and any(
+                str(a).strip().lower() in BLOCKING_STATES for a in actions
+            ):
+                blocked_events.append(e)
+            else:
+                flagged_only_events.append(e)
+
+    total_malicious = len(malicious_url_events)
+    total_blocked = len(blocked_events)
+
+    is_enforced = total_malicious > 0 and total_blocked > 0
+
+    result = {
+        "isURLReputationBlockListEnforced": is_enforced,
+        "maliciousUrlEventCount": total_malicious,
+        "blockedMaliciousUrlEventCount": total_blocked,
+    }
+
+    if is_enforced:
+        sample_ids = [e.get("eventId") for e in blocked_events[:3]]
+        pass_reasons = [
+            f"Found {total_blocked} of {total_malicious} 'Malicious URL' events with a blocking state (e.g. blocked/quarantined/remediated), sample eventIds: {sample_ids}. This confirms URLs matching known-bad reputation lists are blocked at click-time, not merely flagged."
+        ]
+        fail_reasons = []
+        recommendations = []
+    elif total_malicious > 0:
+        pass_reasons = []
+        fail_reasons = [
+            f"Found {total_malicious} 'Malicious URL' events but none carried a blocking state (blocked/quarantined/remediated); observed states were only flag/detect-type, indicating URLs are flagged rather than blocked at click-time."
+        ]
+        recommendations = [
+            "Enable click-time blocking/quarantine action for Malicious URL detections in the Harmony Email and Collaboration policy so matched URLs are blocked rather than only flagged."
+        ]
+    else:
+        pass_reasons = []
+        fail_reasons = [
+            "No 'Malicious URL' type events were found in the queried event set, so no evidence of URL reputation block-list enforcement could be confirmed."
+        ]
+        recommendations = [
+            "Confirm the URL reputation / malicious URL detection engine is enabled and generating events, then verify blocking action is configured."
+        ]
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary={
+            "totalEvents": len(events),
+            "maliciousUrlEventCount": total_malicious,
+            "blockedMaliciousUrlEventCount": total_blocked,
+        },
+        api_errors=api_errors,
+        metadata={
+            "transformationId": "isURLReputationBlockListEnforced",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/messageMoveAuditTrailEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/messageMoveAuditTrailEnabled.py
@@ -1,0 +1,212 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    if not isinstance(data, dict):
+        data = {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("status") == "Error":
+        api_errors.append(
+            "queryEvents returned an authentication/API error: %s"
+            % (data.get("errorMessage") or data.get("message") or "unknown error")
+        )
+
+    items = data.get("responseData") or []
+    if not isinstance(items, list):
+        items = []
+
+    move_action_types = ["quarantine", "restore", "delete", "dismiss", "remediation"]
+
+    total_events = len(items)
+    events_with_actions = 0
+    move_related_events = 0
+    move_related_with_trail = 0
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        actions = item.get("actions")
+        available_actions = item.get("availableEventActions")
+        has_trail = isinstance(actions, list) and len(actions) > 0
+        if has_trail:
+            events_with_actions = events_with_actions + 1
+
+        event_type = str(item.get("type") or "").lower()
+        description = str(item.get("description") or "").lower()
+        is_move_related = False
+        for kw in move_action_types:
+            if kw in event_type or kw in description:
+                is_move_related = True
+                break
+        if not is_move_related and isinstance(available_actions, list):
+            for a in available_actions:
+                a_str = str(a).lower()
+                for kw in move_action_types:
+                    if kw in a_str:
+                        is_move_related = True
+                        break
+                if is_move_related:
+                    break
+
+        if is_move_related:
+            move_related_events = move_related_events + 1
+            if has_trail:
+                move_related_with_trail = move_related_with_trail + 1
+
+    input_summary = {
+        "totalEvents": total_events,
+        "eventsWithActionsArray": events_with_actions,
+        "moveRelatedEvents": move_related_events,
+        "moveRelatedEventsWithTrail": move_related_with_trail,
+    }
+
+    pass_reasons = []
+    fail_reasons = []
+    recommendations = []
+
+    if api_errors:
+        enabled = False
+        fail_reasons.append(
+            "Unable to confirm message-move audit trail: the queryEvents API call failed (%s), so no event 'actions' history could be inspected."
+            % api_errors[0]
+        )
+        recommendations.append(
+            "Verify API credentials (clientId/clientSecret) and re-run the /event/query call to confirm move-action events carry a populated 'actions' audit history array."
+        )
+    elif total_events == 0:
+        enabled = False
+        fail_reasons.append(
+            "queryEvents returned zero events (responseData is empty), so no quarantine/restore/delete action history could be verified."
+        )
+        recommendations.append(
+            "Broaden the /event/query filter criteria or confirm quarantine/restore/delete operations have occurred recently, then re-check that returned events include a non-empty 'actions' array."
+        )
+    elif move_related_events > 0 and move_related_with_trail == move_related_events:
+        enabled = True
+        pass_reasons.append(
+            "All %d quarantine/restore/delete-related events out of %d total events returned by /event/query carry a non-empty 'actions' audit array, confirming every message-move action is logged with an auditable trail."
+            % (move_related_with_trail, total_events)
+        )
+    elif move_related_events > 0 and move_related_with_trail > 0:
+        enabled = False
+        fail_reasons.append(
+            "Only %d of %d quarantine/restore/delete-related events carry a populated 'actions' audit array; some move actions lack a recorded audit trail."
+            % (move_related_with_trail, move_related_events)
+        )
+        recommendations.append(
+            "Investigate why some quarantine/restore/delete events are missing populated 'actions' history and ensure the audit logging pipeline captures every move action."
+        )
+    elif move_related_events > 0 and move_related_with_trail == 0:
+        enabled = False
+        fail_reasons.append(
+            "None of the %d quarantine/restore/delete-related events returned by /event/query carry a populated 'actions' audit array."
+            % move_related_events
+        )
+        recommendations.append(
+            "Confirm the audit-trail feature is enabled for message-move actions; escalate to Check Point support if 'actions' history is never populated."
+        )
+    else:
+        enabled = events_with_actions > 0
+        if enabled:
+            pass_reasons.append(
+                "No explicit quarantine/restore/delete-typed events were found in this query window, but %d of %d returned events carry a populated 'actions' audit array, evidencing the audit-trail mechanism is active."
+                % (events_with_actions, total_events)
+            )
+        else:
+            fail_reasons.append(
+                "No quarantine/restore/delete-typed events were found and none of the %d returned events carry a populated 'actions' audit array."
+                % total_events
+            )
+            recommendations.append(
+                "Perform a quarantine/restore/delete action via the API and re-query to confirm the resulting event includes a populated 'actions' audit trail."
+            )
+
+    result = {
+        "messageMoveAuditTrailEnabled": enabled,
+        "totalEvents": total_events,
+        "moveRelatedEvents": move_related_events,
+        "moveRelatedEventsWithTrail": move_related_with_trail,
+    }
+
+    return create_response(
+        result=result,
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        recommendations=recommendations,
+        input_summary=input_summary,
+        metadata={
+            "transformationId": "messageMoveAuditTrailEnabled",
+            "vendor": "Check Point Software Technologies Email Security",
+            "category": "emailsecurity",
+        },
+        api_errors=api_errors,
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/openQuarantinedMessagesCount.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/openQuarantinedMessagesCount.py
@@ -1,0 +1,124 @@
+import json
+from datetime import datetime
+
+
+def extract_input(input_data):
+    """Extract data and validation from input, handling enriched + legacy formats."""
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        return input_data["data"], input_data["validation"]
+    data = input_data
+    if isinstance(data, dict):
+        wrapper_keys = ["api_response", "response", "result", "apiResponse", "Output"]
+        for _ in range(3):
+            unwrapped = False
+            for key in wrapper_keys:
+                if key in data and isinstance(data.get(key), dict):
+                    data = data[key]
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    validation = {
+        "status": "unknown",
+        "errors": [],
+        "warnings": ["Legacy input format - no schema validation performed"],
+    }
+    return data, validation
+
+
+def create_response(result, validation=None, pass_reasons=None, fail_reasons=None,
+                    recommendations=None, input_summary=None, metadata=None,
+                    transformation_errors=None, api_errors=None, additional_findings=None):
+    """Create the standardized 5-section transformation response."""
+    if validation is None:
+        validation = {"status": "unknown", "errors": [], "warnings": []}
+    api_err_list = api_errors or []
+    transform_err_list = transformation_errors or []
+    data_collection_status = "error" if api_err_list else "success"
+    transformation_status = "error" if transform_err_list else "success"
+    response_metadata = {
+        "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+        "schemaVersion": "2.0",
+    }
+    if metadata:
+        response_metadata.update(metadata)
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {"status": data_collection_status, "errors": api_err_list},
+            "validation": {
+                "status": validation.get("status", "unknown"),
+                "errors": validation.get("errors", []),
+                "warnings": validation.get("warnings", []),
+            },
+            "transformation": {
+                "status": transformation_status,
+                "errors": transform_err_list,
+                "inputSummary": input_summary or {},
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": additional_findings or [],
+            },
+            "metadata": response_metadata,
+        },
+    }
+
+
+def transform(input):
+    data, validation = extract_input(input)
+    data = data if isinstance(data, dict) else {}
+
+    api_errors = []
+    if data.get("error") is True or data.get("statusCode") == 401 or data.get("status") == "Error":
+        error_msg = data.get("errorMessage") or data.get("message") or "Unknown API error"
+        api_errors.append(f"Vendor API error: {error_msg}")
+        return create_response(
+            result={"openQuarantinedMessagesCount": 0},
+            validation=validation,
+            fail_reasons=[f"Could not retrieve quarantine event data due to API error: {error_msg}"],
+            recommendations=["Verify API credentials (clientId/clientSecret) have valid scope for event/query and retry."],
+            input_summary={"apiError": error_msg},
+            api_errors=api_errors,
+            metadata={"transformationId": "openQuarantinedMessagesCount", "vendor": "Check Point Software Technologies Email Security", "category": "emailsecurity"},
+        )
+
+    envelope = data.get("responseEnvelope") or {}
+    items = data.get("responseData") or []
+    if not isinstance(items, list):
+        items = []
+
+    quarantined_in_page = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        state = item.get("state")
+        if isinstance(state, str) and state.lower() == "quarantined":
+            quarantined_in_page = quarantined_in_page + 1
+
+    total_records = envelope.get("totalRecordsNumber")
+
+    if isinstance(total_records, int):
+        count = total_records
+        source_desc = f"responseEnvelope.totalRecordsNumber={total_records} (query filtered on state=quarantined)"
+    else:
+        count = quarantined_in_page
+        source_desc = f"counted {quarantined_in_page} items with state='quarantined' in the returned page (no totalRecordsNumber present)"
+
+    pass_reasons = []
+    fail_reasons = []
+    if count > 0:
+        pass_reasons.append(f"Query for quarantined events returned {count} open quarantined messages ({source_desc}).")
+    else:
+        pass_reasons.append(f"Query for quarantined events returned 0 open quarantined messages ({source_desc}).")
+
+    return create_response(
+        result={"openQuarantinedMessagesCount": count},
+        validation=validation,
+        pass_reasons=pass_reasons,
+        fail_reasons=fail_reasons,
+        input_summary={"totalRecordsNumber": total_records, "itemsInPage": len(items), "quarantinedInPage": quarantined_in_page},
+        metadata={"transformationId": "openQuarantinedMessagesCount", "vendor": "Check Point Software Technologies Email Security", "category": "emailsecurity"},
+    )

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/__init__.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/__init__.py
@@ -1,0 +1,43 @@
+"""Schema registry for this vendor's transformations."""
+
+from .isAccountTakeoverDetectionEnabled import IsAccountTakeoverDetectionEnabledInput
+from .isAntiPhishingEnabled import IsAntiPhishingEnabledInput
+from .isAntivirusVerdictEngineEnabled import IsAntivirusVerdictEngineEnabledInput
+from .isCloudDataLeakPreventionEnabled import IsCloudDataLeakPreventionEnabledInput
+from .isFlexibleSecurityEventQueryEnabled import IsFlexibleSecurityEventQueryEnabledInput
+from .isImposterEmailDetectionEnabled import IsImposterEmailDetectionEnabledInput
+from .isLinkedO365AccountActive import IsLinkedO365AccountActiveInput
+from .isMaliciousClickBlockingEnabled import IsMaliciousClickBlockingEnabledInput
+from .isPostDeliveryQuarantineEnabled import IsPostDeliveryQuarantineEnabledInput
+from .isQuarantineRestoreWorkflowAutomated import IsQuarantineRestoreWorkflowAutomatedInput
+from .isScopedAPIAuthTokenManaged import IsScopedAPIAuthTokenManagedInput
+from .isShadowITDiscoveryEnabled import IsShadowITDiscoveryEnabledInput
+from .isSingleActionMultiEntityRemediationEnabled import IsSingleActionMultiEntityRemediationEnabledInput
+from .isSingleEntityForensicRetrievalEnabled import IsSingleEntityForensicRetrievalEnabledInput
+from .isThreatInvestigationSweepEnabled import IsThreatInvestigationSweepEnabledInput
+from .isThreatMitigationActionAPIEnabled import IsThreatMitigationActionAPIEnabledInput
+from .isURLReputationBlockListEnforced import IsURLReputationBlockListEnforcedInput
+from .messageMoveAuditTrailEnabled import MessageMoveAuditTrailEnabledInput
+from .openQuarantinedMessagesCount import OpenQuarantinedMessagesCountInput
+
+__all__ = [
+    "IsAccountTakeoverDetectionEnabledInput",
+    "IsAntiPhishingEnabledInput",
+    "IsAntivirusVerdictEngineEnabledInput",
+    "IsCloudDataLeakPreventionEnabledInput",
+    "IsFlexibleSecurityEventQueryEnabledInput",
+    "IsImposterEmailDetectionEnabledInput",
+    "IsLinkedO365AccountActiveInput",
+    "IsMaliciousClickBlockingEnabledInput",
+    "IsPostDeliveryQuarantineEnabledInput",
+    "IsQuarantineRestoreWorkflowAutomatedInput",
+    "IsScopedAPIAuthTokenManagedInput",
+    "IsShadowITDiscoveryEnabledInput",
+    "IsSingleActionMultiEntityRemediationEnabledInput",
+    "IsSingleEntityForensicRetrievalEnabledInput",
+    "IsThreatInvestigationSweepEnabledInput",
+    "IsThreatMitigationActionAPIEnabledInput",
+    "IsURLReputationBlockListEnforcedInput",
+    "MessageMoveAuditTrailEnabledInput",
+    "OpenQuarantinedMessagesCountInput",
+]

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAccountTakeoverDetectionEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAccountTakeoverDetectionEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsAccountTakeoverDetectionEnabledInput(BaseModel):
+    """Input schema for the isAccountTakeoverDetectionEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAntiPhishingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAntiPhishingEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsAntiPhishingEnabledInput(BaseModel):
+    """Input schema for the isAntiPhishingEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAntivirusVerdictEngineEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isAntivirusVerdictEngineEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsAntivirusVerdictEngineEnabledInput(BaseModel):
+    """Input schema for the isAntivirusVerdictEngineEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isCloudDataLeakPreventionEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isCloudDataLeakPreventionEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsCloudDataLeakPreventionEnabledInput(BaseModel):
+    """Input schema for the isCloudDataLeakPreventionEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isFlexibleSecurityEventQueryEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isFlexibleSecurityEventQueryEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsFlexibleSecurityEventQueryEnabledInput(BaseModel):
+    """Input schema for the isFlexibleSecurityEventQueryEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isImposterEmailDetectionEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isImposterEmailDetectionEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsImposterEmailDetectionEnabledInput(BaseModel):
+    """Input schema for the isImposterEmailDetectionEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isLinkedO365AccountActive.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isLinkedO365AccountActive.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsLinkedO365AccountActiveInput(BaseModel):
+    """Input schema for the isLinkedO365AccountActive transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isMaliciousClickBlockingEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isMaliciousClickBlockingEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsMaliciousClickBlockingEnabledInput(BaseModel):
+    """Input schema for the isMaliciousClickBlockingEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isPostDeliveryQuarantineEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isPostDeliveryQuarantineEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsPostDeliveryQuarantineEnabledInput(BaseModel):
+    """Input schema for the isPostDeliveryQuarantineEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isQuarantineRestoreWorkflowAutomated.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isQuarantineRestoreWorkflowAutomated.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsQuarantineRestoreWorkflowAutomatedInput(BaseModel):
+    """Input schema for the isQuarantineRestoreWorkflowAutomated transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isScopedAPIAuthTokenManaged.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isScopedAPIAuthTokenManaged.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsScopedAPIAuthTokenManagedInput(BaseModel):
+    """Input schema for the isScopedAPIAuthTokenManaged transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isShadowITDiscoveryEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isShadowITDiscoveryEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsShadowITDiscoveryEnabledInput(BaseModel):
+    """Input schema for the isShadowITDiscoveryEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSingleActionMultiEntityRemediationEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSingleActionMultiEntityRemediationEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsSingleActionMultiEntityRemediationEnabledInput(BaseModel):
+    """Input schema for the isSingleActionMultiEntityRemediationEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSingleEntityForensicRetrievalEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isSingleEntityForensicRetrievalEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsSingleEntityForensicRetrievalEnabledInput(BaseModel):
+    """Input schema for the isSingleEntityForensicRetrievalEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isThreatInvestigationSweepEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isThreatInvestigationSweepEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsThreatInvestigationSweepEnabledInput(BaseModel):
+    """Input schema for the isThreatInvestigationSweepEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isThreatMitigationActionAPIEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isThreatMitigationActionAPIEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsThreatMitigationActionAPIEnabledInput(BaseModel):
+    """Input schema for the isThreatMitigationActionAPIEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isURLReputationBlockListEnforced.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/isURLReputationBlockListEnforced.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class IsURLReputationBlockListEnforcedInput(BaseModel):
+    """Input schema for the isURLReputationBlockListEnforced transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/messageMoveAuditTrailEnabled.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/messageMoveAuditTrailEnabled.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class MessageMoveAuditTrailEnabledInput(BaseModel):
+    """Input schema for the messageMoveAuditTrailEnabled transformation."""
+
+    class Config:
+        extra = "allow"

--- a/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/openQuarantinedMessagesCount.py
+++ b/safeguards/emailsecurity/check-point-software-technologies-email-security/schemas/openQuarantinedMessagesCount.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class OpenQuarantinedMessagesCountInput(BaseModel):
+    """Input schema for the openQuarantinedMessagesCount transformation."""
+
+    class Config:
+        extra = "allow"


### PR DESCRIPTION
## Summary

This PR ships 19 transformation scripts for the **Check Point Software Technologies Email Security** (Harmony Email and Collaboration) integration, covering threat-detection engine evidence, remediation/API workflow capability, and API-credential governance for the emailsecurity category. These scripts are the evaluation layer behind the new HEC vendor onboarding -- each one parses `queryEvents`, `actionOnEntity`, `searchEntityById`, or `generateApiAccessToken` responses into a pass/fail safeguard verdict.

**Context:** Generated by the V2 onboarding pipeline for a net-new Check Point Email Security integration; the scripts fill the emailsecurity safeguard category's threat-detection, remediation-workflow, and API-governance gaps for this vendor.

## What each transformation does

### `isAccountTakeoverDetectionEnabled.py`
Confirms the anomaly/account-takeover detection engine is active by looking for anomaly-labeled events.
- **Consumes:** `queryEvents` (POST `/event/query`)
- **Pass criteria:** At least one returned event has `type` or `description` containing an ATO-related token (`anomaly`, `account takeover`, `impossible travel`, etc.)
- **Key edge cases handled:**
  - Authentication/API errors (`error: true`, `statusCode: 401`, `status: Error`) short-circuit to a fail with a distinct "could not confirm" reason rather than a false negative.
  - Non-list `responseData` is coerced to an empty list rather than raising.

### `isAntiPhishingEnabled.py`
Confirms the anti-phishing detection engine is active via presence of Phishing-typed events.
- **Consumes:** `queryEvents` (POST `/event/query`) -- `type` field confirmed by vendor docs to include `"dlp"`-style category strings on event records.
- **Pass criteria:** `phishingEventCount > 0`, i.e. at least one event with `type` containing `"phish"`.
- **Key edge cases handled:**
  - Auth/API error path returns early with `isAntiPhishingEnabled: False` and a dedicated fail reason instead of silently treating an error response as "no phishing events."
  - `responseEnvelope.totalRecordsNumber` is surfaced in the fail message so reviewers can distinguish "zero events returned" from "events returned but none phishing."

### `isAntivirusVerdictEngineEnabled.py`
Confirms a dedicated signature-based AV verdict is recorded on malware events, independent of sandbox/AI verdicts.
- **Consumes:** `queryEvents` (POST `/event/query`)
- **Pass criteria:** At least one `type == "malware"` event has a non-empty `combinedVerdict.av` field.
- **Key edge cases handled:**
  - Distinguishes "no malware events at all" from "malware events present but no AV verdict populated" with separate fail reasons/recommendations.
  - API errors are appended as an additional fail reason without discarding any malware-event evidence already gathered.

### `isCloudDataLeakPreventionEnabled.py`
Confirms the DLP engine evaluated messages and recorded a verdict.
- **Consumes:** `queryEvents` (POST `/event/query`) -- vendor's own sample response explicitly shows `"type": "dlp"` on an event record with a `description` field describing the detected leak.
- **Pass criteria:** At least one `type == "dlp"` event AND at least one of those carries `state`, `confidenceIndicator`, or `severity`.
- **Key edge cases handled:**
  - Requires both DLP-typed events *and* a populated verdict field -- a DLP-typed event with no verdict field does not pass, avoiding a false positive on partially-populated data.
  - API error path (`error: true` / `status: Error`) is checked first and produces a distinct fail reason before touching event data.

### `isFlexibleSecurityEventQueryEnabled.py`
Confirms the POST `/event/query` flexible multi-criteria query endpoint is reachable and functional.
- **Consumes:** `queryEvents` (POST `/event/query`) -- confirmed by vendor docs as the endpoint to "retrieve a specific security event or multiple events by flexible query criteria."
- **Pass criteria:** Response contains a `responseEnvelope`/`responseData` key (even if `responseData` is empty), and no error flag was set.
- **Key edge cases handled:**
  - Passes even on a zero-result query as long as the documented envelope/data structure is present, correctly distinguishing "query mechanism works, no matches" from "query mechanism broken."
  - `error` flag is checked before the structural check, so an auth failure fails loud rather than being masked by an empty-but-structurally-valid response.

### `isImposterEmailDetectionEnabled.py`
Confirms the AI anti-phishing/impersonation engine issues per-message imposter verdicts.
- **Consumes:** `queryEvents` (POST `/event/query`)
- **Pass criteria:** At least one `type == "phishing"` event OR one event whose `type`/`description` contains an imposter/BEC keyword (`imposter`, `impersonation`, `bec`, `spoof`, etc.).
- **Key edge cases handled:**
  - Auth error (`error`, `statusCode == 401`, `status == "Error"`) returns immediately with a dedicated api_errors entry rather than falling through to the "no events found" fail branch.
  - `responseEnvelope.totalRecordsNumber` falls back to `len(items)` when the envelope is absent.

### `isLinkedO365AccountActive.py`
Confirms a linked O365 tenant is actively streaming entities/events.
- **Consumes:** `queryEvents` (POST `/event/query`) -- vendor's documented sample response includes `"saas": "office365_emails"` on event records, confirming the field.
- **Pass criteria:** At least one returned event's `saas` field contains `"office365"` or `"o365"`.
- **Key edge cases handled:**
  - API error and "zero O365 events" are reported with distinct fail reasons/recommendations rather than collapsed into one generic failure.

### `isMaliciousClickBlockingEnabled.py`
Confirms malicious-URL click-time events are actively blocked, not just logged.
- **Consumes:** `queryEvents` (POST `/event/query`) -- `availableEventActions` array with `actionName`/`actionParameter` entries is confirmed in the vendor's documented event-query response sample.
- **Pass criteria:** At least one `type` containing `"malicious url"` event has a block-family token (`block`, `quarantine`, `remove`, `restrict`, `disable`) in its `state` or `actions`/`availableEventActions`.
- **Key edge cases handled:**
  - Zero "Malicious URL" events returns a distinct early response (`total_malicious == 0`) rather than a generic false, since absence of evidence differs from evidence of logging-only behavior.
  - Separately tracks `logged_only_count` (log/dismiss/acknowledge tokens) to give a specific "logged but not blocked" fail reason.

### `isPostDeliveryQuarantineEnabled.py`
Confirms messages verdicted malicious after delivery can be retroactively quarantined.
- **Consumes:** `queryEvents` (POST `/event/query`)
- **Pass criteria:** At least one event's `availableEventActions` contains a quarantine/restore/remediate action token.
- **Key edge cases handled:**
  - Three distinct early-return branches: API error, zero events, and "events present but no quarantine action" -- each with its own fail reason/recommendation instead of a single collapsed message.
  - `state` values (`quarantined`, `dismissed`, `remediated`, `malicious`) are tracked separately from action-availability to report both signals in `input_summary`.

### `isQuarantineRestoreWorkflowAutomated.py`
Confirms quarantine-restore requests are routed through an asynchronous automated task queue rather than manual triage.
- **Consumes:** `actionOnEntity` (POST `/action/entity`) -- vendor docs confirm the response includes `responseEnvelope`/`responseData` with per-entity result codes; this script additionally expects a `taskId` for async tracking.
- **Pass criteria:** At least one `responseData` item contains a non-empty `taskId`.
- **Key edge cases handled:**
  - Handles `responseData` as either a list or a single dict (normalizes to a list of items).
  - `statusCode == 401` / `error` is treated as a hard fail with a credential-verification recommendation rather than assumed to indicate "no automation."

### `isScopedAPIAuthTokenManaged.py`
Confirms tenant API access uses a scoped, rotatable OAuth token exchange rather than a static shared secret.
- **Consumes:** `generateApiAccessToken` (POST `https://cloudinfra-gw.portal.checkpoint.com/auth/external`)
- **Pass criteria:** Response's `data.token` and `data.expiresIn` are both present/non-null.
- **Key edge cases handled:**
  - Distinguishes an `errorType == "authentication"` failure (fails with a credential-verification recommendation) from a structurally malformed success response (fails with a "token/expiresIn missing" reason listing the actual top-level keys received) -- gives reviewers a concrete diagnostic either way.

### `isShadowITDiscoveryEnabled.py`
Confirms Shadow IT discovery detections are being generated.
- **Consumes:** `queryEvents` (POST `/event/query`) -- Shadow IT as an event `description`/label category is corroborated by third-party SIEM integration samples showing `"label": "Shadow IT"` on Check Point HEC event payloads.
- **Pass criteria:** At least one event's `type` or `description` contains `"shadow it"`.
- **Key edge cases handled:**
  - API-error and zero-matching-event paths produce separate fail reasons/recommendations.

### `isSingleActionMultiEntityRemediationEnabled.py`
Confirms a single remediation action can be fanned out across multiple entities in one API call.
- **Consumes:** `actionOnEntity` (POST `/action/entity`) -- vendor docs confirm the request body accepts an `entityIds` array and the response returns a per-entityId result in `responseData`.
- **Pass criteria:** `entitiesTouched > 1` (multiple `entityId`/`taskId` pairs in one response) triggers a definitive pass; a single-entity response still passes on the grounds that the documented contract supports arrays even if only one ID was tested.
- **Key edge cases handled:**
  - On auth failure with zero entities touched, the script still returns `True` (endpoint's documented multi-entity contract) but flags the gap in `recommendations` as "live verification failed" -- this is a notable design choice: it credits the *documented* capability over a failed live probe, which reviewers should sanity-check against the live-validation evidence for this criterion (passed, HTTP 200, so not triggered in production but worth flagging for future regressions).

### `isSingleEntityForensicRetrievalEnabled.py`
Confirms full forensic detail for one entity can be retrieved via a dedicated single-entity API call.
- **Consumes:** `searchEntityById` (GET `/search/entity/{entityId}`) -- vendor docs confirm this endpoint returns entity detail fields including message metadata, links, attachments, recipients, sender, and SPF result.
- **Pass criteria:** Response's `responseData` has a non-null `entityId` or `messageId`.
- **Key edge cases handled:**
  - Reports which of the expected forensic fields (`messageId`, `size`, `links`, `attachments`, `recipients`, `sender`, `senderDomain`, `senderDisplayName`, `spfResult`) were actually present, rather than a bare boolean.
  - Error responses (`error` / `status == "Error"`) fail with the actual `statusCode` surfaced.

### `isThreatInvestigationSweepEnabled.py`
Confirms the flexible event-query API can sweep historical events across the mailbox estate for investigation purposes.
- **Consumes:** `queryEvents` (POST `/event/query`)
- **Pass criteria:** Events are returned, OR the response has the documented `responseEnvelope`/`responseData` structure even with zero matches.
- **Key edge cases handled:**
  - Same graceful "structure valid, zero matches" pass logic as `isFlexibleSecurityEventQueryEnabled`, appropriately reused since both criteria hinge on the same query mechanism.

### `isThreatMitigationActionAPIEnabled.py`
Confirms remediation actions (quarantine/delete/restore) can be triggered on flagged entities via API.
- **Consumes:** `actionOnEntity` (POST `/action/entity`)
- **Pass criteria:** Response contains at least one `taskId` or `entityId` in `responseData`, and no error/4xx status.
- **Key edge cases handled:**
  - `responseData` normalized from list-of-dicts or single-dict.
  - Distinguishes "API call errored" from "API call succeeded but returned no confirmation data" with separate fail reasons.

### `isURLReputationBlockListEnforced.py`
Confirms URLs matching known-bad reputation lists are blocked at click-time, not merely flagged.
- **Consumes:** `queryEvents` (POST `/event/query`)
- **Pass criteria:** At least one `type == "malicious url"` event has `state` in a blocking-state set (`blocked`, `quarantined`, `remediated`, `removed`, `deleted`) or a blocking action in `availableEventActions`.
- **Key edge cases handled:**
  - Three-way outcome: enforced (blocked), detected-but-not-enforced (flag-only states), or no evidence at all (zero Malicious URL events) -- each with a distinct fail reason.

### `messageMoveAuditTrailEnabled.py`
Confirms quarantine/restore/delete actions are logged with an auditable trail per event.
- **Consumes:** `queryEvents` (POST `/event/query`) -- vendor's documented event sample shows an `availableEventActions` array recording actions like `dismiss`/`severityChange` per event, which this script treats as the audit-trail evidence via the `actions` field.
- **Pass criteria:** All move-related events (`type`/`description`/`availableEventActions` containing `quarantine`/`restore`/`delete`/`dismiss`/`remediation`) have a non-empty `actions` array; partial coverage fails.
- **Key edge cases handled:**
  - Five distinct branches (API error, zero events, full trail coverage, partial coverage, zero coverage, no move-related events but general `actions` present) each produce a tailored fail/pass reason -- this is the most granular outcome logic among the batch.

### `openQuarantinedMessagesCount.py`
Returns the count of messages currently in quarantine awaiting review/restore.
- **Consumes:** `queryEvents` (POST `/event/query`, filtered to `state=quarantined`) -- `responseEnvelope.totalRecordsNumber` is the vendor-documented aggregate count field.
- **Pass criteria:** N/A (count metric, not boolean) -- returns `totalRecordsNumber` if present, else counts `state == "quarantined"` items in the current page as a fallback.
- **Key edge cases handled:**
  - Falls back to manual per-page counting when `totalRecordsNumber` is absent (e.g. legacy response shape), and records which counting method was used in `source_desc` for auditability.
  - API error path returns `count: 0` explicitly rather than `None`, keeping the metric type-stable downstream.

## Architecture notes

All 19 scripts share the same `extract_input` -> `transform` -> `create_response` contract: `extract_input` unwraps legacy/enriched envelopes and returns `(data, validation)`; `create_response` assembles the standardized 5-section payload (`dataCollection`, `validation`, `transformation`, `evaluation` with `passReasons`/`failReasons`/`recommendations`/`additionalFindings`, and `metadata`) under `schemaVersion: 2.0`. Every script checks for vendor error envelopes (`error`, `statusCode`, `errorType`, `status`) before evaluating business logic, so RestrictedPython sandboxing constraints (no arbitrary imports beyond `json`/`datetime`) are consistently respected.

## Test plan

- [ ] Verify `evaluate()`/`transform()` returns correct result for: valid multi-event data, empty `responseData`, and API error envelopes (`error: true`, `statusCode: 401`, `status: Error`) for each of the 19 scripts
- [ ] Confirm `data.get("responseData")`, `data.get("responseEnvelope")`, and nested `combinedVerdict.av` / `availableEventActions` field names match the current HEC API Reference Guide sample payloads
- [ ] Spot-check `isSingleActionMultiEntityRemediationEnabled.py`'s auth-failure branch (returns `True` on documented-but-unverified capability) against future live-validation runs to confirm it doesn't mask a genuine regression
- [ ] Confirm `openQuarantinedMessagesCount.py`'s dual counting paths (`totalRecordsNumber` vs. page-level fallback) both produce a non-negative integer

🤖 Generated by Spektrum integration onboarding pipeline