### PR TITLE
LABS-3319: add SonicWall local-account MFA transformations

### DIFF
--- a/safeguards/firewall/sonicwall/conftest.py
+++ b/safeguards/firewall/sonicwall/conftest.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent
+FIXTURES = ROOT / "fixtures"
+
+
+def load_module(filename, directory=None):
+    path = (directory or ROOT) / filename
+    spec = importlib.util.spec_from_file_location("sonicwall_" + path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def otp(method):
+    if method == "totp":
+        return {"totp": True}
+    if method == "email":
+        return {"otp": True}
+    if method == "unknown":
+        return None
+    return {"otp": False}
+
+
+def user(name, method="none", groups=None, expired=False, domain=None,
+         vendor_uuid=None, email_address=None, include_state=True):
+    record = {"name": name, "one_time_password": otp(method)}
+    if include_state:
+        record["account_lifetime"] = {"expired": expired}
+    if groups is not None:
+        record["member_of"] = [{"name": group} for group in groups]
+    if domain is not None:
+        record["domain"] = domain
+    if vendor_uuid is not None:
+        record["uuid"] = vendor_uuid
+    if email_address is not None:
+        record["email_address"] = email_address
+    return record
+
+
+def group(name, method="none", members=None):
+    record = {"name": name, "one_time_password": otp(method)}
+    if members is not None:
+        record["member"] = [{"name": member} for member in members]
+    return record
+
+
+def envelope(users=None, groups=None, admin=None, contract="gen7-split"):
+    users = users or []
+    groups = groups or []
+    admin = admin or {"name": "built-in-administrator", "one_time_password": {"totp": True}}
+    local_users = {"user": {"local": {"user": users}}}
+    evidence = {"localUsers": local_users, "administrationGlobal": {"administration": {"administration": {"admin": admin}}}}
+    if contract == "gen6-combined":
+        local_users["user"]["local"]["group"] = groups
+    else:
+        evidence["localGroups"] = {"user": {"local": {"group": groups}}}
+    return {
+        "source": {"vendor": "SonicWall", "product": "SonicOS",
+                   "firmwareVersion": "6.5.4.8" if contract.startswith("gen6") else "7.x",
+                   "apiContract": contract, "authenticationMode": "basicSession"},
+        "collection": {"requiredEndpointsSucceeded": True,
+                       "capabilityProfileRecognized": True,
+                       "allExpectedResponseSectionsPresent": True, "errors": []},
+        "counts": {"rawUserEntries": len(users), "rawGroupEntries": len(groups)},
+        "evidence": evidence,
+    }
+
+
+def fixture_envelope(contract):
+    admin = json.loads((FIXTURES / (contract + "-administration-global.json")).read_text())
+    if contract == "gen6-combined":
+        combined = json.loads((FIXTURES / "gen6-combined-user-local.json").read_text())
+        users = combined["user"]["local"]["user"]
+        groups = combined["user"]["local"]["group"]
+        evidence = {"localUsers": combined, "administrationGlobal": admin}
+    else:
+        users_body = json.loads((FIXTURES / (contract + "-users.json")).read_text())
+        groups_body = json.loads((FIXTURES / (contract + "-groups.json")).read_text())
+        users = users_body["user"]["local"]["user"]
+        groups = groups_body["user"]["local"]["group"]
+        evidence = {"localUsers": users_body, "localGroups": groups_body, "administrationGlobal": admin}
+    return {
+        "source": {"vendor": "SonicWall", "product": "SonicOS",
+                   "firmwareVersion": "6.5.4.8" if contract.startswith("gen6") else "7.x",
+                   "apiContract": contract, "authenticationMode": "basicSession"},
+        "collection": {"requiredEndpointsSucceeded": True,
+                       "capabilityProfileRecognized": True,
+                       "allExpectedResponseSectionsPresent": True, "errors": []},
+        "counts": {"rawUserEntries": len(users), "rawGroupEntries": len(groups)},
+        "evidence": evidence,
+    }

--- a/safeguards/firewall/sonicwall/fixtures/gen6-combined-administration-global.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen6-combined-administration-global.json
@@ -1,0 +1,12 @@
+{
+  "administration": {
+    "administration": {
+      "admin": {
+        "name": "synthetic-built-in-admin",
+        "one_time_password": {
+          "totp": true
+        }
+      }
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/fixtures/gen6-combined-user-local.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen6-combined-user-local.json
@@ -1,0 +1,301 @@
+{
+  "user": {
+    "local": {
+      "group": [
+        {
+          "name": "Synthetic Email OTP Group",
+          "one_time_password": {
+            "otp": true
+          },
+          "member": [
+            {
+              "name": "synthetic-user-inherited-email"
+            },
+            {
+              "name": "synthetic-user-inherited-email"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Nested Parent",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Nested Child"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Nested Child",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-user-inherited-nested"
+            }
+          ]
+        },
+        {
+          "name": "SonicWall Administrators",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "synthetic-additional-admin"
+            },
+            {
+              "name": "Synthetic Full Admin Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Full Admin Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-full-admin-nested"
+            }
+          ]
+        },
+        {
+          "name": "SSLVPN Services",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-additional-admin"
+            },
+            {
+              "name": "Synthetic VPN Delegates"
+            }
+          ]
+        },
+        {
+          "name": "SonicWall Read-Only Admins",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Read-Only Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Read-Only Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-read-only-admin"
+            }
+          ]
+        },
+        {
+          "name": "Limited Administrators",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Limited Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Limited Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-limited-admin"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic VPN Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-vpn-nested"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Cycle A",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "Synthetic Cycle B"
+            },
+            {
+              "name": "synthetic-user-cycle"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Cycle B",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "Synthetic Cycle A"
+            }
+          ]
+        }
+      ],
+      "user": [
+        {
+          "name": "synthetic-user-direct-email",
+          "one_time_password": {
+            "otp": true
+          }
+        },
+        {
+          "name": "synthetic-user-direct-totp",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-user-inherited-email",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Email OTP Group"
+            },
+            {
+              "name": "Synthetic Email OTP Group"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-inherited-nested",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Nested Child"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-expired",
+          "one_time_password": {
+            "otp": false
+          },
+          "account_lifetime": {
+            "expired": true
+          }
+        },
+        {
+          "name": "synthetic-user-unknown-state",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-additional-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "SonicWall Administrators"
+            },
+            {
+              "name": "SSLVPN Services"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-cycle",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Cycle A"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-service-backup-agent",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-domain-proxy",
+          "domain": {
+            "name": "synthetic.example"
+          },
+          "one_time_password": {
+            "otp": false
+          }
+        },
+        {
+          "name": "synthetic-read-only-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Read-Only Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-limited-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Limited Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-vpn-nested",
+          "one_time_password": {
+            "totp": true
+          },
+          "member_of": [
+            {
+              "name": "Synthetic VPN Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-full-admin-nested",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Full Admin Delegates"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/fixtures/gen6-split-administration-global.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen6-split-administration-global.json
@@ -1,0 +1,12 @@
+{
+  "administration": {
+    "administration": {
+      "admin": {
+        "name": "synthetic-built-in-admin",
+        "one_time_password": {
+          "totp": true
+        }
+      }
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/fixtures/gen6-split-groups.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen6-split-groups.json
@@ -1,0 +1,163 @@
+{
+  "user": {
+    "local": {
+      "group": [
+        {
+          "name": "Synthetic Email OTP Group",
+          "one_time_password": {
+            "otp": true
+          },
+          "member": [
+            {
+              "name": "synthetic-user-inherited-email"
+            },
+            {
+              "name": "synthetic-user-inherited-email"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Nested Parent",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Nested Child"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Nested Child",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-user-inherited-nested"
+            }
+          ]
+        },
+        {
+          "name": "SonicWall Administrators",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "synthetic-additional-admin"
+            },
+            {
+              "name": "Synthetic Full Admin Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Full Admin Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-full-admin-nested"
+            }
+          ]
+        },
+        {
+          "name": "SSLVPN Services",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-additional-admin"
+            },
+            {
+              "name": "Synthetic VPN Delegates"
+            }
+          ]
+        },
+        {
+          "name": "SonicWall Read-Only Admins",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Read-Only Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Read-Only Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-read-only-admin"
+            }
+          ]
+        },
+        {
+          "name": "Limited Administrators",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Limited Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Limited Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-limited-admin"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic VPN Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-vpn-nested"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Cycle A",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "Synthetic Cycle B"
+            },
+            {
+              "name": "synthetic-user-cycle"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Cycle B",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "Synthetic Cycle A"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/fixtures/gen6-split-users.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen6-split-users.json
@@ -1,0 +1,144 @@
+{
+  "user": {
+    "local": {
+      "user": [
+        {
+          "name": "synthetic-user-direct-email",
+          "one_time_password": {
+            "otp": true
+          }
+        },
+        {
+          "name": "synthetic-user-direct-totp",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-user-inherited-email",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Email OTP Group"
+            },
+            {
+              "name": "Synthetic Email OTP Group"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-inherited-nested",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Nested Child"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-expired",
+          "one_time_password": {
+            "otp": false
+          },
+          "account_lifetime": {
+            "expired": true
+          }
+        },
+        {
+          "name": "synthetic-user-unknown-state",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-additional-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "SonicWall Administrators"
+            },
+            {
+              "name": "SSLVPN Services"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-cycle",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Cycle A"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-service-backup-agent",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-domain-proxy",
+          "domain": {
+            "name": "synthetic.example"
+          },
+          "one_time_password": {
+            "otp": false
+          }
+        },
+        {
+          "name": "synthetic-read-only-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Read-Only Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-limited-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Limited Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-vpn-nested",
+          "one_time_password": {
+            "totp": true
+          },
+          "member_of": [
+            {
+              "name": "Synthetic VPN Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-full-admin-nested",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Full Admin Delegates"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/fixtures/gen7-split-administration-global.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen7-split-administration-global.json
@@ -1,0 +1,12 @@
+{
+  "administration": {
+    "administration": {
+      "admin": {
+        "name": "synthetic-built-in-admin",
+        "one_time_password": {
+          "totp": true
+        }
+      }
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/fixtures/gen7-split-groups.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen7-split-groups.json
@@ -1,0 +1,163 @@
+{
+  "user": {
+    "local": {
+      "group": [
+        {
+          "name": "Synthetic Email OTP Group",
+          "one_time_password": {
+            "otp": true
+          },
+          "member": [
+            {
+              "name": "synthetic-user-inherited-email"
+            },
+            {
+              "name": "synthetic-user-inherited-email"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Nested Parent",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Nested Child"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Nested Child",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-user-inherited-nested"
+            }
+          ]
+        },
+        {
+          "name": "SonicWall Administrators",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "synthetic-additional-admin"
+            },
+            {
+              "name": "Synthetic Full Admin Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Full Admin Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-full-admin-nested"
+            }
+          ]
+        },
+        {
+          "name": "SSLVPN Services",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-additional-admin"
+            },
+            {
+              "name": "Synthetic VPN Delegates"
+            }
+          ]
+        },
+        {
+          "name": "SonicWall Read-Only Admins",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Read-Only Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Read-Only Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-read-only-admin"
+            }
+          ]
+        },
+        {
+          "name": "Limited Administrators",
+          "one_time_password": {
+            "totp": true
+          },
+          "member": [
+            {
+              "name": "Synthetic Limited Delegates"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Limited Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-limited-admin"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic VPN Delegates",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "synthetic-vpn-nested"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Cycle A",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "Synthetic Cycle B"
+            },
+            {
+              "name": "synthetic-user-cycle"
+            }
+          ]
+        },
+        {
+          "name": "Synthetic Cycle B",
+          "one_time_password": {
+            "otp": false
+          },
+          "member": [
+            {
+              "name": "Synthetic Cycle A"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/fixtures/gen7-split-users.json
+++ b/safeguards/firewall/sonicwall/fixtures/gen7-split-users.json
@@ -1,0 +1,142 @@
+{
+  "user": {
+    "local": {
+      "user": [
+        {
+          "name": "synthetic-user-direct-email",
+          "one_time_password": {
+            "otp": true
+          }
+        },
+        {
+          "name": "synthetic-user-direct-totp",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-user-inherited-email",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Email OTP Group"
+            },
+            {
+              "name": "Synthetic Email OTP Group"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-inherited-nested",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Nested Child"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-expired",
+          "one_time_password": {
+            "otp": false
+          },
+          "account_lifetime": {
+            "expired": true
+          }
+        },
+        {
+          "name": "synthetic-user-unknown-state",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-additional-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "SonicWall Administrators"
+            },
+            {
+              "name": "SSLVPN Services"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-user-cycle",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Cycle A"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-service-backup-agent",
+          "one_time_password": {
+            "totp": true
+          }
+        },
+        {
+          "name": "synthetic-domain-proxy",
+          "domain": "synthetic.example",
+          "one_time_password": {
+            "otp": false
+          }
+        },
+        {
+          "name": "synthetic-read-only-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Read-Only Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-limited-admin",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Limited Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-vpn-nested",
+          "one_time_password": {
+            "totp": true
+          },
+          "member_of": [
+            {
+              "name": "Synthetic VPN Delegates"
+            }
+          ]
+        },
+        {
+          "name": "synthetic-full-admin-nested",
+          "one_time_password": {
+            "otp": false
+          },
+          "member_of": [
+            {
+              "name": "Synthetic Full Admin Delegates"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/safeguards/firewall/sonicwall/hasidentifiedserviceaccountsmfagap.py
+++ b/safeguards/firewall/sonicwall/hasidentifiedserviceaccountsmfagap.py
@@ -1,0 +1,249 @@
+"""Identify configured MFA gaps among conservatively named SonicOS service accounts."""
+
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "hasIdentifiedServiceAccountsMFAGap"
+CONTRACTS = ("gen6-combined", "gen6-split", "gen7-split")
+AUTH_MODES = ("basicSession", "digestSession", "tfaBearer")
+ADMIN_GROUPS = ("sonicwall administrators", "sonicwall read-only admins", "limited administrators")
+SERVICE_PREFIXES = ("svc-", "service-", "api-", "bot-", "automation-")
+
+
+def empty_counts():
+    return {"serviceCandidateAccounts": 0, "candidatesWithConfiguredMFA": 0,
+            "candidatesWithoutConfiguredMFA": 0, "administratorCandidates": 0,
+            "expiredCandidates": 0, "excludedDomainProxies": 0, "unknownAccounts": 0}
+
+
+def response(has_gap, counts=None, validation_status="passed", validation_errors=None,
+             collection_errors=None, transformation_errors=None, pass_reasons=None,
+             fail_reasons=None, recommendations=None):
+    counts = counts or empty_counts(); result = {CRITERIA_KEY: has_gap}; result.update(counts)
+    return {"transformedResponse": result, "additionalInfo": {
+        "dataCollection": {"status": "error" if collection_errors else "success", "errors": collection_errors or []},
+        "validation": {"status": validation_status, "errors": validation_errors or [], "warnings": []},
+        "transformation": {"status": "error" if transformation_errors else "success", "errors": transformation_errors or [], "inputSummary": counts},
+        "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": ["SonicOS settings show MFA configuration; they do not prove enforcement during authentication."]},
+        "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "2.0", "transformationId": CRITERIA_KEY, "vendor": "SonicWall", "category": "Firewall"}}}
+
+
+def normalized(value):
+    if not isinstance(value, str): return None
+    value = value.strip().lower()
+    return value if value else None
+
+
+def nested(data, path):
+    for key in path:
+        if not isinstance(data, dict) or key not in data: return None
+        data = data.get(key)
+    return data
+
+
+def unpack(value):
+    unknown = {"status": "unknown", "errors": [], "warnings": []}
+    if isinstance(value, dict) and "data" in value and "validation" in value:
+        if "source" in value or "collection" in value or "counts" in value or "evidence" in value:
+            return None, unknown, True
+        return value.get("data"), value.get("validation") or unknown, True
+    data = value
+    if isinstance(data, dict) and ("source" in data or "collection" in data or "counts" in data or "evidence" in data):
+        return data, unknown, False
+    if isinstance(data, dict):
+        for unused in range(3):
+            if "source" in data or "collection" in data or "counts" in data or "evidence" in data: break
+            found = False
+            for key in ("api_response", "response", "result", "apiResponse", "Output"):
+                if isinstance(data.get(key), dict): data = data.get(key); found = True; break
+            if not found: break
+    return data, unknown, False
+
+
+def otp(record):
+    value = record.get("one_time_password") if isinstance(record, dict) else None
+    if not isinstance(value, dict) or (("otp" in value) == ("totp" in value)): return "unknown"
+    if "totp" in value: return "totp" if value.get("totp") is True else ("none" if value.get("totp") is False else "unknown")
+    return "email" if value.get("otp") is True else ("none" if value.get("otp") is False else "unknown")
+
+
+def state(record):
+    lifetime = record.get("account_lifetime")
+    if not isinstance(lifetime, dict): return "unknown"
+    return "expired" if lifetime.get("expired") is True else ("active" if lifetime.get("expired") is False else "unknown")
+
+
+def source(record, contract):
+    if "domain" not in record or record.get("domain") is None: return "local"
+    domain = record.get("domain")
+    if contract.startswith("gen6"): return "domainProxy" if isinstance(domain, dict) and normalized(domain.get("name")) else "unknown"
+    return "domainProxy" if isinstance(domain, str) and normalized(domain) else "unknown"
+
+
+def identity(record, contract, account_name):
+    vendor_uuid = normalized(record.get("uuid"))
+    if vendor_uuid: return ("uuid", vendor_uuid)
+    domain = record.get("domain")
+    if domain is None: return ("local", account_name)
+    domain_name = normalized(domain.get("name")) if contract.startswith("gen6") and isinstance(domain, dict) else (normalized(domain) if not contract.startswith("gen6") else None)
+    return ("domain", domain_name, account_name) if domain_name else ("unknown", account_name)
+
+
+def references(record, field):
+    if field not in record or record.get(field) is None: return [], False
+    values = record.get(field)
+    if not isinstance(values, list): return [], True
+    names, invalid = [], False
+    for value in values:
+        item = normalized(value.get("name")) if isinstance(value, dict) else None
+        if item is None: invalid = True
+        elif item not in names: names.append(item)
+    return names, invalid
+
+
+def validate(data):
+    errors = []
+    if not isinstance(data, dict): return None, ["collector_envelope_not_object"]
+    source_data, collection, counts, evidence = data.get("source"), data.get("collection"), data.get("counts"), data.get("evidence")
+    if not isinstance(source_data, dict): errors.append("source_missing"); source_data = {}
+    if not isinstance(collection, dict): errors.append("collection_missing"); collection = {}
+    if not isinstance(counts, dict): errors.append("counts_missing"); counts = {}
+    if not isinstance(evidence, dict): errors.append("evidence_missing"); evidence = {}
+    contract = source_data.get("apiContract")
+    if source_data.get("vendor") != "SonicWall" or source_data.get("product") != "SonicOS": errors.append("source_not_sonicos")
+    if contract not in CONTRACTS: errors.append("api_contract_unrecognized")
+    if source_data.get("authenticationMode") not in AUTH_MODES: errors.append("authentication_mode_unrecognized")
+    if not isinstance(source_data.get("firmwareVersion"), str): errors.append("firmware_version_invalid")
+    collection_errors = collection.get("errors")
+    ready = collection.get("requiredEndpointsSucceeded") is True and collection.get("capabilityProfileRecognized") is True and collection.get("allExpectedResponseSectionsPresent") is True and isinstance(collection_errors, list) and not collection_errors
+    if not ready: return {"collectionErrors": collection_errors if isinstance(collection_errors, list) and collection_errors else ["required_collection_incomplete"]}, errors
+    users_body, groups_body = evidence.get("localUsers"), evidence.get("localGroups")
+    users = nested(users_body, ("user", "local", "user"))
+    if contract == "gen6-combined":
+        groups = nested(users_body, ("user", "local", "group"))
+        if groups_body is not None: errors.append("combined_contract_has_split_groups")
+    else: groups = nested(groups_body, ("user", "local", "group"))
+    if contract != "gen6-combined" and nested(users_body, ("user", "local", "group")) is not None: errors.append("split_contract_has_combined_groups")
+    if not isinstance(users, list): errors.append("local_users_shape_unrecognized"); users = []
+    if not isinstance(groups, list): errors.append("local_groups_shape_unrecognized"); groups = []
+    admin = nested(evidence.get("administrationGlobal"), ("administration", "administration", "admin"))
+    raw_users, raw_groups = counts.get("rawUserEntries"), counts.get("rawGroupEntries")
+    if not isinstance(raw_users, int) or isinstance(raw_users, bool) or raw_users != len(users): errors.append("raw_user_count_mismatch")
+    if not isinstance(admin, dict): errors.append("built_in_administrator_shape_unrecognized")
+    if not isinstance(raw_groups, int) or isinstance(raw_groups, bool) or raw_groups != len(groups): errors.append("raw_group_count_mismatch")
+    return {"contract": contract, "users": users, "groups": groups, "collectionErrors": []}, errors
+
+
+def parse(validated):
+    users, groups, errors, contract = {}, {}, [], validated["contract"]
+    for record in validated["users"]:
+        if not isinstance(record, dict): errors.append("local_user_record_not_object"); continue
+        account_name = normalized(record.get("name"))
+        if account_name is None: errors.append("local_user_identity_missing"); continue
+        key = identity(record, contract, account_name)
+        if key in users: errors.append("duplicate_local_user_identity"); continue
+        member_of, invalid = references(record, "member_of"); email = record.get("email_address")
+        users[key] = {"name": account_name, "candidate": account_name.startswith(SERVICE_PREFIXES),
+                      "source": source(record, contract), "state": state(record), "otp": otp(record),
+                      "hasEmail": isinstance(email, str) and bool(email.strip()),
+                      "memberOf": member_of, "membershipUnknown": invalid}
+    for record in validated["groups"]:
+        if not isinstance(record, dict): errors.append("local_group_record_not_object"); continue
+        group_name = normalized(record.get("name"))
+        if group_name is None: errors.append("local_group_identity_missing"); continue
+        if group_name in groups: errors.append("duplicate_local_group_identity"); continue
+        members, invalid = references(record, "member")
+        groups[group_name] = {"otp": otp(record), "members": members, "invalid": invalid}
+    return users, groups, errors
+
+
+def graph(users, groups):
+    direct, parents, by_name, errors = {}, {}, {}, []
+    for key in users:
+        direct[key] = []; account_name = users[key]["name"]
+        if account_name not in by_name: by_name[account_name] = []
+        by_name[account_name].append(key)
+    for group_name in groups: parents[group_name] = []
+    for key in users:
+        for group_name in users[key]["memberOf"]:
+            if group_name not in groups: users[key]["membershipUnknown"] = True
+            elif group_name not in direct[key]: direct[key].append(group_name)
+    for parent in groups:
+        if groups[parent]["invalid"]: errors.append("group_membership_unresolved")
+        for member in groups[parent]["members"]:
+            matches, is_group = by_name.get(member, []), member in groups
+            if len(matches) > 1 or ((len(matches) == 1) == is_group): errors.append("group_membership_unresolved")
+            elif len(matches) == 1:
+                if parent not in direct[matches[0]]: direct[matches[0]].append(parent)
+            elif parent not in parents[member]: parents[member].append(parent)
+    return direct, parents, errors
+
+
+def memberships(key, users, groups, direct, parents):
+    found, stack, unknown = [], [], users[key]["membershipUnknown"]
+    for group_name in direct[key]: stack.append((group_name, []))
+    while stack:
+        group_name, path = stack.pop()
+        if group_name in path: unknown = True; continue
+        if group_name in found: continue
+        found.append(group_name)
+        if groups[group_name]["otp"] == "unknown": unknown = True
+        for parent in parents[group_name]: stack.append((parent, path + [group_name]))
+    return found, unknown
+
+
+def stronger(first, second):
+    ranks = {"unknown": -1, "none": 0, "email": 1, "totp": 2}
+    return first if ranks[first] >= ranks[second] else second
+
+
+def evaluate(users, groups, errors):
+    counts = empty_counts(); direct, parents, graph_errors = graph(users, groups); errors.extend(graph_errors)
+    for key in users:
+        user = users[key]
+        if not user["candidate"]: continue
+        counts["serviceCandidateAccounts"] = counts["serviceCandidateAccounts"] + 1
+        if user["source"] == "domainProxy": counts["excludedDomainProxies"] = counts["excludedDomainProxies"] + 1; continue
+        if user["source"] == "unknown": errors.append("service_candidate_source_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        groups_for_user, membership_unknown = memberships(key, users, groups, direct, parents)
+        is_admin, inherited = False, "none"
+        for group_name in groups_for_user:
+            if group_name in ADMIN_GROUPS: is_admin = True
+            inherited = stronger(inherited, groups[group_name]["otp"])
+        if is_admin: counts["administratorCandidates"] = counts["administratorCandidates"] + 1
+        if user["state"] == "expired": counts["expiredCandidates"] = counts["expiredCandidates"] + 1; continue
+        if user["state"] == "unknown": errors.append("service_candidate_state_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        if membership_unknown or user["otp"] == "unknown" or inherited == "unknown": errors.append("service_candidate_mfa_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        effective = stronger(user["otp"], inherited)
+        compliant = effective == "totp" if is_admin else (effective == "totp" or (effective == "email" and user["hasEmail"]))
+        if compliant: counts["candidatesWithConfiguredMFA"] = counts["candidatesWithConfiguredMFA"] + 1
+        else: counts["candidatesWithoutConfiguredMFA"] = counts["candidatesWithoutConfiguredMFA"] + 1
+    unique = []
+    for error in errors:
+        if error not in unique: unique.append(error)
+    return counts, unique
+
+
+def safe_collection(errors):
+    allowed = ("invalid_settings", "authentication_failed", "local_users_failed", "local_groups_failed", "administration_global_failed", "logout_failed", "required_collection_incomplete")
+    return [str(error) if str(error) in allowed else "collector_error" for error in errors]
+
+
+def transform(input):
+    try:
+        if isinstance(input, str): input = json.loads(input)
+        elif isinstance(input, bytes): input = json.loads(input.decode("utf-8"))
+        data, upstream, enriched = unpack(input)
+        if enriched and (not isinstance(upstream, dict) or upstream.get("status") != "passed" or not isinstance(upstream.get("errors"), list) or upstream.get("errors")):
+            return response(True, validation_status="failed", validation_errors=["upstream_schema_validation_failed"], transformation_errors=["input_validation_failed"], fail_reasons=["Service-account MFA evidence could not be validated"])
+        validated, envelope_errors = validate(data)
+        if validated is not None and validated.get("collectionErrors"):
+            return response(True, validation_status="unknown", collection_errors=safe_collection(validated["collectionErrors"]), fail_reasons=["Required service-account evidence was not collected"])
+        if envelope_errors: return response(True, validation_status="failed", validation_errors=envelope_errors, transformation_errors=["collector_contract_invalid"], fail_reasons=["Service-account evidence did not match a recognized SonicOS contract"])
+        users, groups, parse_errors = parse(validated); counts, errors = evaluate(users, groups, parse_errors)
+        if errors: return response(True, counts, "failed", errors, fail_reasons=["Service-account MFA configuration evidence was indeterminate, so a configured MFA gap cannot be ruled out"])
+        has_gap = counts["candidatesWithoutConfiguredMFA"] > 0
+        if not has_gap: return response(False, counts, pass_reasons=["No configured MFA gap was identified among conservatively named active service-account candidates"])
+        return response(True, counts, fail_reasons=[str(counts["candidatesWithoutConfiguredMFA"]) + " conservatively named active service-account candidate(s) lack an approved configured MFA method"], recommendations=["Configure an approved MFA method for every active service-account candidate"])
+    except Exception:
+        return response(True, validation_status="failed", validation_errors=["transformation_exception"], transformation_errors=["transformation_failed_safely"], fail_reasons=["Service-account MFA configuration evaluation was indeterminate, so a configured MFA gap cannot be ruled out"])

--- a/safeguards/firewall/sonicwall/haslocalaccountinventoryvisibility.py
+++ b/safeguards/firewall/sonicwall/haslocalaccountinventoryvisibility.py
@@ -1,0 +1,307 @@
+"""Evaluate visibility of the SonicOS local-account inventory."""
+
+import json
+from datetime import datetime
+
+
+CRITERIA_KEY = "hasLocalAccountInventoryVisibility"
+SUPPORTED_CONTRACTS = ("gen6-combined", "gen6-split", "gen7-split")
+SUPPORTED_AUTHENTICATION_MODES = ("basicSession", "digestSession", "tfaBearer")
+
+
+def empty_counts():
+    return {
+        "totalLocalAccounts": 0,
+        "activeLocalAccounts": 0,
+        "expiredAccounts": 0,
+        "excludedDomainProxies": 0,
+        "unknownAccounts": 0,
+    }
+
+
+def create_response(passed, counts=None, validation_status="passed", validation_errors=None,
+                    collection_errors=None, transformation_errors=None, pass_reasons=None,
+                    fail_reasons=None, recommendations=None):
+    if counts is None:
+        counts = empty_counts()
+    result = {CRITERIA_KEY: passed}
+    for key in counts:
+        result[key] = counts[key]
+    return {
+        "transformedResponse": result,
+        "additionalInfo": {
+            "dataCollection": {
+                "status": "error" if collection_errors else "success",
+                "errors": collection_errors or [],
+            },
+            "validation": {
+                "status": validation_status,
+                "errors": validation_errors or [],
+                "warnings": [],
+            },
+            "transformation": {
+                "status": "error" if transformation_errors else "success",
+                "errors": transformation_errors or [],
+                "inputSummary": counts,
+            },
+            "evaluation": {
+                "passReasons": pass_reasons or [],
+                "failReasons": fail_reasons or [],
+                "recommendations": recommendations or [],
+                "additionalFindings": [],
+            },
+            "metadata": {
+                "evaluatedAt": datetime.utcnow().isoformat() + "Z",
+                "schemaVersion": "2.0",
+                "transformationId": CRITERIA_KEY,
+                "vendor": "SonicWall",
+                "category": "Firewall",
+            },
+        },
+    }
+
+
+def normalized_name(value):
+    if not isinstance(value, str):
+        return None
+    value = value.strip().lower()
+    return value if value else None
+
+
+def nested_value(data, path):
+    current = data
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current.get(key)
+    return current
+
+
+def extract_input(input_data):
+    unknown = {"status": "unknown", "errors": [], "warnings": []}
+    if isinstance(input_data, dict) and "data" in input_data and "validation" in input_data:
+        if "source" in input_data or "collection" in input_data or "counts" in input_data or "evidence" in input_data:
+            return None, unknown, True
+        return input_data.get("data"), input_data.get("validation") or unknown, True
+    data = input_data
+    if isinstance(data, dict) and ("source" in data or "collection" in data or "counts" in data or "evidence" in data):
+        return data, unknown, False
+    if isinstance(data, dict):
+        for unused in range(3):
+            if "source" in data or "collection" in data or "counts" in data or "evidence" in data:
+                break
+            unwrapped = False
+            for key in ("api_response", "response", "result", "apiResponse", "Output"):
+                if isinstance(data.get(key), dict):
+                    data = data.get(key)
+                    unwrapped = True
+                    break
+            if not unwrapped:
+                break
+    return data, unknown, False
+
+
+def parse_source(record, contract):
+    if "domain" not in record or record.get("domain") is None:
+        return "local"
+    domain = record.get("domain")
+    if contract.startswith("gen6"):
+        if isinstance(domain, dict) and normalized_name(domain.get("name")):
+            return "domainProxy"
+        return "unknown"
+    if isinstance(domain, str) and normalized_name(domain):
+        return "domainProxy"
+    return "unknown"
+
+
+def parse_state(record):
+    lifetime = record.get("account_lifetime")
+    if not isinstance(lifetime, dict):
+        return "unknown"
+    if lifetime.get("expired") is True:
+        return "expired"
+    if lifetime.get("expired") is False:
+        return "active"
+    return "unknown"
+
+
+def identity(record, contract, name):
+    vendor_uuid = normalized_name(record.get("uuid"))
+    if vendor_uuid is not None:
+        return ("uuid", vendor_uuid)
+    domain = record.get("domain")
+    if domain is None:
+        return ("local", name)
+    if contract.startswith("gen6") and isinstance(domain, dict):
+        domain_name = normalized_name(domain.get("name"))
+    elif not contract.startswith("gen6") and isinstance(domain, str):
+        domain_name = normalized_name(domain)
+    else:
+        domain_name = None
+    if domain_name is not None:
+        return ("domain", domain_name, name)
+    return ("unknown", name)
+
+
+def validate_envelope(data):
+    errors = []
+    if not isinstance(data, dict):
+        return None, ["collector_envelope_not_object"]
+    source = data.get("source")
+    collection = data.get("collection")
+    counts = data.get("counts")
+    evidence = data.get("evidence")
+    if not isinstance(source, dict):
+        errors.append("source_missing")
+        source = {}
+    if not isinstance(collection, dict):
+        errors.append("collection_missing")
+        collection = {}
+    if not isinstance(counts, dict):
+        errors.append("counts_missing")
+        counts = {}
+    if not isinstance(evidence, dict):
+        errors.append("evidence_missing")
+        evidence = {}
+    contract = source.get("apiContract")
+    if source.get("vendor") != "SonicWall" or source.get("product") != "SonicOS":
+        errors.append("source_not_sonicos")
+    if contract not in SUPPORTED_CONTRACTS:
+        errors.append("api_contract_unrecognized")
+    if source.get("authenticationMode") not in SUPPORTED_AUTHENTICATION_MODES:
+        errors.append("authentication_mode_unrecognized")
+    if not isinstance(source.get("firmwareVersion"), str):
+        errors.append("firmware_version_invalid")
+    collection_errors = collection.get("errors")
+    ready = (
+        collection.get("requiredEndpointsSucceeded") is True
+        and collection.get("capabilityProfileRecognized") is True
+        and collection.get("allExpectedResponseSectionsPresent") is True
+        and isinstance(collection_errors, list)
+        and len(collection_errors) == 0
+    )
+    if not ready:
+        safe = collection_errors if isinstance(collection_errors, list) and collection_errors else ["required_collection_incomplete"]
+        return {"collectionErrors": safe}, errors
+    users_body = evidence.get("localUsers")
+    groups_body = evidence.get("localGroups")
+    admin_body = evidence.get("administrationGlobal")
+    users = nested_value(users_body, ("user", "local", "user"))
+    if contract == "gen6-combined":
+        groups = nested_value(users_body, ("user", "local", "group"))
+        if groups_body is not None:
+            errors.append("combined_contract_has_split_groups")
+    else:
+        groups = nested_value(groups_body, ("user", "local", "group"))
+        if nested_value(users_body, ("user", "local", "group")) is not None:
+            errors.append("split_contract_has_combined_groups")
+    admin = nested_value(admin_body, ("administration", "administration", "admin"))
+    if not isinstance(users, list):
+        errors.append("local_users_shape_unrecognized")
+        users = []
+    if not isinstance(groups, list):
+        errors.append("local_groups_shape_unrecognized")
+        groups = []
+    if not isinstance(admin, dict):
+        errors.append("built_in_administrator_shape_unrecognized")
+    raw_users = counts.get("rawUserEntries")
+    raw_groups = counts.get("rawGroupEntries")
+    if not isinstance(raw_users, int) or isinstance(raw_users, bool) or raw_users != len(users):
+        errors.append("raw_user_count_mismatch")
+    if not isinstance(raw_groups, int) or isinstance(raw_groups, bool) or raw_groups != len(groups):
+        errors.append("raw_group_count_mismatch")
+    return {"contract": contract, "users": users, "collectionErrors": []}, errors
+
+
+def sanitize_collection_errors(errors):
+    allowed = (
+        "invalid_settings", "authentication_failed", "local_users_failed",
+        "local_groups_failed", "administration_global_failed", "logout_failed",
+        "required_collection_incomplete",
+    )
+    safe = []
+    for error in errors:
+        text = str(error)
+        safe.append(text if text in allowed else "collector_error")
+    return safe
+
+
+def evaluate(users, contract):
+    counts = empty_counts()
+    errors = []
+    identities = {}
+    for record in users:
+        if not isinstance(record, dict):
+            errors.append("local_user_record_not_object")
+            counts["unknownAccounts"] = counts["unknownAccounts"] + 1
+            continue
+        name = normalized_name(record.get("name"))
+        if name is None:
+            errors.append("local_user_identity_missing")
+            counts["unknownAccounts"] = counts["unknownAccounts"] + 1
+            continue
+        account_identity = identity(record, contract, name)
+        if account_identity in identities:
+            errors.append("duplicate_local_user_identity")
+            counts["unknownAccounts"] = counts["unknownAccounts"] + 1
+            continue
+        identities[account_identity] = True
+        source = parse_source(record, contract)
+        if source == "domainProxy":
+            counts["excludedDomainProxies"] = counts["excludedDomainProxies"] + 1
+            continue
+        if source == "unknown":
+            errors.append("account_source_unresolved")
+            counts["unknownAccounts"] = counts["unknownAccounts"] + 1
+            continue
+        counts["totalLocalAccounts"] = counts["totalLocalAccounts"] + 1
+        state = parse_state(record)
+        if state == "active":
+            counts["activeLocalAccounts"] = counts["activeLocalAccounts"] + 1
+        elif state == "expired":
+            counts["expiredAccounts"] = counts["expiredAccounts"] + 1
+        else:
+            errors.append("account_state_unresolved")
+            counts["unknownAccounts"] = counts["unknownAccounts"] + 1
+    unique_errors = []
+    for error in errors:
+        if error not in unique_errors:
+            unique_errors.append(error)
+    return counts, unique_errors
+
+
+def transform(input):
+    try:
+        if isinstance(input, str):
+            input = json.loads(input)
+        elif isinstance(input, bytes):
+            input = json.loads(input.decode("utf-8"))
+        data, upstream, enriched = extract_input(input)
+        if enriched and (not isinstance(upstream, dict) or upstream.get("status") != "passed" or not isinstance(upstream.get("errors"), list) or upstream.get("errors")):
+            return create_response(False, validation_status="failed",
+                                   validation_errors=["upstream_schema_validation_failed"],
+                                   transformation_errors=["input_validation_failed"],
+                                   fail_reasons=["SonicOS account inventory evidence could not be validated"])
+        validated, envelope_errors = validate_envelope(data)
+        if validated is not None and validated.get("collectionErrors"):
+            return create_response(False, validation_status="unknown",
+                                   collection_errors=sanitize_collection_errors(validated["collectionErrors"]),
+                                   fail_reasons=["Required SonicOS account inventory evidence was not collected"],
+                                   recommendations=["Verify the SonicOS integration and re-run collection"])
+        if envelope_errors:
+            return create_response(False, validation_status="failed", validation_errors=envelope_errors,
+                                   transformation_errors=["collector_contract_invalid"],
+                                   fail_reasons=["SonicOS account inventory evidence did not match a recognized contract"],
+                                   recommendations=["Re-collect using a validated SonicOS capability profile"])
+        counts, errors = evaluate(validated["users"], validated["contract"])
+        if errors:
+            return create_response(False, counts=counts, validation_status="failed", validation_errors=errors,
+                                   fail_reasons=["SonicOS local-account inventory evidence was indeterminate"],
+                                   recommendations=["Resolve incomplete account identity, source, or state evidence and re-check"])
+        return create_response(True, counts=counts,
+                               pass_reasons=["The complete SonicOS local-account inventory is visible"])
+    except Exception:
+        return create_response(False, validation_status="failed",
+                               validation_errors=["transformation_exception"],
+                               transformation_errors=["transformation_failed_safely"],
+                               fail_reasons=["SonicOS local-account inventory evaluation could not be completed"])

--- a/safeguards/firewall/sonicwall/isbuiltinadministratormfabound.py
+++ b/safeguards/firewall/sonicwall/isbuiltinadministratormfabound.py
@@ -1,0 +1,128 @@
+"""Report whether SonicOS has built-in administrator TOTP configured."""
+
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "isBuiltInAdministratorMFABound"
+CONTRACTS = ("gen6-combined", "gen6-split", "gen7-split")
+AUTH_MODES = ("basicSession", "digestSession", "tfaBearer")
+
+
+def empty_counts():
+    return {"builtInAdministratorAccounts": 0, "totpConfiguredAccounts": 0,
+            "notTotpConfiguredAccounts": 0, "unknownAccounts": 0}
+
+
+def response(passed, counts=None, validation_status="passed", validation_errors=None,
+             collection_errors=None, transformation_errors=None, pass_reasons=None,
+             fail_reasons=None, recommendations=None):
+    counts = counts or empty_counts(); result = {CRITERIA_KEY: passed}; result.update(counts)
+    return {"transformedResponse": result, "additionalInfo": {
+        "dataCollection": {"status": "error" if collection_errors else "success", "errors": collection_errors or []},
+        "validation": {"status": validation_status, "errors": validation_errors or [], "warnings": []},
+        "transformation": {"status": "error" if transformation_errors else "success", "errors": transformation_errors or [], "inputSummary": counts},
+        "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": ["This setting evidence shows TOTP configuration only; it does not prove that TOTP is bound to a person or enforced during authentication."]},
+        "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "2.0", "transformationId": CRITERIA_KEY, "vendor": "SonicWall", "category": "Firewall"}}}
+
+
+def normalized(value):
+    if not isinstance(value, str): return None
+    value = value.strip().lower()
+    return value if value else None
+
+
+def nested(data, path):
+    for key in path:
+        if not isinstance(data, dict) or key not in data: return None
+        data = data.get(key)
+    return data
+
+
+def unpack(value):
+    unknown = {"status": "unknown", "errors": [], "warnings": []}
+    if isinstance(value, dict) and "data" in value and "validation" in value:
+        if "source" in value or "collection" in value or "counts" in value or "evidence" in value:
+            return None, unknown, True
+        return value.get("data"), value.get("validation") or unknown, True
+    data = value
+    if isinstance(data, dict) and ("source" in data or "collection" in data or "counts" in data or "evidence" in data):
+        return data, unknown, False
+    if isinstance(data, dict):
+        for unused in range(3):
+            if "source" in data or "collection" in data or "counts" in data or "evidence" in data: break
+            found = False
+            for key in ("api_response", "response", "result", "apiResponse", "Output"):
+                if isinstance(data.get(key), dict): data = data.get(key); found = True; break
+            if not found: break
+    return data, unknown, False
+
+
+def validate(data):
+    errors = []
+    if not isinstance(data, dict): return None, ["collector_envelope_not_object"]
+    source, collection, counts, evidence = data.get("source"), data.get("collection"), data.get("counts"), data.get("evidence")
+    if not isinstance(source, dict): errors.append("source_missing"); source = {}
+    if not isinstance(collection, dict): errors.append("collection_missing"); collection = {}
+    if not isinstance(counts, dict): errors.append("counts_missing"); counts = {}
+    if not isinstance(evidence, dict): errors.append("evidence_missing"); evidence = {}
+    contract = source.get("apiContract")
+    if source.get("vendor") != "SonicWall" or source.get("product") != "SonicOS": errors.append("source_not_sonicos")
+    if contract not in CONTRACTS: errors.append("api_contract_unrecognized")
+    if source.get("authenticationMode") not in AUTH_MODES: errors.append("authentication_mode_unrecognized")
+    if not isinstance(source.get("firmwareVersion"), str): errors.append("firmware_version_invalid")
+    collection_errors = collection.get("errors")
+    ready = collection.get("requiredEndpointsSucceeded") is True and collection.get("capabilityProfileRecognized") is True and collection.get("allExpectedResponseSectionsPresent") is True and isinstance(collection_errors, list) and not collection_errors
+    if not ready: return {"collectionErrors": collection_errors if isinstance(collection_errors, list) and collection_errors else ["required_collection_incomplete"]}, errors
+    users_body, groups_body = evidence.get("localUsers"), evidence.get("localGroups")
+    users = nested(users_body, ("user", "local", "user"))
+    if contract == "gen6-combined":
+        groups = nested(users_body, ("user", "local", "group"))
+        if groups_body is not None: errors.append("combined_contract_has_split_groups")
+    else: groups = nested(groups_body, ("user", "local", "group"))
+    if contract != "gen6-combined" and nested(users_body, ("user", "local", "group")) is not None: errors.append("split_contract_has_combined_groups")
+    admin = nested(evidence.get("administrationGlobal"), ("administration", "administration", "admin"))
+    if not isinstance(users, list): errors.append("local_users_shape_unrecognized"); users = []
+    if not isinstance(groups, list): errors.append("local_groups_shape_unrecognized"); groups = []
+    if not isinstance(admin, dict): errors.append("built_in_administrator_shape_unrecognized"); admin = {}
+    if not isinstance(counts.get("rawUserEntries"), int) or isinstance(counts.get("rawUserEntries"), bool) or counts.get("rawUserEntries") != len(users): errors.append("raw_user_count_mismatch")
+    if not isinstance(counts.get("rawGroupEntries"), int) or isinstance(counts.get("rawGroupEntries"), bool) or counts.get("rawGroupEntries") != len(groups): errors.append("raw_group_count_mismatch")
+    return {"admin": admin, "collectionErrors": []}, errors
+
+
+def evaluate(admin):
+    counts = empty_counts(); counts["builtInAdministratorAccounts"] = 1
+    if normalized(admin.get("name")) is None:
+        counts["unknownAccounts"] = 1
+        return counts, ["built_in_administrator_identity_missing"]
+    value = admin.get("one_time_password")
+    if not isinstance(value, dict) or "totp" not in value or "otp" in value or not isinstance(value.get("totp"), bool):
+        counts["unknownAccounts"] = 1
+        return counts, ["built_in_administrator_totp_unresolved"]
+    if value.get("totp") is True: counts["totpConfiguredAccounts"] = 1
+    else: counts["notTotpConfiguredAccounts"] = 1
+    return counts, []
+
+
+def safe_collection(errors):
+    allowed = ("invalid_settings", "authentication_failed", "local_users_failed", "local_groups_failed", "administration_global_failed", "logout_failed", "required_collection_incomplete")
+    return [str(error) if str(error) in allowed else "collector_error" for error in errors]
+
+
+def transform(input):
+    try:
+        if isinstance(input, str): input = json.loads(input)
+        elif isinstance(input, bytes): input = json.loads(input.decode("utf-8"))
+        data, upstream, enriched = unpack(input)
+        if enriched and (not isinstance(upstream, dict) or upstream.get("status") != "passed" or not isinstance(upstream.get("errors"), list) or upstream.get("errors")):
+            return response(False, validation_status="failed", validation_errors=["upstream_schema_validation_failed"], transformation_errors=["input_validation_failed"], fail_reasons=["Built-in administrator TOTP configuration evidence could not be validated"])
+        validated, envelope_errors = validate(data)
+        if validated is not None and validated.get("collectionErrors"):
+            return response(False, validation_status="unknown", collection_errors=safe_collection(validated["collectionErrors"]), fail_reasons=["Required built-in administrator evidence was not collected"])
+        if envelope_errors: return response(False, validation_status="failed", validation_errors=envelope_errors, transformation_errors=["collector_contract_invalid"], fail_reasons=["Built-in administrator evidence did not match a recognized SonicOS contract"])
+        counts, errors = evaluate(validated["admin"])
+        if errors: return response(False, counts, "failed", errors, fail_reasons=["Built-in administrator TOTP configuration evidence was indeterminate"])
+        if counts["totpConfiguredAccounts"] == 1:
+            return response(True, counts, pass_reasons=["TOTP is configured for the built-in administrator"])
+        return response(False, counts, fail_reasons=["TOTP is not configured for the built-in administrator"], recommendations=["Configure TOTP for the built-in administrator"])
+    except Exception:
+        return response(False, validation_status="failed", validation_errors=["transformation_exception"], transformation_errors=["transformation_failed_safely"], fail_reasons=["Built-in administrator TOTP configuration evaluation could not be completed"])

--- a/safeguards/firewall/sonicwall/ismfaenforcedforadministratoraccounts.py
+++ b/safeguards/firewall/sonicwall/ismfaenforcedforadministratoraccounts.py
@@ -1,0 +1,243 @@
+"""Evaluate configured TOTP coverage for additional local SonicOS administrators."""
+
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "isMFAEnforcedForAdministratorAccounts"
+CONTRACTS = ("gen6-combined", "gen6-split", "gen7-split")
+AUTH_MODES = ("basicSession", "digestSession", "tfaBearer")
+ADMIN_GROUPS = ("sonicwall administrators", "sonicwall read-only admins", "limited administrators")
+
+
+def empty_counts():
+    return {"scoredAdministratorAccounts": 0, "compliantAdministratorAccounts": 0,
+            "noncompliantAdministratorAccounts": 0, "expiredAdministratorAccounts": 0,
+            "excludedDomainProxies": 0, "unknownAccounts": 0}
+
+
+def response(passed, counts=None, validation_status="passed", validation_errors=None,
+             collection_errors=None, transformation_errors=None, pass_reasons=None,
+             fail_reasons=None, recommendations=None):
+    counts = counts or empty_counts(); result = {CRITERIA_KEY: passed}; result.update(counts)
+    return {"transformedResponse": result, "additionalInfo": {
+        "dataCollection": {"status": "error" if collection_errors else "success", "errors": collection_errors or []},
+        "validation": {"status": validation_status, "errors": validation_errors or [], "warnings": []},
+        "transformation": {"status": "error" if transformation_errors else "success", "errors": transformation_errors or [], "inputSummary": counts},
+        "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": ["SonicOS settings show TOTP configuration; they do not prove enforcement during authentication."]},
+        "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "2.0", "transformationId": CRITERIA_KEY, "vendor": "SonicWall", "category": "Firewall"}}}
+
+
+def normalized(value):
+    if not isinstance(value, str): return None
+    value = value.strip().lower()
+    return value if value else None
+
+
+def nested(data, path):
+    for key in path:
+        if not isinstance(data, dict) or key not in data: return None
+        data = data.get(key)
+    return data
+
+
+def unpack(value):
+    unknown = {"status": "unknown", "errors": [], "warnings": []}
+    if isinstance(value, dict) and "data" in value and "validation" in value:
+        if "source" in value or "collection" in value or "counts" in value or "evidence" in value:
+            return None, unknown, True
+        return value.get("data"), value.get("validation") or unknown, True
+    data = value
+    if isinstance(data, dict) and ("source" in data or "collection" in data or "counts" in data or "evidence" in data):
+        return data, unknown, False
+    if isinstance(data, dict):
+        for unused in range(3):
+            if "source" in data or "collection" in data or "counts" in data or "evidence" in data: break
+            found = False
+            for key in ("api_response", "response", "result", "apiResponse", "Output"):
+                if isinstance(data.get(key), dict): data = data.get(key); found = True; break
+            if not found: break
+    return data, unknown, False
+
+
+def otp(record):
+    value = record.get("one_time_password") if isinstance(record, dict) else None
+    if not isinstance(value, dict) or (("otp" in value) == ("totp" in value)): return "unknown"
+    if "totp" in value: return "totp" if value.get("totp") is True else ("none" if value.get("totp") is False else "unknown")
+    return "email" if value.get("otp") is True else ("none" if value.get("otp") is False else "unknown")
+
+
+def state(record):
+    lifetime = record.get("account_lifetime")
+    if not isinstance(lifetime, dict): return "unknown"
+    return "expired" if lifetime.get("expired") is True else ("active" if lifetime.get("expired") is False else "unknown")
+
+
+def source(record, contract):
+    if "domain" not in record or record.get("domain") is None: return "local"
+    domain = record.get("domain")
+    if contract.startswith("gen6"): return "domainProxy" if isinstance(domain, dict) and normalized(domain.get("name")) else "unknown"
+    return "domainProxy" if isinstance(domain, str) and normalized(domain) else "unknown"
+
+
+def identity(record, contract, account_name):
+    vendor_uuid = normalized(record.get("uuid"))
+    if vendor_uuid: return ("uuid", vendor_uuid)
+    domain = record.get("domain")
+    if domain is None: return ("local", account_name)
+    domain_name = normalized(domain.get("name")) if contract.startswith("gen6") and isinstance(domain, dict) else (normalized(domain) if not contract.startswith("gen6") else None)
+    return ("domain", domain_name, account_name) if domain_name else ("unknown", account_name)
+
+
+def references(record, field):
+    if field not in record or record.get(field) is None: return [], False
+    values = record.get(field)
+    if not isinstance(values, list): return [], True
+    names, invalid = [], False
+    for value in values:
+        item = normalized(value.get("name")) if isinstance(value, dict) else None
+        if item is None: invalid = True
+        elif item not in names: names.append(item)
+    return names, invalid
+
+
+def validate(data):
+    errors = []
+    if not isinstance(data, dict): return None, ["collector_envelope_not_object"]
+    source_data, collection, counts, evidence = data.get("source"), data.get("collection"), data.get("counts"), data.get("evidence")
+    if not isinstance(source_data, dict): errors.append("source_missing"); source_data = {}
+    if not isinstance(collection, dict): errors.append("collection_missing"); collection = {}
+    if not isinstance(counts, dict): errors.append("counts_missing"); counts = {}
+    if not isinstance(evidence, dict): errors.append("evidence_missing"); evidence = {}
+    contract = source_data.get("apiContract")
+    if source_data.get("vendor") != "SonicWall" or source_data.get("product") != "SonicOS": errors.append("source_not_sonicos")
+    if contract not in CONTRACTS: errors.append("api_contract_unrecognized")
+    if source_data.get("authenticationMode") not in AUTH_MODES: errors.append("authentication_mode_unrecognized")
+    if not isinstance(source_data.get("firmwareVersion"), str): errors.append("firmware_version_invalid")
+    collection_errors = collection.get("errors")
+    ready = collection.get("requiredEndpointsSucceeded") is True and collection.get("capabilityProfileRecognized") is True and collection.get("allExpectedResponseSectionsPresent") is True and isinstance(collection_errors, list) and not collection_errors
+    if not ready: return {"collectionErrors": collection_errors if isinstance(collection_errors, list) and collection_errors else ["required_collection_incomplete"]}, errors
+    users_body, groups_body = evidence.get("localUsers"), evidence.get("localGroups")
+    users = nested(users_body, ("user", "local", "user"))
+    if contract == "gen6-combined":
+        groups = nested(users_body, ("user", "local", "group"))
+        if groups_body is not None: errors.append("combined_contract_has_split_groups")
+    else: groups = nested(groups_body, ("user", "local", "group"))
+    if contract != "gen6-combined" and nested(users_body, ("user", "local", "group")) is not None: errors.append("split_contract_has_combined_groups")
+    if not isinstance(users, list): errors.append("local_users_shape_unrecognized"); users = []
+    if not isinstance(groups, list): errors.append("local_groups_shape_unrecognized"); groups = []
+    admin = nested(evidence.get("administrationGlobal"), ("administration", "administration", "admin"))
+    raw_users, raw_groups = counts.get("rawUserEntries"), counts.get("rawGroupEntries")
+    if not isinstance(raw_users, int) or isinstance(raw_users, bool) or raw_users != len(users): errors.append("raw_user_count_mismatch")
+    if not isinstance(admin, dict): errors.append("built_in_administrator_shape_unrecognized")
+    if not isinstance(raw_groups, int) or isinstance(raw_groups, bool) or raw_groups != len(groups): errors.append("raw_group_count_mismatch")
+    return {"contract": contract, "users": users, "groups": groups, "collectionErrors": []}, errors
+
+
+def parse(validated):
+    users, groups, errors, contract = {}, {}, [], validated["contract"]
+    for record in validated["users"]:
+        if not isinstance(record, dict): errors.append("local_user_record_not_object"); continue
+        account_name = normalized(record.get("name"))
+        if account_name is None: errors.append("local_user_identity_missing"); continue
+        key = identity(record, contract, account_name)
+        if key in users: errors.append("duplicate_local_user_identity"); continue
+        member_of, invalid = references(record, "member_of")
+        users[key] = {"name": account_name, "source": source(record, contract), "state": state(record), "otp": otp(record), "memberOf": member_of, "membershipUnknown": invalid}
+    for record in validated["groups"]:
+        if not isinstance(record, dict): errors.append("local_group_record_not_object"); continue
+        group_name = normalized(record.get("name"))
+        if group_name is None: errors.append("local_group_identity_missing"); continue
+        if group_name in groups: errors.append("duplicate_local_group_identity"); continue
+        members, invalid = references(record, "member")
+        groups[group_name] = {"otp": otp(record), "members": members, "invalid": invalid}
+    return users, groups, errors
+
+
+def graph(users, groups):
+    direct, parents, by_name, errors = {}, {}, {}, []
+    for key in users:
+        direct[key] = []; account_name = users[key]["name"]
+        if account_name not in by_name: by_name[account_name] = []
+        by_name[account_name].append(key)
+    for group_name in groups: parents[group_name] = []
+    for key in users:
+        for group_name in users[key]["memberOf"]:
+            if group_name not in groups: users[key]["membershipUnknown"] = True
+            elif group_name not in direct[key]: direct[key].append(group_name)
+    for parent in groups:
+        if groups[parent]["invalid"]: errors.append("group_membership_unresolved")
+        for member in groups[parent]["members"]:
+            matches, is_group = by_name.get(member, []), member in groups
+            if len(matches) > 1 or ((len(matches) == 1) == is_group): errors.append("group_membership_unresolved")
+            elif len(matches) == 1:
+                if parent not in direct[matches[0]]: direct[matches[0]].append(parent)
+            elif parent not in parents[member]: parents[member].append(parent)
+    return direct, parents, errors
+
+
+def memberships(key, users, groups, direct, parents):
+    found, stack, unknown = [], [], users[key]["membershipUnknown"]
+    for group_name in direct[key]: stack.append((group_name, []))
+    while stack:
+        group_name, path = stack.pop()
+        if group_name in path: unknown = True; continue
+        if group_name in found: continue
+        found.append(group_name)
+        if groups[group_name]["otp"] == "unknown": unknown = True
+        for parent in parents[group_name]: stack.append((parent, path + [group_name]))
+    return found, unknown
+
+
+def stronger(first, second):
+    ranks = {"unknown": -1, "none": 0, "email": 1, "totp": 2}
+    return first if ranks[first] >= ranks[second] else second
+
+
+def evaluate(users, groups, errors):
+    counts = empty_counts(); direct, parents, graph_errors = graph(users, groups); errors.extend(graph_errors)
+    for key in users:
+        user = users[key]
+        if user["source"] == "domainProxy": counts["excludedDomainProxies"] = counts["excludedDomainProxies"] + 1; continue
+        if user["source"] == "unknown": errors.append("account_source_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        groups_for_user, membership_unknown = memberships(key, users, groups, direct, parents)
+        is_admin, inherited = False, "none"
+        for group_name in groups_for_user:
+            if group_name in ADMIN_GROUPS: is_admin = True
+            inherited = stronger(inherited, groups[group_name]["otp"])
+        if membership_unknown: errors.append("administrator_membership_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        if not is_admin: continue
+        if user["state"] == "expired": counts["expiredAdministratorAccounts"] = counts["expiredAdministratorAccounts"] + 1; continue
+        if user["state"] == "unknown": errors.append("administrator_state_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        counts["scoredAdministratorAccounts"] = counts["scoredAdministratorAccounts"] + 1
+        if user["otp"] == "unknown" or inherited == "unknown": errors.append("administrator_otp_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        if stronger(user["otp"], inherited) == "totp": counts["compliantAdministratorAccounts"] = counts["compliantAdministratorAccounts"] + 1
+        else: counts["noncompliantAdministratorAccounts"] = counts["noncompliantAdministratorAccounts"] + 1
+    unique = []
+    for error in errors:
+        if error not in unique: unique.append(error)
+    return counts, unique
+
+
+def safe_collection(errors):
+    allowed = ("invalid_settings", "authentication_failed", "local_users_failed", "local_groups_failed", "administration_global_failed", "logout_failed", "required_collection_incomplete")
+    return [str(error) if str(error) in allowed else "collector_error" for error in errors]
+
+
+def transform(input):
+    try:
+        if isinstance(input, str): input = json.loads(input)
+        elif isinstance(input, bytes): input = json.loads(input.decode("utf-8"))
+        data, upstream, enriched = unpack(input)
+        if enriched and (not isinstance(upstream, dict) or upstream.get("status") != "passed" or not isinstance(upstream.get("errors"), list) or upstream.get("errors")):
+            return response(False, validation_status="failed", validation_errors=["upstream_schema_validation_failed"], transformation_errors=["input_validation_failed"], fail_reasons=["SonicOS administrator MFA evidence could not be validated"])
+        validated, envelope_errors = validate(data)
+        if validated is not None and validated.get("collectionErrors"):
+            return response(False, validation_status="unknown", collection_errors=safe_collection(validated["collectionErrors"]), fail_reasons=["Required SonicOS administrator evidence was not collected"])
+        if envelope_errors: return response(False, validation_status="failed", validation_errors=envelope_errors, transformation_errors=["collector_contract_invalid"], fail_reasons=["SonicOS administrator evidence did not match a recognized contract"])
+        users, groups, parse_errors = parse(validated); counts, errors = evaluate(users, groups, parse_errors)
+        if errors: return response(False, counts, "failed", errors, fail_reasons=["SonicOS additional-administrator MFA evidence was indeterminate"])
+        passed = counts["noncompliantAdministratorAccounts"] == 0 and counts["compliantAdministratorAccounts"] == counts["scoredAdministratorAccounts"]
+        if passed: return response(True, counts, pass_reasons=["Every active additional local administrator has configured TOTP; an empty valid additional-administrator population also satisfies this criterion"])
+        return response(False, counts, fail_reasons=[str(counts["noncompliantAdministratorAccounts"]) + " additional administrator account(s) lack configured TOTP"], recommendations=["Configure TOTP for every active additional local administrator"])
+    except Exception:
+        return response(False, validation_status="failed", validation_errors=["transformation_exception"], transformation_errors=["transformation_failed_safely"], fail_reasons=["SonicOS additional-administrator MFA evaluation could not be completed"])

--- a/safeguards/firewall/sonicwall/ismfaenforcedforlocalaccounts.py
+++ b/safeguards/firewall/sonicwall/ismfaenforcedforlocalaccounts.py
@@ -1,0 +1,290 @@
+"""Evaluate configured MFA coverage for ordinary local SonicOS accounts."""
+
+import json
+from datetime import datetime
+
+CRITERIA_KEY = "isMFAEnforcedForLocalAccounts"
+SUPPORTED_CONTRACTS = ("gen6-combined", "gen6-split", "gen7-split")
+SUPPORTED_AUTHENTICATION_MODES = ("basicSession", "digestSession", "tfaBearer")
+ADMIN_GROUPS = ("sonicwall administrators", "sonicwall read-only admins", "limited administrators")
+SSL_VPN_GROUP = "sslvpn services"
+
+
+def empty_counts():
+    return {"scoredLocalAccounts": 0, "compliantLocalAccounts": 0,
+            "noncompliantLocalAccounts": 0, "administratorAccountsExcluded": 0,
+            "sslVpnAccounts": 0, "expiredAccounts": 0,
+            "excludedDomainProxies": 0, "unknownAccounts": 0}
+
+
+def response(passed, counts=None, validation_status="passed", validation_errors=None,
+             collection_errors=None, transformation_errors=None, pass_reasons=None,
+             fail_reasons=None, recommendations=None):
+    counts = counts or empty_counts()
+    result = {CRITERIA_KEY: passed}
+    result.update(counts)
+    return {"transformedResponse": result, "additionalInfo": {
+        "dataCollection": {"status": "error" if collection_errors else "success", "errors": collection_errors or []},
+        "validation": {"status": validation_status, "errors": validation_errors or [], "warnings": []},
+        "transformation": {"status": "error" if transformation_errors else "success", "errors": transformation_errors or [], "inputSummary": counts},
+        "evaluation": {"passReasons": pass_reasons or [], "failReasons": fail_reasons or [], "recommendations": recommendations or [], "additionalFindings": ["SonicOS settings show MFA configuration; they do not prove enforcement during authentication."]},
+        "metadata": {"evaluatedAt": datetime.utcnow().isoformat() + "Z", "schemaVersion": "2.0", "transformationId": CRITERIA_KEY, "vendor": "SonicWall", "category": "Firewall"}}}
+
+
+def name(value):
+    if not isinstance(value, str):
+        return None
+    value = value.strip().lower()
+    return value if value else None
+
+
+def at(data, path):
+    for key in path:
+        if not isinstance(data, dict) or key not in data:
+            return None
+        data = data.get(key)
+    return data
+
+
+def unpack(value):
+    unknown = {"status": "unknown", "errors": [], "warnings": []}
+    if isinstance(value, dict) and "data" in value and "validation" in value:
+        if "source" in value or "collection" in value or "counts" in value or "evidence" in value:
+            return None, unknown, True
+        return value.get("data"), value.get("validation") or unknown, True
+    data = value
+    if isinstance(data, dict) and ("source" in data or "collection" in data or "counts" in data or "evidence" in data):
+        return data, unknown, False
+    if isinstance(data, dict):
+        for unused in range(3):
+            if "source" in data or "collection" in data or "counts" in data or "evidence" in data:
+                break
+            found = False
+            for key in ("api_response", "response", "result", "apiResponse", "Output"):
+                if isinstance(data.get(key), dict):
+                    data = data.get(key)
+                    found = True
+                    break
+            if not found:
+                break
+    return data, unknown, False
+
+
+def otp(record):
+    value = record.get("one_time_password") if isinstance(record, dict) else None
+    if not isinstance(value, dict) or (("otp" in value) == ("totp" in value)):
+        return "unknown"
+    if "totp" in value:
+        return "totp" if value.get("totp") is True else ("none" if value.get("totp") is False else "unknown")
+    return "email" if value.get("otp") is True else ("none" if value.get("otp") is False else "unknown")
+
+
+def state(record):
+    lifetime = record.get("account_lifetime")
+    if not isinstance(lifetime, dict):
+        return "unknown"
+    return "expired" if lifetime.get("expired") is True else ("active" if lifetime.get("expired") is False else "unknown")
+
+
+def source(record, contract):
+    if "domain" not in record or record.get("domain") is None:
+        return "local"
+    domain = record.get("domain")
+    if contract.startswith("gen6"):
+        return "domainProxy" if isinstance(domain, dict) and name(domain.get("name")) else "unknown"
+    return "domainProxy" if isinstance(domain, str) and name(domain) else "unknown"
+
+
+def identity(record, contract, account_name):
+    vendor_uuid = name(record.get("uuid"))
+    if vendor_uuid:
+        return ("uuid", vendor_uuid)
+    domain = record.get("domain")
+    if domain is None:
+        return ("local", account_name)
+    domain_name = name(domain.get("name")) if contract.startswith("gen6") and isinstance(domain, dict) else (name(domain) if not contract.startswith("gen6") else None)
+    return ("domain", domain_name, account_name) if domain_name else ("unknown", account_name)
+
+
+def references(record, field):
+    if field not in record or record.get(field) is None:
+        return [], False
+    values = record.get(field)
+    if not isinstance(values, list):
+        return [], True
+    names = []
+    invalid = False
+    for value in values:
+        reference = name(value.get("name")) if isinstance(value, dict) else None
+        if reference is None:
+            invalid = True
+        elif reference not in names:
+            names.append(reference)
+    return names, invalid
+
+
+def validate(data):
+    errors = []
+    if not isinstance(data, dict):
+        return None, ["collector_envelope_not_object"]
+    source_data, collection, counts, evidence = data.get("source"), data.get("collection"), data.get("counts"), data.get("evidence")
+    if not isinstance(source_data, dict):
+        errors.append("source_missing"); source_data = {}
+    if not isinstance(collection, dict):
+        errors.append("collection_missing"); collection = {}
+    if not isinstance(counts, dict):
+        errors.append("counts_missing"); counts = {}
+    if not isinstance(evidence, dict):
+        errors.append("evidence_missing"); evidence = {}
+    contract = source_data.get("apiContract")
+    if source_data.get("vendor") != "SonicWall" or source_data.get("product") != "SonicOS": errors.append("source_not_sonicos")
+    if contract not in SUPPORTED_CONTRACTS: errors.append("api_contract_unrecognized")
+    if source_data.get("authenticationMode") not in SUPPORTED_AUTHENTICATION_MODES: errors.append("authentication_mode_unrecognized")
+    if not isinstance(source_data.get("firmwareVersion"), str): errors.append("firmware_version_invalid")
+    collection_errors = collection.get("errors")
+    ready = collection.get("requiredEndpointsSucceeded") is True and collection.get("capabilityProfileRecognized") is True and collection.get("allExpectedResponseSectionsPresent") is True and isinstance(collection_errors, list) and not collection_errors
+    if not ready:
+        return {"collectionErrors": collection_errors if isinstance(collection_errors, list) and collection_errors else ["required_collection_incomplete"]}, errors
+    users_body, groups_body = evidence.get("localUsers"), evidence.get("localGroups")
+    users = at(users_body, ("user", "local", "user"))
+    if contract == "gen6-combined":
+        groups = at(users_body, ("user", "local", "group"))
+        if groups_body is not None: errors.append("combined_contract_has_split_groups")
+    else:
+        groups = at(groups_body, ("user", "local", "group"))
+        if at(users_body, ("user", "local", "group")) is not None: errors.append("split_contract_has_combined_groups")
+    admin = at(evidence.get("administrationGlobal"), ("administration", "administration", "admin"))
+    if not isinstance(users, list): errors.append("local_users_shape_unrecognized"); users = []
+    if not isinstance(groups, list): errors.append("local_groups_shape_unrecognized"); groups = []
+    if not isinstance(admin, dict): errors.append("built_in_administrator_shape_unrecognized")
+    raw_users, raw_groups = counts.get("rawUserEntries"), counts.get("rawGroupEntries")
+    if not isinstance(raw_users, int) or isinstance(raw_users, bool) or raw_users != len(users): errors.append("raw_user_count_mismatch")
+    if not isinstance(raw_groups, int) or isinstance(raw_groups, bool) or raw_groups != len(groups): errors.append("raw_group_count_mismatch")
+    return {"contract": contract, "users": users, "groups": groups, "collectionErrors": []}, errors
+
+
+def parse(validated):
+    users, groups, errors = {}, {}, []
+    contract = validated["contract"]
+    for record in validated["users"]:
+        if not isinstance(record, dict): errors.append("local_user_record_not_object"); continue
+        account_name = name(record.get("name"))
+        if account_name is None: errors.append("local_user_identity_missing"); continue
+        key = identity(record, contract, account_name)
+        if key in users: errors.append("duplicate_local_user_identity"); continue
+        member_of, invalid = references(record, "member_of")
+        email = record.get("email_address")
+        users[key] = {"name": account_name, "source": source(record, contract), "state": state(record),
+                      "otp": otp(record), "hasEmail": isinstance(email, str) and bool(email.strip()),
+                      "memberOf": member_of, "membershipUnknown": invalid}
+    for record in validated["groups"]:
+        if not isinstance(record, dict): errors.append("local_group_record_not_object"); continue
+        group_name = name(record.get("name"))
+        if group_name is None: errors.append("local_group_identity_missing"); continue
+        if group_name in groups: errors.append("duplicate_local_group_identity"); continue
+        members, invalid = references(record, "member")
+        groups[group_name] = {"otp": otp(record), "members": members, "invalid": invalid}
+    return users, groups, errors
+
+
+def graph(users, groups):
+    direct, parents, by_name, errors = {}, {}, {}, []
+    for key in users:
+        direct[key] = []
+        account_name = users[key]["name"]
+        if account_name not in by_name: by_name[account_name] = []
+        by_name[account_name].append(key)
+    for group_name in groups: parents[group_name] = []
+    for key in users:
+        for group_name in users[key]["memberOf"]:
+            if group_name not in groups: users[key]["membershipUnknown"] = True
+            elif group_name not in direct[key]: direct[key].append(group_name)
+    for parent in groups:
+        if groups[parent]["invalid"]: errors.append("group_membership_unresolved")
+        for member in groups[parent]["members"]:
+            matches, is_group = by_name.get(member, []), member in groups
+            if len(matches) > 1 or ((len(matches) == 1) == is_group): errors.append("group_membership_unresolved")
+            elif len(matches) == 1:
+                if parent not in direct[matches[0]]: direct[matches[0]].append(parent)
+            elif parent not in parents[member]: parents[member].append(parent)
+    return direct, parents, errors
+
+
+def resolved_groups(key, users, groups, direct, parents):
+    resolved, stack, unknown = [], [], users[key]["membershipUnknown"]
+    for group_name in direct[key]: stack.append((group_name, []))
+    while stack:
+        group_name, path = stack.pop()
+        if group_name in path: unknown = True; continue
+        if group_name in resolved: continue
+        resolved.append(group_name)
+        if groups[group_name]["otp"] == "unknown": unknown = True
+        for parent in parents[group_name]: stack.append((parent, path + [group_name]))
+    return resolved, unknown
+
+
+def stronger(first, second):
+    ranks = {"unknown": -1, "none": 0, "email": 1, "totp": 2}
+    return first if ranks[first] >= ranks[second] else second
+
+
+def evaluate(users, groups, errors):
+    counts = empty_counts()
+    direct, parents, graph_errors = graph(users, groups)
+    errors.extend(graph_errors)
+    for key in users:
+        user = users[key]
+        if user["source"] == "domainProxy": counts["excludedDomainProxies"] = counts["excludedDomainProxies"] + 1; continue
+        if user["source"] == "unknown": errors.append("account_source_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        memberships, membership_unknown = resolved_groups(key, users, groups, direct, parents)
+        is_admin, is_ssl_vpn, inherited = False, False, "none"
+        for group_name in memberships:
+            if group_name in ADMIN_GROUPS: is_admin = True
+            if group_name == SSL_VPN_GROUP: is_ssl_vpn = True
+            inherited = stronger(inherited, groups[group_name]["otp"])
+        if is_ssl_vpn: counts["sslVpnAccounts"] = counts["sslVpnAccounts"] + 1
+        if user["state"] == "expired": counts["expiredAccounts"] = counts["expiredAccounts"] + 1; continue
+        if user["state"] == "unknown": errors.append("account_state_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        if is_admin:
+            counts["administratorAccountsExcluded"] = counts["administratorAccountsExcluded"] + 1
+            if membership_unknown: errors.append("administrator_membership_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1
+            continue
+        counts["scoredLocalAccounts"] = counts["scoredLocalAccounts"] + 1
+        if membership_unknown or user["otp"] == "unknown" or inherited == "unknown":
+            errors.append("scored_account_evidence_unresolved"); counts["unknownAccounts"] = counts["unknownAccounts"] + 1; continue
+        effective = stronger(user["otp"], inherited)
+        if effective == "totp" or (effective == "email" and user["hasEmail"]): counts["compliantLocalAccounts"] = counts["compliantLocalAccounts"] + 1
+        else: counts["noncompliantLocalAccounts"] = counts["noncompliantLocalAccounts"] + 1
+    unique = []
+    for error in errors:
+        if error not in unique: unique.append(error)
+    return counts, unique
+
+
+def safe_collection(errors):
+    allowed = ("invalid_settings", "authentication_failed", "local_users_failed", "local_groups_failed", "administration_global_failed", "logout_failed", "required_collection_incomplete")
+    return [str(error) if str(error) in allowed else "collector_error" for error in errors]
+
+
+def transform(input):
+    try:
+        if isinstance(input, str): input = json.loads(input)
+        elif isinstance(input, bytes): input = json.loads(input.decode("utf-8"))
+        data, upstream, enriched = unpack(input)
+        if enriched and (not isinstance(upstream, dict) or upstream.get("status") != "passed" or not isinstance(upstream.get("errors"), list) or upstream.get("errors")):
+            return response(False, validation_status="failed", validation_errors=["upstream_schema_validation_failed"], transformation_errors=["input_validation_failed"], fail_reasons=["SonicOS local-account MFA evidence could not be validated"])
+        validated, envelope_errors = validate(data)
+        if validated is not None and validated.get("collectionErrors"):
+            return response(False, validation_status="unknown", collection_errors=safe_collection(validated["collectionErrors"]), fail_reasons=["Required SonicOS account MFA evidence was not collected"], recommendations=["Verify the SonicOS integration and re-run collection"])
+        if envelope_errors:
+            return response(False, validation_status="failed", validation_errors=envelope_errors, transformation_errors=["collector_contract_invalid"], fail_reasons=["SonicOS account MFA evidence did not match a recognized contract"])
+        users, groups, parse_errors = parse(validated)
+        counts, errors = evaluate(users, groups, parse_errors)
+        if errors:
+            return response(False, counts, "failed", errors, fail_reasons=["SonicOS local-account MFA evidence was indeterminate"], recommendations=["Resolve incomplete OTP, account-state, or group-membership evidence and re-check"])
+        passed = counts["noncompliantLocalAccounts"] == 0 and counts["compliantLocalAccounts"] == counts["scoredLocalAccounts"]
+        if passed:
+            return response(True, counts, pass_reasons=["Every scored ordinary local account has configured TOTP or email OTP with a configured email address"])
+        return response(False, counts, fail_reasons=[str(counts["noncompliantLocalAccounts"]) + " ordinary local account(s) lack an approved configured MFA method"], recommendations=["Configure TOTP, or email OTP with a nonblank email address, for every ordinary local account"])
+    except Exception:
+        return response(False, validation_status="failed", validation_errors=["transformation_exception"], transformation_errors=["transformation_failed_safely"], fail_reasons=["SonicOS local-account MFA evaluation could not be completed"])

--- a/safeguards/firewall/sonicwall/schemas/__init__.py
+++ b/safeguards/firewall/sonicwall/schemas/__init__.py
@@ -1,0 +1,13 @@
+from .hasidentifiedserviceaccountsmfagap import HasidentifiedserviceaccountsmfagapInput
+from .haslocalaccountinventoryvisibility import HaslocalaccountinventoryvisibilityInput
+from .isbuiltinadministratormfabound import IsbuiltinadministratormfaboundInput
+from .ismfaenforcedforadministratoraccounts import IsmfaenforcedforadministratoraccountsInput
+from .ismfaenforcedforlocalaccounts import IsmfaenforcedforlocalaccountsInput
+
+__all__ = [
+    "HasidentifiedserviceaccountsmfagapInput",
+    "HaslocalaccountinventoryvisibilityInput",
+    "IsbuiltinadministratormfaboundInput",
+    "IsmfaenforcedforadministratoraccountsInput",
+    "IsmfaenforcedforlocalaccountsInput",
+]

--- a/safeguards/firewall/sonicwall/schemas/hasidentifiedserviceaccountsmfagap.py
+++ b/safeguards/firewall/sonicwall/schemas/hasidentifiedserviceaccountsmfagap.py
@@ -1,0 +1,53 @@
+"""Input schema for SonicWall identified service-account MFA gaps."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class Source(BaseModel):
+    vendor: str
+    product: str
+    firmwareVersion: str
+    apiContract: str
+    authenticationMode: str
+
+    class Config:
+        extra = "allow"
+
+
+class Collection(BaseModel):
+    requiredEndpointsSucceeded: bool
+    capabilityProfileRecognized: bool
+    allExpectedResponseSectionsPresent: bool
+    errors: List[str]
+
+    class Config:
+        extra = "allow"
+
+
+class Counts(BaseModel):
+    rawUserEntries: int
+    rawGroupEntries: int
+
+    class Config:
+        extra = "allow"
+
+
+class Evidence(BaseModel):
+    localUsers: Dict[str, Any]
+    localGroups: Optional[Dict[str, Any]] = None
+    administrationGlobal: Dict[str, Any]
+
+    class Config:
+        extra = "allow"
+
+
+class HasidentifiedserviceaccountsmfagapInput(BaseModel):
+    source: Source
+    collection: Collection
+    counts: Counts
+    evidence: Evidence
+
+    class Config:
+        extra = "allow"

--- a/safeguards/firewall/sonicwall/schemas/haslocalaccountinventoryvisibility.py
+++ b/safeguards/firewall/sonicwall/schemas/haslocalaccountinventoryvisibility.py
@@ -1,0 +1,53 @@
+"""Input schema for SonicWall local-account inventory visibility."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class Source(BaseModel):
+    vendor: str
+    product: str
+    firmwareVersion: str
+    apiContract: str
+    authenticationMode: str
+
+    class Config:
+        extra = "allow"
+
+
+class Collection(BaseModel):
+    requiredEndpointsSucceeded: bool
+    capabilityProfileRecognized: bool
+    allExpectedResponseSectionsPresent: bool
+    errors: List[str]
+
+    class Config:
+        extra = "allow"
+
+
+class Counts(BaseModel):
+    rawUserEntries: int
+    rawGroupEntries: int
+
+    class Config:
+        extra = "allow"
+
+
+class Evidence(BaseModel):
+    localUsers: Dict[str, Any]
+    localGroups: Optional[Dict[str, Any]] = None
+    administrationGlobal: Dict[str, Any]
+
+    class Config:
+        extra = "allow"
+
+
+class HaslocalaccountinventoryvisibilityInput(BaseModel):
+    source: Source
+    collection: Collection
+    counts: Counts
+    evidence: Evidence
+
+    class Config:
+        extra = "allow"

--- a/safeguards/firewall/sonicwall/schemas/isbuiltinadministratormfabound.py
+++ b/safeguards/firewall/sonicwall/schemas/isbuiltinadministratormfabound.py
@@ -1,0 +1,53 @@
+"""Input schema for SonicWall built-in administrator TOTP configuration."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class Source(BaseModel):
+    vendor: str
+    product: str
+    firmwareVersion: str
+    apiContract: str
+    authenticationMode: str
+
+    class Config:
+        extra = "allow"
+
+
+class Collection(BaseModel):
+    requiredEndpointsSucceeded: bool
+    capabilityProfileRecognized: bool
+    allExpectedResponseSectionsPresent: bool
+    errors: List[str]
+
+    class Config:
+        extra = "allow"
+
+
+class Counts(BaseModel):
+    rawUserEntries: int
+    rawGroupEntries: int
+
+    class Config:
+        extra = "allow"
+
+
+class Evidence(BaseModel):
+    localUsers: Dict[str, Any]
+    localGroups: Optional[Dict[str, Any]] = None
+    administrationGlobal: Dict[str, Any]
+
+    class Config:
+        extra = "allow"
+
+
+class IsbuiltinadministratormfaboundInput(BaseModel):
+    source: Source
+    collection: Collection
+    counts: Counts
+    evidence: Evidence
+
+    class Config:
+        extra = "allow"

--- a/safeguards/firewall/sonicwall/schemas/ismfaenforcedforadministratoraccounts.py
+++ b/safeguards/firewall/sonicwall/schemas/ismfaenforcedforadministratoraccounts.py
@@ -1,0 +1,53 @@
+"""Input schema for SonicWall additional-administrator MFA."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class Source(BaseModel):
+    vendor: str
+    product: str
+    firmwareVersion: str
+    apiContract: str
+    authenticationMode: str
+
+    class Config:
+        extra = "allow"
+
+
+class Collection(BaseModel):
+    requiredEndpointsSucceeded: bool
+    capabilityProfileRecognized: bool
+    allExpectedResponseSectionsPresent: bool
+    errors: List[str]
+
+    class Config:
+        extra = "allow"
+
+
+class Counts(BaseModel):
+    rawUserEntries: int
+    rawGroupEntries: int
+
+    class Config:
+        extra = "allow"
+
+
+class Evidence(BaseModel):
+    localUsers: Dict[str, Any]
+    localGroups: Optional[Dict[str, Any]] = None
+    administrationGlobal: Dict[str, Any]
+
+    class Config:
+        extra = "allow"
+
+
+class IsmfaenforcedforadministratoraccountsInput(BaseModel):
+    source: Source
+    collection: Collection
+    counts: Counts
+    evidence: Evidence
+
+    class Config:
+        extra = "allow"

--- a/safeguards/firewall/sonicwall/schemas/ismfaenforcedforlocalaccounts.py
+++ b/safeguards/firewall/sonicwall/schemas/ismfaenforcedforlocalaccounts.py
@@ -1,0 +1,53 @@
+"""Input schema for SonicWall ordinary local-account MFA."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class Source(BaseModel):
+    vendor: str
+    product: str
+    firmwareVersion: str
+    apiContract: str
+    authenticationMode: str
+
+    class Config:
+        extra = "allow"
+
+
+class Collection(BaseModel):
+    requiredEndpointsSucceeded: bool
+    capabilityProfileRecognized: bool
+    allExpectedResponseSectionsPresent: bool
+    errors: List[str]
+
+    class Config:
+        extra = "allow"
+
+
+class Counts(BaseModel):
+    rawUserEntries: int
+    rawGroupEntries: int
+
+    class Config:
+        extra = "allow"
+
+
+class Evidence(BaseModel):
+    localUsers: Dict[str, Any]
+    localGroups: Optional[Dict[str, Any]] = None
+    administrationGlobal: Dict[str, Any]
+
+    class Config:
+        extra = "allow"
+
+
+class IsmfaenforcedforlocalaccountsInput(BaseModel):
+    source: Source
+    collection: Collection
+    counts: Counts
+    evidence: Evidence
+
+    class Config:
+        extra = "allow"

--- a/safeguards/firewall/sonicwall/test_hasidentifiedserviceaccountsmfagap.py
+++ b/safeguards/firewall/sonicwall/test_hasidentifiedserviceaccountsmfagap.py
@@ -1,0 +1,104 @@
+import unittest
+
+from conftest import envelope, fixture_envelope, group, load_module, user
+
+
+FILENAME = "hasidentifiedserviceaccountsmfagap.py"
+
+
+def transformation():
+    return load_module(FILENAME)
+
+
+def test_only_explicit_prefixes_are_candidates_and_output_is_aggregate_only():
+    module = transformation()
+    users = [
+        user("svc-good", "totp"),
+        user("service-gap", "none"),
+        user("api-email-no-address", "email"),
+        user("bot-email", "email", email_address="bot@example.test"),
+        user("automation-admin", "email", ["SonicWall Administrators"], email_address="admin@example.test"),
+        user("backup-service", "none"),
+    ]
+    groups = [group("SonicWall Administrators", members=["automation-admin"])]
+    response = module.transform(envelope(users, groups))
+    result = response["transformedResponse"]
+    assert result["hasIdentifiedServiceAccountsMFAGap"] is True
+    assert result["serviceCandidateAccounts"] == 5
+    assert result["candidatesWithConfiguredMFA"] == 2
+    assert result["candidatesWithoutConfiguredMFA"] == 3
+    assert result["administratorCandidates"] == 1
+    for account_name in ("svc-good", "service-gap", "api-email-no-address", "bot-email", "automation-admin", "backup-service"):
+        assert account_name not in str(response)
+
+
+def test_empty_candidate_population_and_nested_inherited_totp_have_no_gap():
+    module = transformation()
+    empty = module.transform(envelope())["transformedResponse"]
+    assert empty["hasIdentifiedServiceAccountsMFAGap"] is False
+    assert empty["serviceCandidateAccounts"] == 0
+
+    groups = [group("child", members=["svc-nested"]), group("parent", "totp", ["child"])]
+    nested = module.transform(envelope([user("svc-nested", "none", ["child"])], groups))["transformedResponse"]
+    assert nested["hasIdentifiedServiceAccountsMFAGap"] is False
+    assert nested["candidatesWithConfiguredMFA"] == 1
+
+
+def test_cycle_ambiguity_and_unknown_input_report_a_gap_fail_closed():
+    module = transformation()
+    cycle = envelope(
+        [user("svc-cycle", "totp", ["cycle-a"])],
+        [group("cycle-a", members=["cycle-b", "svc-cycle"]), group("cycle-b", members=["cycle-a"])],
+    )
+    cycle_response = module.transform(cycle)
+    assert cycle_response["transformedResponse"]["hasIdentifiedServiceAccountsMFAGap"] is True
+    assert cycle_response["transformedResponse"]["unknownAccounts"] == 1
+
+    ambiguous = envelope(
+        [user("svc-same", "totp")],
+        [group("svc-same"), group("parent", "totp", ["svc-same"])],
+    )
+    ambiguity_response = module.transform(ambiguous)
+    assert ambiguity_response["transformedResponse"]["hasIdentifiedServiceAccountsMFAGap"] is True
+    assert "group_membership_unresolved" in ambiguity_response["additionalInfo"]["validation"]["errors"]
+
+    unknown_state = module.transform(envelope([user("api-unknown", "totp", include_state=False)]))
+    assert unknown_state["transformedResponse"]["hasIdentifiedServiceAccountsMFAGap"] is True
+    assert unknown_state["additionalInfo"]["validation"]["status"] == "failed"
+
+    malformed = envelope()
+    malformed["counts"]["rawUserEntries"] = 1
+    assert module.transform(malformed)["transformedResponse"]["hasIdentifiedServiceAccountsMFAGap"] is True
+
+
+def test_expired_and_domain_candidates_are_reported_but_unscored():
+    module = transformation()
+    response = module.transform(envelope([
+        user("svc-expired", "none", expired=True),
+        user("api-domain", "none", domain="example.test"),
+    ]))
+    result = response["transformedResponse"]
+    assert result["hasIdentifiedServiceAccountsMFAGap"] is False
+    assert result["serviceCandidateAccounts"] == 2
+    assert result["expiredCandidates"] == 1
+    assert result["excludedDomainProxies"] == 1
+    assert result["candidatesWithoutConfiguredMFA"] == 0
+
+
+def test_supported_generation_fixtures_are_compatible_and_nonprefix_names_are_not_candidates():
+    module = transformation()
+    for contract in ("gen6-combined", "gen6-split", "gen7-split"):
+        response = module.transform(fixture_envelope(contract))
+        result = response["transformedResponse"]
+        assert result["hasIdentifiedServiceAccountsMFAGap"] is False
+        assert result["serviceCandidateAccounts"] == 0
+        assert response["additionalInfo"]["validation"]["status"] == "passed"
+        assert "synthetic-" not in str(response)
+
+
+def load_tests(loader, standard_tests, pattern):
+    suite = unittest.TestSuite()
+    for function_name in sorted(globals()):
+        if function_name.startswith("test_"):
+            suite.addTest(unittest.FunctionTestCase(globals()[function_name], description=function_name))
+    return suite

--- a/safeguards/firewall/sonicwall/test_haslocalaccountinventoryvisibility.py
+++ b/safeguards/firewall/sonicwall/test_haslocalaccountinventoryvisibility.py
@@ -1,0 +1,157 @@
+import ast
+import unittest
+
+from conftest import ROOT, envelope, fixture_envelope, load_module, user
+
+
+FILENAME = "haslocalaccountinventoryvisibility.py"
+
+
+def transformation():
+    return load_module(FILENAME)
+
+
+def test_valid_empty_inventory_and_domain_expired_classification():
+    module = transformation()
+    empty = module.transform(envelope())
+    assert empty["transformedResponse"] == {
+        "hasLocalAccountInventoryVisibility": True,
+        "totalLocalAccounts": 0,
+        "activeLocalAccounts": 0,
+        "expiredAccounts": 0,
+        "excludedDomainProxies": 0,
+        "unknownAccounts": 0,
+    }
+    data = envelope([
+        user("active", "totp"),
+        user("expired", expired=True),
+        user("proxy", domain="example.test"),
+    ])
+    result = module.transform(data)["transformedResponse"]
+    assert result["hasLocalAccountInventoryVisibility"] is True
+    assert result["totalLocalAccounts"] == 2
+    assert result["activeLocalAccounts"] == 1
+    assert result["expiredAccounts"] == 1
+    assert result["excludedDomainProxies"] == 1
+
+
+def test_unknown_partial_and_duplicate_evidence_fail_closed():
+    module = transformation()
+    unknown = module.transform(envelope([user("unknown-state", include_state=False)]))
+    assert unknown["transformedResponse"]["hasLocalAccountInventoryVisibility"] is False
+    assert unknown["transformedResponse"]["unknownAccounts"] == 1
+    assert unknown["additionalInfo"]["validation"]["status"] == "failed"
+
+    partial = envelope()
+    del partial["evidence"]["localUsers"]
+    assert module.transform(partial)["transformedResponse"]["hasLocalAccountInventoryVisibility"] is False
+
+    duplicates = envelope([user("same", vendor_uuid="same-id"), user("other", vendor_uuid="same-id")])
+    duplicate_response = module.transform(duplicates)
+    assert duplicate_response["transformedResponse"]["hasLocalAccountInventoryVisibility"] is False
+    assert "duplicate_local_user_identity" in duplicate_response["additionalInfo"]["validation"]["errors"]
+
+
+def test_gen6_and_gen7_fixtures_are_normalized_and_fail_closed_when_indeterminate():
+    module = transformation()
+    for contract in ("gen6-combined", "gen6-split", "gen7-split"):
+        result = module.transform(fixture_envelope(contract))
+        assert result["transformedResponse"]["hasLocalAccountInventoryVisibility"] is False
+        assert result["transformedResponse"]["unknownAccounts"] > 0
+        assert "synthetic-user" not in str(result)
+
+
+def test_all_five_schemas_accept_collector_contract_and_scripts_follow_restricted_conventions():
+    filenames = (
+        "haslocalaccountinventoryvisibility.py",
+        "ismfaenforcedforlocalaccounts.py",
+        "ismfaenforcedforadministratoraccounts.py",
+        "isbuiltinadministratormfabound.py",
+        "hasidentifiedserviceaccountsmfagap.py",
+    )
+    data = envelope()
+    for filename in filenames:
+        schema = load_module(filename, ROOT / "schemas")
+        model_name = filename[:-3].capitalize() + "Input"
+        model = getattr(schema, model_name)
+        model(**data)
+        missing_evidence = dict(data)
+        del missing_evidence["evidence"]
+        rejected = False
+        try:
+            model(**missing_evidence)
+        except Exception:
+            rejected = True
+        assert rejected
+
+        source = (ROOT / filename).read_text()
+        tree = ast.parse(source)
+        compile(source, filename, "exec")
+        for node in ast.walk(tree):
+            assert not (isinstance(node, ast.AugAssign) and isinstance(node.target, ast.Subscript))
+            if isinstance(node, ast.Import):
+                assert all(alias.name in ("json",) for alias in node.names)
+            if isinstance(node, ast.ImportFrom):
+                assert node.module == "datetime"
+
+
+def test_partial_collector_envelope_cannot_look_safe_for_any_criterion():
+    expected = {
+        "haslocalaccountinventoryvisibility.py": ("hasLocalAccountInventoryVisibility", False),
+        "ismfaenforcedforlocalaccounts.py": ("isMFAEnforcedForLocalAccounts", False),
+        "ismfaenforcedforadministratoraccounts.py": ("isMFAEnforcedForAdministratorAccounts", False),
+        "isbuiltinadministratormfabound.py": ("isBuiltInAdministratorMFABound", False),
+        "hasidentifiedserviceaccountsmfagap.py": ("hasIdentifiedServiceAccountsMFAGap", True),
+    }
+    data = envelope()
+    del data["evidence"]["administrationGlobal"]
+    for filename in expected:
+        key, safe_value = expected[filename]
+        response = load_module(filename).transform(data)
+        assert response["transformedResponse"][key] is safe_value
+        assert response["additionalInfo"]["validation"]["status"] == "failed"
+
+
+def test_partial_upstream_validation_and_mixed_profile_shapes_fail_closed():
+    expected = {
+        "haslocalaccountinventoryvisibility.py": ("hasLocalAccountInventoryVisibility", False),
+        "ismfaenforcedforlocalaccounts.py": ("isMFAEnforcedForLocalAccounts", False),
+        "ismfaenforcedforadministratoraccounts.py": ("isMFAEnforcedForAdministratorAccounts", False),
+        "isbuiltinadministratormfabound.py": ("isBuiltInAdministratorMFABound", False),
+        "hasidentifiedserviceaccountsmfagap.py": ("hasIdentifiedServiceAccountsMFAGap", True),
+    }
+    for filename in expected:
+        key, safe_value = expected[filename]
+        module = load_module(filename)
+        wrapper = {"data": envelope(), "validation": {"status": "passed"}}
+        wrapper_response = module.transform(wrapper)
+        assert wrapper_response["transformedResponse"][key] is safe_value
+        assert wrapper_response["additionalInfo"]["validation"]["status"] == "failed"
+
+        mixed_form = envelope()
+        mixed_form["data"] = envelope()
+        mixed_form["validation"] = {"status": "passed", "errors": [], "warnings": []}
+        mixed_form_response = module.transform(mixed_form)
+        assert mixed_form_response["transformedResponse"][key] is safe_value
+        assert mixed_form_response["additionalInfo"]["validation"]["status"] == "failed"
+
+        legacy_mixed = envelope()
+        legacy_mixed["counts"]["rawUserEntries"] = 99
+        legacy_mixed["response"] = envelope()
+        legacy_mixed_response = module.transform(legacy_mixed)
+        assert legacy_mixed_response["transformedResponse"][key] is safe_value
+        assert "raw_user_count_mismatch" in legacy_mixed_response["additionalInfo"]["validation"]["errors"]
+
+        mixed_profile = envelope()
+        mixed_profile["evidence"]["localUsers"]["user"]["local"]["group"] = []
+        mixed_response = module.transform(mixed_profile)
+        assert mixed_response["transformedResponse"][key] is safe_value
+        assert "split_contract_has_combined_groups" in mixed_response["additionalInfo"]["validation"]["errors"]
+
+
+def load_tests(loader, standard_tests, pattern):
+    suite = unittest.TestSuite()
+    for function_name in sorted(globals()):
+        if function_name.startswith("test_"):
+            suite.addTest(unittest.FunctionTestCase(globals()[function_name], description=function_name))
+    return suite

--- a/safeguards/firewall/sonicwall/test_isbuiltinadministratormfabound.py
+++ b/safeguards/firewall/sonicwall/test_isbuiltinadministratormfabound.py
@@ -1,0 +1,84 @@
+import unittest
+
+from conftest import envelope, fixture_envelope, load_module
+
+
+FILENAME = "isbuiltinadministratormfabound.py"
+
+
+def transformation():
+    return load_module(FILENAME)
+
+
+def test_exact_builtin_totp_setting_passes_and_is_described_as_configuration_only():
+    response = transformation().transform(envelope())
+    result = response["transformedResponse"]
+    assert result == {
+        "isBuiltInAdministratorMFABound": True,
+        "builtInAdministratorAccounts": 1,
+        "totpConfiguredAccounts": 1,
+        "notTotpConfiguredAccounts": 0,
+        "unknownAccounts": 0,
+    }
+    evaluation = response["additionalInfo"]["evaluation"]
+    prose = str(evaluation).lower()
+    assert "totp is configured" in prose
+    assert "does not prove" in prose
+    assert "bound to a person" in prose
+    assert "enforced during authentication" in prose
+
+
+def test_explicit_false_is_confirmed_not_configured():
+    admin = {"name": "built-in-administrator", "one_time_password": {"totp": False}}
+    response = transformation().transform(envelope(admin=admin))
+    result = response["transformedResponse"]
+    assert result["isBuiltInAdministratorMFABound"] is False
+    assert result["notTotpConfiguredAccounts"] == 1
+    assert result["unknownAccounts"] == 0
+    assert response["additionalInfo"]["validation"]["status"] == "passed"
+
+
+def test_missing_ambiguous_and_partial_builtin_evidence_fail_closed():
+    module = transformation()
+    missing = {"name": "built-in-administrator"}
+    missing_response = module.transform(envelope(admin=missing))
+    assert missing_response["transformedResponse"]["isBuiltInAdministratorMFABound"] is False
+    assert missing_response["transformedResponse"]["unknownAccounts"] == 1
+    assert missing_response["additionalInfo"]["validation"]["status"] == "failed"
+
+    ambiguous = {"name": "built-in-administrator", "one_time_password": {"totp": True, "otp": True}}
+    assert module.transform(envelope(admin=ambiguous))["transformedResponse"]["isBuiltInAdministratorMFABound"] is False
+
+    partial = envelope()
+    del partial["evidence"]["administrationGlobal"]
+    assert module.transform(partial)["transformedResponse"]["isBuiltInAdministratorMFABound"] is False
+
+    simplified = envelope()
+    simplified["evidence"]["administrationGlobal"] = {
+        "administration": {
+            "admin": {
+                "name": "built-in-administrator",
+                "one_time_password": {"totp": True},
+            }
+        }
+    }
+    simplified_response = module.transform(simplified)
+    assert simplified_response["transformedResponse"]["isBuiltInAdministratorMFABound"] is False
+    assert "built_in_administrator_shape_unrecognized" in simplified_response["additionalInfo"]["validation"]["errors"]
+
+
+def test_gen6_and_gen7_administration_fixtures_show_totp_configured():
+    module = transformation()
+    for contract in ("gen6-combined", "gen6-split", "gen7-split"):
+        response = module.transform(fixture_envelope(contract))
+        assert response["transformedResponse"]["isBuiltInAdministratorMFABound"] is True
+        assert response["transformedResponse"]["totpConfiguredAccounts"] == 1
+        assert "synthetic-built-in-admin" not in str(response)
+
+
+def load_tests(loader, standard_tests, pattern):
+    suite = unittest.TestSuite()
+    for function_name in sorted(globals()):
+        if function_name.startswith("test_"):
+            suite.addTest(unittest.FunctionTestCase(globals()[function_name], description=function_name))
+    return suite

--- a/safeguards/firewall/sonicwall/test_ismfaenforcedforadministratoraccounts.py
+++ b/safeguards/firewall/sonicwall/test_ismfaenforcedforadministratoraccounts.py
@@ -1,0 +1,99 @@
+import unittest
+
+from conftest import envelope, fixture_envelope, group, load_module, user
+
+
+FILENAME = "ismfaenforcedforadministratoraccounts.py"
+
+
+def transformation():
+    return load_module(FILENAME)
+
+
+def test_empty_additional_administrator_population_passes_separately_from_builtin():
+    result = transformation().transform(envelope())["transformedResponse"]
+    assert result["isMFAEnforcedForAdministratorAccounts"] is True
+    assert result["scoredAdministratorAccounts"] == 0
+    assert result["compliantAdministratorAccounts"] == 0
+
+
+def test_additional_administrators_require_effective_totp_not_email_otp():
+    module = transformation()
+    groups = [group("SonicWall Administrators", members=["totp-admin", "email-admin"])]
+    response = module.transform(envelope([
+        user("totp-admin", "totp"),
+        user("email-admin", "email", email_address="admin@example.test"),
+    ], groups))
+    result = response["transformedResponse"]
+    assert result["isMFAEnforcedForAdministratorAccounts"] is False
+    assert result["scoredAdministratorAccounts"] == 2
+    assert result["compliantAdministratorAccounts"] == 1
+    assert result["noncompliantAdministratorAccounts"] == 1
+    assert "totp-admin" not in str(response)
+    assert "email-admin" not in str(response)
+
+
+def test_nested_administrator_membership_and_inherited_totp_pass():
+    module = transformation()
+    groups = [
+        group("delegates", members=["nested-admin"]),
+        group("SonicWall Read-Only Admins", "totp", ["delegates"]),
+    ]
+    result = module.transform(envelope([user("nested-admin", "none", ["delegates"])], groups))["transformedResponse"]
+    assert result["isMFAEnforcedForAdministratorAccounts"] is True
+    assert result["compliantAdministratorAccounts"] == 1
+
+
+def test_cycle_ambiguity_and_unknown_admin_evidence_fail_closed():
+    module = transformation()
+    cycle = envelope(
+        [user("cycle-admin", "totp", ["cycle-a"])],
+        [group("cycle-a", members=["cycle-b", "cycle-admin"]),
+         group("cycle-b", members=["cycle-a", "SonicWall Administrators"]),
+         group("SonicWall Administrators", members=["cycle-b"])],
+    )
+    cycle_response = module.transform(cycle)
+    assert cycle_response["transformedResponse"]["isMFAEnforcedForAdministratorAccounts"] is False
+    assert cycle_response["additionalInfo"]["validation"]["status"] == "failed"
+
+    ambiguous = envelope(
+        [user("same", "totp")],
+        [group("same"), group("SonicWall Administrators", "totp", ["same"])],
+    )
+    ambiguity_response = module.transform(ambiguous)
+    assert ambiguity_response["transformedResponse"]["isMFAEnforcedForAdministratorAccounts"] is False
+    assert "group_membership_unresolved" in ambiguity_response["additionalInfo"]["validation"]["errors"]
+
+    unknown = envelope([user("unknown-admin", "unknown", ["SonicWall Administrators"])],
+                       [group("SonicWall Administrators", members=["unknown-admin"])])
+    assert module.transform(unknown)["transformedResponse"]["isMFAEnforcedForAdministratorAccounts"] is False
+
+
+def test_domain_and_expired_administrators_are_reported_but_unscored():
+    module = transformation()
+    groups = [group("Limited Administrators", "totp", ["expired-admin", "domain-admin"])]
+    result = module.transform(envelope([
+        user("expired-admin", "none", expired=True),
+        user("domain-admin", "none", domain="example.test"),
+    ], groups))["transformedResponse"]
+    assert result["isMFAEnforcedForAdministratorAccounts"] is True
+    assert result["expiredAdministratorAccounts"] == 1
+    assert result["excludedDomainProxies"] == 1
+    assert result["scoredAdministratorAccounts"] == 0
+
+
+def test_supported_generation_fixtures_normalize_and_indeterminate_admins_fail_closed():
+    module = transformation()
+    for contract in ("gen6-combined", "gen6-split", "gen7-split"):
+        response = module.transform(fixture_envelope(contract))
+        assert response["transformedResponse"]["isMFAEnforcedForAdministratorAccounts"] is False
+        assert response["additionalInfo"]["validation"]["status"] == "failed"
+        assert "synthetic-" not in str(response)
+
+
+def load_tests(loader, standard_tests, pattern):
+    suite = unittest.TestSuite()
+    for function_name in sorted(globals()):
+        if function_name.startswith("test_"):
+            suite.addTest(unittest.FunctionTestCase(globals()[function_name], description=function_name))
+    return suite

--- a/safeguards/firewall/sonicwall/test_ismfaenforcedforlocalaccounts.py
+++ b/safeguards/firewall/sonicwall/test_ismfaenforcedforlocalaccounts.py
@@ -1,0 +1,102 @@
+import unittest
+
+from conftest import envelope, fixture_envelope, group, load_module, user
+
+
+FILENAME = "ismfaenforcedforlocalaccounts.py"
+
+
+def transformation():
+    return load_module(FILENAME)
+
+
+def test_totp_and_email_with_address_pass_but_email_without_address_fails():
+    module = transformation()
+    passing = envelope([
+        user("totp-user", "totp"),
+        user("email-user", "email", email_address="person@example.test"),
+    ])
+    result = module.transform(passing)["transformedResponse"]
+    assert result["isMFAEnforcedForLocalAccounts"] is True
+    assert result["scoredLocalAccounts"] == 2
+    assert result["compliantLocalAccounts"] == 2
+
+    missing_address = module.transform(envelope([user("email-no-address", "email")]))
+    result = missing_address["transformedResponse"]
+    assert result["isMFAEnforcedForLocalAccounts"] is False
+    assert result["noncompliantLocalAccounts"] == 1
+    assert "email-no-address" not in str(missing_address)
+
+
+def test_direct_and_nested_inherited_otp_and_administrator_exclusion():
+    module = transformation()
+    users = [
+        user("nested", groups=["child"]),
+        user("admin", "totp", groups=["admin delegates"]),
+    ]
+    groups = [
+        group("child", members=["nested"]),
+        group("parent", "totp", members=["child"]),
+        group("SSLVPN Services", members=["child"]),
+        group("admin delegates", members=["admin"]),
+        group("SonicWall Administrators", "totp", members=["admin delegates"]),
+    ]
+    result = module.transform(envelope(users, groups))["transformedResponse"]
+    assert result["isMFAEnforcedForLocalAccounts"] is True
+    assert result["compliantLocalAccounts"] == 1
+    assert result["administratorAccountsExcluded"] == 1
+    assert result["sslVpnAccounts"] == 1
+
+
+def test_cycles_ambiguity_and_unknown_evidence_fail_closed():
+    module = transformation()
+    cycle = envelope(
+        [user("cycle-user", "totp", ["cycle-a"])],
+        [group("cycle-a", members=["cycle-b", "cycle-user"]), group("cycle-b", members=["cycle-a"])],
+    )
+    cycle_response = module.transform(cycle)
+    assert cycle_response["transformedResponse"]["isMFAEnforcedForLocalAccounts"] is False
+    assert cycle_response["transformedResponse"]["unknownAccounts"] == 1
+
+    ambiguous = envelope(
+        [user("ambiguous", "totp")],
+        [group("ambiguous"), group("parent", "totp", ["ambiguous"])],
+    )
+    ambiguity_response = module.transform(ambiguous)
+    assert ambiguity_response["transformedResponse"]["isMFAEnforcedForLocalAccounts"] is False
+    assert "group_membership_unresolved" in ambiguity_response["additionalInfo"]["validation"]["errors"]
+
+    unknown = module.transform(envelope([user("unknown", "unknown")]))
+    assert unknown["transformedResponse"]["isMFAEnforcedForLocalAccounts"] is False
+    assert unknown["additionalInfo"]["validation"]["status"] == "failed"
+
+
+def test_empty_population_domain_proxies_and_expired_accounts_are_unscored():
+    module = transformation()
+    empty = module.transform(envelope())["transformedResponse"]
+    assert empty["isMFAEnforcedForLocalAccounts"] is True
+    assert empty["scoredLocalAccounts"] == 0
+
+    data = envelope([user("expired", "none", expired=True), user("proxy", "none", domain="example.test")])
+    result = module.transform(data)["transformedResponse"]
+    assert result["isMFAEnforcedForLocalAccounts"] is True
+    assert result["expiredAccounts"] == 1
+    assert result["excludedDomainProxies"] == 1
+    assert result["scoredLocalAccounts"] == 0
+
+
+def test_supported_generation_fixtures_are_accepted_but_indeterminate_accounts_do_not_pass():
+    module = transformation()
+    for contract in ("gen6-combined", "gen6-split", "gen7-split"):
+        response = module.transform(fixture_envelope(contract))
+        assert response["transformedResponse"]["isMFAEnforcedForLocalAccounts"] is False
+        assert response["additionalInfo"]["validation"]["status"] == "failed"
+        assert "synthetic-user" not in str(response)
+
+
+def load_tests(loader, standard_tests, pattern):
+    suite = unittest.TestSuite()
+    for function_name in sorted(globals()):
+        if function_name.startswith("test_"):
+            suite.addTest(unittest.FunctionTestCase(globals()[function_name], description=function_name))
+    return suite


### PR DESCRIPTION
### How it works
These transformations receive the sanitized SonicWall evidence envelope and evaluate five separate safeguards: whether account inventory is visible, whether ordinary local and administrator accounts have configured MFA, whether the built-in administrator has TOTP configured, and whether likely service accounts have an MFA gap. Results contain aggregate counts only—not account names or other identity evidence.

### Implementation
- add five standalone schema-v2 transformations
- normalize Gen6 combined and Gen6/Gen7 split response layouts
- resolve direct and inherited group membership and effective OTP/TOTP methods
- exclude expired and domain-proxy records from scoring while reporting their counts
- fail closed on partial, malformed, duplicate, cyclic, or indeterminate evidence

### Criteria
- `hasLocalAccountInventoryVisibility`
- `isMFAEnforcedForLocalAccounts`
- `isMFAEnforcedForAdministratorAccounts`
- `isBuiltInAdministratorMFABound`
- `hasIdentifiedServiceAccountsMFAGap`

### Verification
- focused SonicWall suite: **26 passed**
- mocked collector-to-transformation smoke path: **passed**

### Validation boundary
The transformations report readable configured OTP/TOTP state. They do not claim successful live challenges, completed enrollment, or email delivery. Live SonicOS validation is required before activating the coordinated Integration-Service mappings.